### PR TITLE
Issue #80: Removed values 2 and 3 from input-{solar,ac}charger

### DIFF
--- a/src/services/services.json
+++ b/src/services/services.json
@@ -372,8 +372,6 @@
                 "enum": {
                     "0": "Off (deprecated)",
                     "1": "On",
-                    "2": "Error",
-                    "3": "Unavailable, Unknown",
                     "4": "Off"
                 }
             },
@@ -480,8 +478,6 @@
                 "enum": {
                     "0": "Off (deprecated)",
                     "1": "On",
-                    "2": "Error",
-                    "3": "Unavailable, Unknown",
                     "4": "Off"
                 }
             },


### PR DESCRIPTION
Only valid states for both accharger an solar input are:
- 0 Off (deprecated)
- 1 On
- 4 Off

States 2 and 3 don't exist.