### PR TITLE
Fix relay node publishing to the same service

### DIFF
--- a/src/nodes/output-relay.js
+++ b/src/nodes/output-relay.js
@@ -3,34 +3,35 @@ module.exports = function(RED) {
     "use strict";
 
     function OutputRelay(config) {
-        RED.nodes.createNode(this, config);
+        RED.nodes.createNode(this, config)
 
-        this.service = JSON.parse(config.service);
-        this.state = config.state;
-        this.config = RED.nodes.getNode("victron-client-id");
-        this.client = this.config.client;
+        this.service = JSON.parse(config.service)
+        this.state = config.state
+        this.config = RED.nodes.getNode("victron-client-id")
+        this.client = this.config.client
 
-        let toggleState = 0;
+        let toggleState = 0
 
         let stateToMessage = state => {
             switch(state) {
                 case 'on':
-                    return 1;
+                    return 1
                 case 'off':
-                    return 0;
+                    return 0
                 case 'toggle':
                     // Ideally the initial state would be fetched from the relay itself
-                    toggleState = 1 - toggleState;
-                    return toggleState;
+                    toggleState = 1 - toggleState
+                    return toggleState
             }
         };
-        
+
         this.on("input", function(msg) {
             let path = this.service.paths[0].path
-            this.client.publish("com.victronenergy.system", path, stateToMessage(this.state));
+            let service = this.service.service
+            this.client.publish(service, path, stateToMessage(this.state))
         });
 
     }
 
-    RED.nodes.registerType("victron-relay", OutputRelay);
+    RED.nodes.registerType("victron-relay", OutputRelay)
 }

--- a/src/services/victronclient.js
+++ b/src/services/victronclient.js
@@ -157,7 +157,13 @@ class VictronClient {
      * @param {string} value value to write to the given dbus service, e.g. 1
      */
     publish(dbusInterface, path, value) {
-        this.write(dbusInterface, path, value)
+        if (this.connected) {
+            debug(`[PUBLISH] ${dbusInterface} - ${path} | ${value}`)
+            this.write(dbusInterface, path, value)
+        }
+        else {
+            throw Error('Not connected to dbus. Publish was unsuccessful.')
+        }
     }
 
 }


### PR DESCRIPTION
Fix a bug where the relay node would always publish to the same service.
Check that the client is connected when VictronClient.publish() is
called.