### PR TITLE
Issue #81: Relay fix plus clearer warning

### DIFF
--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -49,7 +49,7 @@ const TEMPLATE = (service, name, paths) => {
  * Shown in the UI if the system relay mode is set to any other than 'manual'
  */
 const RELAY_MODE_WARNING = (func) =>
-    `This relay is reserved for ${func} function. Please navigate to Settings > Relay and change it to manual.`
+    `The relays are configured for <strong>${func}</strong> function. Please navigate to Settings > Relay and change it to manual.`
 
 /**
  * All possible system relay functions

--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -80,6 +80,8 @@ class SystemConfiguration {
                     if (systemRelayFunction !== 2) { // manual
                         relayObject["disabled"] = true
                         relayObject["warning"] = utils.RELAY_MODE_WARNING(utils.RELAY_FUNCTIONS[systemRelayFunction])
+                    } else {
+                       delete(relayObject["warning"])
                     }
                 }
                 return relayObject


### PR DESCRIPTION
- Fix issue #81: Relay no longer retains a warning when the
  relay is switched to manual.
- Made the warning message for relays more clear, with the
  current relay mode being strong.