### PR TITLE
Show service connection status under the nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The following graph demonstrates the architecture of this plugin.
 ![Architecture](documentation/images/architecture.png)
 
 ### Directory Structure
-
 ```
 .
 ├── README.md
@@ -33,18 +32,24 @@ The following graph demonstrates the architecture of this plugin.
 │   │   ├── example-tank-edit.png
 │   │   └── example-use-case.png
 │   └── specification.md
+├── package-lock.json
+├── package.json
 └── src
     ├── nodes
     │   ├── config-client.html
-    │   ├── config-client.js        <-- global configuration node
+    │   ├── config-client.js
+    │   ├── icons
+    │   │   └── victronenergy.svg
     │   ├── input-battery.html
-    │   ├── input-battery.js        <-- battery node
+    │   ├── input-battery.js
     │   ├── output-relay.html
-    │   └── output-relay.js         <-- relay node
+    │   └── output-relay.js
     └── services
-        ├── dbus-listener.js        <-- github.com/sbender9/signalk-venus-plugin
-        ├── systemconfiguration.js  <-- SystemConfiguration cache
-        └── victronclient.js        <-- Victron Energy D-Bus Client
+        ├── dbus-listener.js
+        ├── utils.js
+        ├── victron-client.js       <-- Victron Energy D-Bus client
+        ├── victron-services.js     <-- Node-to-D-Bus service mapping
+        └── victron-system.js       <-- D-Bus service cache
 ```
 
 ## Installation and Usage

--- a/src/nodes/config-client.js
+++ b/src/nodes/config-client.js
@@ -1,32 +1,102 @@
 
+
+var VictronClient = require('../services/victron-client.js')
+
 function setReplacer(key, value) {
     if (typeof value === 'object' && value instanceof Set)
-        return [...value];
-    return value;
+        return [...value]
+    return value
 }
 
+/**
+ * VictronClient should be initialized as a global singleton.
+ * This way, deploying the flows doesn't reset the connection
+ * and cache.
+ */
+const globalClient = new VictronClient(process.env.NODE_RED_DBUS_ADDRESS)
+globalClient.connect()
+
+
+/**
+ * Victron Energy Configuration Node.
+ *
+ * This global configuration node is used by
+ * all the other Victron Energy nodes to access the dbus.
+ *
+ * It keeps track of incoming status messages and updates
+ * listening nodes' status in the UI accordingly.
+ */
 module.exports = function(RED) {
     "use strict"
 
-    var VictronClient = require('../services/victronclient.js');
+    const utils = require('../services/utils.js')
+
+    const debug = require('debug')('node-red-contrib-victron:config-client')
+    const _ = require('lodash')
 
     function VictronClientNode(config) {
-        RED.nodes.createNode(this, config);
-        var node = this;
+        RED.nodes.createNode(this, config)
+        let _this = this
 
-        this.client = new VictronClient(process.env.NODE_RED_DBUS_ADDRESS);
+        this.client = globalClient
+        let statusListeners = []
 
-        this.client.connect()
+        /**
+         * This node registers a VictronClient status update listener
+         * that updates each node's statuses when a path gets added
+         * or a service removed.
+         *
+         * Current architecture supports for service and path additions,
+         * but only service-level disconnects (so, e.g. a disappearing
+         * system relay doesn't get registered).
+         */
+        this.client.onStatusUpdate = (msg, status) => {
+            statusListeners
+                .forEach(obj => {
+                    if (obj.service === msg.service) {
+                        if (status === utils.STATUS.SERVICE_REMOVE)
+                            obj.node.status(utils.DISCONNECTED)
+                        else if (status === utils.STATUS.PATH_ADD && obj.path === msg.path) {
+                            obj.node.status(utils.CONNECTED)
+                        }
+                    }
+                })
+        }
+
+        // isConnected function is called to check the node
+        // connection state and adjust the node status accordingly
+        this.addStatusListener = (listener, service, path) => {
+            const id = utils.UUID()
+
+            // Upon initialization, the initial node status will be fetched from the cache
+            if (service) {
+                if (_.get(this.client, ['system', 'cache', service, path]) === undefined)
+                    listener.status(utils.DISCONNECTED)
+                else
+                    listener.status(utils.CONNECTED)
+            }
+
+            statusListeners.push({
+                "node": listener,
+                "service": service,
+                "path": path,
+                "id": id
+            })
+
+            return id
+        }
+
+        this.removeStatusListener = id => statusListeners = statusListeners.filter(o => o.id === id)
 
         // An endpoint for nodes to request services from - returns either a single service, or all available services
         // depending whether the requester gives the service parameter
         RED.httpAdmin.get("/victron/services/:service?", RED.auth.needsPermission('victron-client.read'), function(req, res) {
-            let serialized = JSON.stringify(node.client.system.listAvailableServices(req.params.service), setReplacer)
-            res.setHeader('Content-Type', 'application/json');
+            let serialized = JSON.stringify(_this.client.system.listAvailableServices(req.params.service), setReplacer)
+            res.setHeader('Content-Type', 'application/json')
             return res.send(serialized)
-        });
+        })
 
     }
 
-    RED.nodes.registerType("victron-client", VictronClientNode);
+    RED.nodes.registerType("victron-client", VictronClientNode)
 }

--- a/src/nodes/input-battery.js
+++ b/src/nodes/input-battery.js
@@ -1,34 +1,41 @@
-
+/**
+ * Victron Energy battery node
+ */
 module.exports = function(RED) {
-    "use strict";
+    "use strict"
+
+    const _ = require('lodash')
 
     function InputBattery(config) {
-        RED.nodes.createNode(this, config);
-        var node = this;
+        RED.nodes.createNode(this, config)
+        let _this = this
 
-        this.service = config.service
+        this.service = _.get(config.service, 'service')
         this.path = config.path
 
-        this.subscription = null;
-        this.config = RED.nodes.getNode("victron-client-id");
-        this.client = this.config.client;
+        this.subscription = null
+        this.config = RED.nodes.getNode("victron-client-id")
+        this.client = this.config.client
+
+
+        let handlerId = this.config.addStatusListener(this, this.service, this.path)
 
         if (this.service && this.path) {
-            this.subscription = this.client.subscribe(this.service.service, this.path, (msg) => {
-                node.send({
+            this.subscription = this.client.subscribe(this.service, this.path, (msg) => {
+                _this.send({
                     payload: msg.value,
-                    topic: `${this.service.service} - ${this.path.path}`
-                });
-            });
+                    topic: `${this.service} - ${this.path}`
+                })
+            })
         }
 
         this.on('close', function(done) {
-            node.client.unsubscribe(node.subscription);
-            node.client.subscriptions = {}
-            done();
-        });
+            _this.client.unsubscribe(_this.subscription)
+            _this.config.removeStatusListener(handlerId)
+            done()
+        })
 
     }
 
-    RED.nodes.registerType("victron-battery", InputBattery);
+    RED.nodes.registerType("victron-battery", InputBattery)
 }

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -1,9 +1,9 @@
-/*
-  Directly from https://github.com/sbender9/signalk-venus-plugin/blob/master/dbus-listener.js
-*/
+/**
+ * Original taken from https://github.com/sbender9/signalk-venus-plugin/blob/master/dbus-listener.js
+ */
 
 const dbus = require('dbus-native')
-const debug = require('debug')('signalk-venus-plugin:dbus')
+const debug = require('debug')('node-red-contrib-victron:dbus')
 const _ = require('lodash')
 
 module.exports = function (app, messageCallback, address, plugin, pollInterval) {
@@ -254,7 +254,7 @@ module.exports = function (app, messageCallback, address, plugin, pollInterval) 
         },
         function (err, res) {
           if (err) {
-            console.error(err)
+            debug('Error: ' + err)
           }
         }
       )
@@ -281,14 +281,12 @@ module.exports = function (app, messageCallback, address, plugin, pollInterval) 
 
     bus.connection.on('error', error => {
       setProviderError(error.message)
-      console.error(`ERROR: signalk-venus-plugin: ${error.message}`)
       reject(error)
       plugin.onError()
     })
 
     bus.connection.on('end', () => {
       setProviderError('lost connection to D-Bus')
-      console.error(`ERROR: lost connection to D-Bus`)
       // here we could (should?) also clear the polling timer. But decided not to do that;
       // to be looked at when properly fixing the dbus-connection lost issue.
     })

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,0 +1,28 @@
+/**
+ * This file contains various utility functions
+ * and enums.
+ */
+
+const CONNECTED = {fill: "green", shape: "dot", text: "service connected"}
+const DISCONNECTED = {fill: "red", shape: "ring", text: "service disconnected"}
+
+const STATUS = {
+    SERVICE_ADD: 1,
+    SERVICE_REMOVE: 2,
+    PATH_ADD: 3,
+    PATH_REMOVE: 4,
+    PROVIDER_STATUS: 5,
+    PROVIDER_ERROR: 6,
+    PLUGIN_ERROR: 7
+}
+
+function UUID() {
+    return Math.floor((1 + Math.random()) * 0x10000000).toString(16)
+}
+
+module.exports = {
+    CONNECTED,
+    DISCONNECTED,
+    STATUS,
+    UUID
+}

--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -1,14 +1,16 @@
-'use strict';
+'use strict'
 
 const createDbusListener = require('./dbus-listener')
-const SystemConfiguration = require('./systemconfiguration');
+const SystemConfiguration = require('./victron-system')
 const promiseRetry = require('promise-retry')
-const debug = require('debug')('node-red-contrib-victron:victronclient')
+const _ = require('lodash')
+const debug = require('debug')('node-red-contrib-victron:victron-client')
+const utils = require('./utils.js')
 
 /**
  * VictronClient class encapsulates all the necessary functions to
  * both subscribe to dbus value updates as well as write values to dbus.
- * 
+ *
  * @param {string} address IP address for dbus over TCP, both address and port. E.g. 127.0.0.1:78
  */
 class VictronClient {
@@ -17,7 +19,10 @@ class VictronClient {
 
         this.write
         this.read
-        this.connected = false;
+        this.connected = false
+
+        // Overwrite the onStatusUpdate to catch relevant VictronClient status updates
+        this.onStatusUpdate = (message, statusType) => debug(`[${statusType}] ${message}`)
 
         this.system = new SystemConfiguration()
         this.subscriptions = {} // an array of subscription objects [{ "topic": topic, "handler": function }, ...]
@@ -25,7 +30,7 @@ class VictronClient {
 
     /**
      * Connects to the dbus service.
-     * 
+     *
      * example:
      *     let vc = new VictronClient()
      *     await vc.connect()
@@ -42,7 +47,7 @@ class VictronClient {
                 let msgKey = `${msg.senderName}${msg.path}`
                 if (msgKey in _this.subscriptions)
                     _this.subscriptions[msgKey].forEach(sub => sub.callback(msg))
-            });
+            })
         }
 
         // Use dbus over TCP if an address is given,
@@ -59,16 +64,17 @@ class VictronClient {
             // createDbusListener(app, messageCallback, address, plugin, pollInterval)
             return createDbusListener(
                 {
-                    setProviderStatus: msg => debug(`[PROVIDER STATUS] ${msg}`),
-                    setProviderError: msg => debug(`[PROVIDER ERROR] ${msg}`)
+                    setProviderStatus: (msg) => this.onStatusUpdate(msg, utils.STATUS.PROVIDER_STATUS),
+                    setProviderError: (msg) => this.onStatusUpdate(msg, utils.STATUS.PROVIDER_ERROR),
                 },
                 messageHandler,
                 dbusConnectionString,
                 {
-                    onError: msg => debug(`[ERROR] ${msg}`),
+                    onError: (msg) => this.onStatusUpdate(msg, utils.STATUS.PLUGIN_ERROR),
                     onServiceChange: (changeType, serviceName) => {
                         if (changeType === 'DELETE' && serviceName !== null) {
                             delete this.system.cache[serviceName]
+                            this.onStatusUpdate({"service": serviceName}, utils.STATUS.SERVICE_REMOVE)
                         }
                     }
                 },
@@ -82,26 +88,28 @@ class VictronClient {
         }
         )
         .then(dbusHandlers => {
-            // on connection, set the status to 'connected' and store the returned handlers
             _this.write = dbusHandlers.setValue
             _this.read = dbusHandlers.getValue
-
-            _this.connected = true // We should probably use the setProviderStatus for various dbus states
+            _this.connected = true
         })
     }
 
     /**
      * a callback that should be called on each received dbus message
      * in order to maintain a list of available devices on the dbus.
-     * 
+     *
      * @param {object} msg a message object received from the dbus-listener
      */
     saveToCache(msg) {
-        //let dbusPaths = this.cache[msg.senderName] || {}
         let dbusPaths = {}
+
         if (this.system.cache[msg.senderName]) {
             dbusPaths = this.system.cache[msg.senderName]
         } else {
+            // this is currently not used anywhere
+            // it causes some overhead in node statuslisteners if enabled
+            // this.onStatusUpdate({"service": msg.senderName}, 'SERVICE_ADD')
+
             // Upon first discovery, request the customname and productname
             // of the battery. The returned message gets saved to the cache.
             if (msg.senderName.startsWith('com.victronenergy.battery')) {
@@ -112,8 +120,12 @@ class VictronClient {
 
         // some dbus messages are empty arrays []
         if (msg.value.length == 0 ) {
-            msg.value = undefined
+            msg.value = null
         }
+
+        // We need to update the nodes on new paths
+        // e.g. in the case of system relays, which might or might not be there
+        if (!(msg.path in dbusPaths)) this.onStatusUpdate({'service': msg.senderName, 'path': msg.path, }, utils.STATUS.PATH_ADD)
 
         dbusPaths[msg.path] = msg.value
         this.system.cache[msg.senderName] = dbusPaths
@@ -122,17 +134,16 @@ class VictronClient {
     /**
      * Subscribes to a dbus service, provided a valid interface and path were given.
      * The callback function is invoked for each subscribed whenever a valid subscription matching the message path and interface is found.
-     * 
+     *
      * @param {string} dbusInterface user specified dbus interface, e.g. com.victronenergy.system
      * @param {string} path specific path to subscribe to, e.g. /Dc/Battery/Voltage
      * @param {function} callback a callback function which is invoked upon receiving a message that matches both the interface and path
      */
     subscribe(dbusInterface, path, callback) {
-        const subscriptionId = Math.floor((1 + Math.random()) * 0x10000000).toString(16); // unique enough, used for unsubscribing
+        const subscriptionId = utils.UUID()
+        const newSubscription =  {callback, dbusInterface, path, subscriptionId}
 
-        let newSubscription =  {callback, dbusInterface, path, subscriptionId}
-
-        let msgKey = dbusInterface + path
+        const msgKey = dbusInterface + path
         if (msgKey in this.subscriptions)
             this.subscriptions[msgKey].push(newSubscription)
         else
@@ -140,23 +151,24 @@ class VictronClient {
 
         debug(`[SUBSCRIBE] [${dbusInterface} | ${path}] ID: ${subscriptionId}`)
 
-        return subscriptionId;
+        return subscriptionId
     }
 
     /**
      * Unsubscribes a node from a list of dbus message listeners
-     * 
+     *
      * @param {string} subscriptionId a semi-unique string identifying a single node-specific message listener
      */
     unsubscribe(subscriptionId) {
-        Object.keys(this.subscriptions).forEach(topic => {
-            this.subscriptions[topic] = this.subscriptions[topic].filter(obj => obj.id !== subscriptionId)
-        });
+        _.forOwn(this.subscriptions, (topicSubscriptions) => {
+            _.remove(topicSubscriptions, {subscriptionId: subscriptionId});
+        })
         debug(`[UNSUBSCRIBE] ${subscriptionId}`)
     }
 
     /**
-     * 
+     * Writes data to dbus services
+     *
      * @param {string} dbusInterface a dbus interface, e.g. e.g. com.victronenergy.system
      * @param {string} path specific path to publish to, e.g. /Relay/0/State
      * @param {string} value value to write to the given dbus service, e.g. 1
@@ -174,4 +186,4 @@ class VictronClient {
 }
 
 
-module.exports = VictronClient;
+module.exports = VictronClient

--- a/src/services/victron-services.js
+++ b/src/services/victron-services.js
@@ -1,8 +1,13 @@
+/**
+ * This file contains the node specific dbus service mappings
+ * and related helper functions.
+ */
+
 
 /**
  * Generates a unique hash from the given string.
  * This is used to identify services from each other.
- * 
+ *
  * @param {string} str a string the hash is generated from
  */
 function getHash(str){

--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -1,8 +1,8 @@
-'use strict';
+'use strict'
 
-const mapping = require('./servicemapping');
+const mapping = require('./victron-services')
 const _ = require('lodash')
-const debug = require('debug')('node-red-contrib-victron:systemconfiguartion')
+const debug = require('debug')('node-red-contrib-victron:system-configuration')
 
 /**
  * SystemConfiguration contains information on the given Venus system.
@@ -36,7 +36,7 @@ class SystemConfiguration {
             })
 
             return mapping.BATTERY(dbusInterface, name, paths)
-        });
+        })
 
     }
     /**
@@ -83,14 +83,14 @@ class SystemConfiguration {
                         buildRelayObject(service, relayPath))
                     )
                 return acc
-            }, []);
+            }, [])
     }
 
     /**
      * List all currently available services. This list is used to populate the nodes' edit dialog.
      * E.g. if a battery monitor is available, all the given battery monitor services are listed
      * in the input-battery node.
-     * 
+     *
      * @param {string} service an optional parameter to filter available services based on the given device
      */
     listAvailableServices(device=null) {
@@ -98,13 +98,13 @@ class SystemConfiguration {
             "battery": this.getBatteryServices(),
             "relay": this.getRelayServices(),
             "cache": this.cache
-        };
+        }
 
         return device !== null
             ? services[device]
-            : services;
+            : services
     }
 
 }
 
-module.exports = SystemConfiguration;
+module.exports = SystemConfiguration


### PR DESCRIPTION
The node connection status (red/green dot under the node) gets updated
when a path gets added or a service removed from the cache. Current
architecture only supports service-level disconnects.