### PR TITLE
Faberd/issue 123

### DIFF
--- a/scripts/check-services-json.js
+++ b/scripts/check-services-json.js
@@ -37,7 +37,7 @@ workbook.xlsx.readFile(xls_file)
       node = node + row.values[1].split('.')[2];
       if ( node === 'input-grid' ) { node = 'input-gridmeter'; }
       if ( node === 'input-charger' ) { node = 'input-accharger'; }
-      path = row.values[7];
+      path = row.values[7].replace('Cgwacs', 'CGwacs');
       // console.log("Check for node " + node + ", path: " + path);
 
       if ( ! services[node] ) {
@@ -84,7 +84,7 @@ workbook.xlsx.readFile(xls_file)
             missing['enum'] = {};
             row.values[9].split(';').forEach( en => {
               x = en.split('=');
-              missing['enum'][x[0]] = x[1];
+              missing['enum'][x[0].trim()] = x[1].trim();
             })
           }
 
@@ -117,8 +117,7 @@ workbook.xlsx.readFile(xls_file)
           if (service.path.match(/\/Relay/) ) { found = true; }
           for (let i = 2; i <= maxrows; i++ ) {
             if ( worksheet.getCell('A'+i).value === dbus_service_name &&
-                 worksheet.getCell('G'+i).value === service.path &&
-                 worksheet.getCell('H'+i).value === writable ) {
+                 worksheet.getCell('G'+i).value.replace('Cgwacs', 'CGwacs') === service.path ) {
               found = true;
               break;
             }

--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -64,69 +64,1946 @@ Questions can also be asked on the Victron Energy community:
 </script>
 
 <!-- # The rest of the file has been generated from services.json -->
+<script type="text/x-red" data-help-name="victron-input-accharger">
+<p>The AC charger can be read with this node.</p>
+<h3>charger</h3>
+<dl class="message-properties">
+  <dt class="optional">AC Current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/CurrentLimit</b>
+</dd>
+  <dt class="optional">AC Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/L1/I</b>
+</dd>
+  <dt class="optional">AC Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/L1/P</b>
+</dd>
+  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Output 1 - current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Output 1 - temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Output 1 - voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Output 2 - current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/1/Current</b>
+</dd>
+  <dt class="optional">Battery 1 temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/1/Temperature</b>
+</dd>
+  <dt class="optional">Output 2 - voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b>
+</dd>
+  <dt class="optional">Output 3 - current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/2/Current</b>
+</dd>
+  <dt class="optional">Battery 2 temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/2/Temperature</b>
+</dd>
+  <dt class="optional">Output 3 - voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/2/Voltage</b>
+</dd>
+  <dt class="optional">Error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ErrorCode</b>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - Err 1: Battery temperature too high</li>
+  <li>2 - Err 2: Battery voltage too high</li>
+  <li>3 - Err 3: Battery temperature sensor miswired (+)</li>
+  <li>4 - Err 3: Battery temperature sensor miswired (-)</li>
+  <li>5 - Err 5: Battery temperature sensor disconnected</li>
+  <li>6 - Err 6: Battery voltage sense miswired (+)</li>
+  <li>7 - Err 7: Battery voltage sense miswired (-)</li>
+  <li>8 - Err 8: Battery voltage sense disconnected</li>
+  <li>9 - Err 9: Battery voltage wire losses too high</li>
+  <li>17 - Err 17: Charger temperature too high</li>
+  <li>18 - Err 18: Charger over-current</li>
+  <li>19 - Err 19: Charger current polarity reversed</li>
+  <li>20 - Err 20: Bulk time limit reached</li>
+  <li>22 - Err 22: Charger temperature sensor miswired</li>
+  <li>23 - Err 23: Charger temperature sensor disconnected</li>
+  <li>34 - Err 34: Input current too high</li>
+  <li>67 - Err 67: No BMS</li>
+</ul>
+</dd>
+  <dt class="optional">Charger on/off<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>1 - On</li>
+  <li>4 - Off</li>
+</ul>
+</dd>
+  <dt class="optional">Number of charger outputs<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/NrOfOutputs</b>
+</dd>
+  <dt class="optional">Relay on the charger<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Relay/0/State</b>
+<ul>
+  <li>0 - Open</li>
+  <li>1 - Closed</li>
+</ul>
+</dd>
+  <dt class="optional">Charge state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/State</b>
+<ul>
+  <li>0 - Off</li>
+  <li>2 - Fault</li>
+  <li>3 - Bulk</li>
+  <li>4 - Absorption</li>
+  <li>5 - Float</li>
+  <li>6 - Storage</li>
+  <li>7 - Equalize</li>
+  <li>11 - Power supply mode</li>
+  <li>246 - Repeated absorption</li>
+  <li>247 - Equalize</li>
+  <li>248 - Battery safe</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-acload">
+<p>This node allows for AC load monitoring. Measuring can be done by using an energy meter and assigning it the 'ac load' role.</p>
+<h3>acload</h3>
+<dl class="message-properties">
+  <dt class="optional">L1 Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Current</b>
+</dd>
+  <dt class="optional">L1 Energy (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Energy/Forward</b>
+</dd>
+  <dt class="optional">L1 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Power</b>
+</dd>
+  <dt class="optional">L1 Voltage (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Voltage</b>
+</dd>
+  <dt class="optional">L2 Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Current</b>
+</dd>
+  <dt class="optional">L2 Energy (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Energy/Forward</b>
+</dd>
+  <dt class="optional">L2 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Power</b>
+</dd>
+  <dt class="optional">L2 Voltage (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Voltage</b>
+</dd>
+  <dt class="optional">L3 Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Current</b>
+</dd>
+  <dt class="optional">L3 Energy (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Energy/Forward</b>
+</dd>
+  <dt class="optional">L3 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Power</b>
+</dd>
+  <dt class="optional">L3 Voltage (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Voltage</b>
+</dd>
+  <dt class="optional">Serial number<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/Serial</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-alternator">
+<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is Alternator or an alternator controller which is interfaced to the Venus OS.</p>
+<h3>alternator</h3>
+<dl class="message-properties">
+  <dt class="optional">Alternator Error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/AlternatorError</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Charger Error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/ChargerError</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High auxiliary voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low auxiliary voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Charger Overload<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Overload</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Charger high temperature<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Temperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Alternator RPM<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/AlternatorRPM</b>
+</dd>
+  <dt class="optional">Alterntor Charging Status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/AlternatorStatus</b>
+<ul>
+  <li>0 - Not Charging</li>
+  <li>1 - Charing</li>
+  <li>2 - Error</li>
+  <li>3 - Not Available</li>
+</ul>
+</dd>
+  <dt class="optional">Charger Status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ChargeEnable</b>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - On</li>
+</ul>
+</dd>
+  <dt class="optional">Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Power</b>
+</dd>
+  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Auxiliary voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b>
+</dd>
+  <dt class="optional">Engine RPM<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/EngineRPM</b>
+</dd>
+  <dt class="optional">Alternator Field Drive %<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/FieldDrive</b>
+</dd>
+  <dt class="optional">Total energy produced (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/EnergyOut</b>
+</dd>
+  <dt class="optional">Charger Mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>0 - Standalone</li>
+  <li>1 - Master</li>
+  <li>2 - Slave</li>
+</ul>
+</dd>
+  <dt class="optional">Charger State<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/State</b>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Bulk</li>
+  <li>2 - Absorbtion</li>
+  <li>5 - Float</li>
+  <li>7 - Ext. Control</li>
+  <li>8 - Disabled</li>
+  <li>9 - Fault</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-battery">
+<p>This node allows for monitoring the state of the battery.</p>
+<h3>battery</h3>
+<dl class="message-properties">
+  <dt class="optional">Alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Alarm</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Cell Imbalance alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/CellImbalance</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Fuse blown alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/FuseBlown</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High charge current alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighChargeCurrent</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High charge temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighChargeTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High discharge current alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighDischargeCurrent</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High fused-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighFusedVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High internal-temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighInternalTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High starter-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High battery temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Internal error alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/InternalFailure</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low cell voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowCellVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Almost discharged</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low charge temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowChargeTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low fused-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowFusedVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low state-of-charge alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowSoc</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low starter-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low battery temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Mid-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/MidVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Balancing<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Balancing</b>
+<ul>
+  <li>0 - Inactive</li>
+  <li>1 - Active</li>
+</ul>
+</dd>
+  <dt class="optional">Capacity (Ah)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Capacity</b>
+</dd>
+  <dt class="optional">Consumed Amphours (Ah)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/ConsumedAmphours</b>
+</dd>
+  <dt class="optional">Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Mid-point voltage of the battery bank (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/MidVoltage</b>
+</dd>
+  <dt class="optional">Mid-point deviation of the battery bank (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/MidVoltageDeviation</b>
+</dd>
+  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b>
+</dd>
+  <dt class="optional">Diagnostics; 1st last error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Diagnostics/LastErrors/1/Error</b>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - Battery initialization error</li>
+  <li>2 - No batteries connected</li>
+  <li>3 - Unknown battery connected</li>
+  <li>4 - Different battery type</li>
+  <li>5 - Number of batteries incorrect</li>
+  <li>6 - Lynx Shunt not found</li>
+  <li>7 - Battery measure error</li>
+  <li>8 - Internal calculation error</li>
+  <li>9 - Batteries in series not ok</li>
+  <li>10 - Number of batteries incorrect</li>
+  <li>11 - Hardware error</li>
+  <li>12 - Watchdog error</li>
+  <li>13 - Over voltage</li>
+  <li>14 - Under voltage</li>
+  <li>15 - Over temperature</li>
+  <li>16 - Under temperature</li>
+  <li>17 - Hardware fault</li>
+  <li>18 - Standby shutdown</li>
+  <li>19 - Pre-charge charge error</li>
+  <li>20 - Safety contactor check error</li>
+  <li>21 - Pre-charge discharge error</li>
+  <li>22 - ADC error</li>
+  <li>23 - Slave error</li>
+  <li>24 - Slave warning</li>
+  <li>25 - Pre-charge error</li>
+  <li>26 - Safety contactor error</li>
+  <li>27 - Over current</li>
+  <li>28 - Slave update failed</li>
+  <li>29 - Slave update unavailable</li>
+  <li>30 - Calibration data lost</li>
+  <li>31 - Settings invalid</li>
+  <li>32 - BMS cable</li>
+  <li>33 - Reference failure</li>
+  <li>34 - Wrong system voltage</li>
+  <li>35 - Pre-charge timeout</li>
+</ul>
+</dd>
+  <dt class="optional">Diagnostics; 1st last error timestamp<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Diagnostics/LastErrors/1/Time</b>
+</dd>
+  <dt class="optional">Diagnostics; 2nd last error timestamp<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Diagnostics/LastErrors/2/Time</b>
+</dd>
+  <dt class="optional">Diagnostics; 3rd last error timestamp<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Diagnostics/LastErrors/3/Time</b>
+</dd>
+  <dt class="optional">Diagnostics; 4th last error timestamp<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Diagnostics/LastErrors/4/Time</b>
+</dd>
+  <dt class="optional">Diagnostics; shutdowns due to error (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Diagnostics/ShutDownsDueError</b>
+</dd>
+  <dt class="optional">Error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ErrorCode</b>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - Battery initialization error</li>
+  <li>2 - No batteries connected</li>
+  <li>3 - Unknown battery connected</li>
+  <li>4 - Different battery type</li>
+  <li>5 - Number of batteries incorrect</li>
+  <li>6 - Lynx Shunt not found</li>
+  <li>7 - Battery measure error</li>
+  <li>8 - Internal calculation error</li>
+  <li>9 - Batteries in series not ok</li>
+  <li>10 - Number of batteries incorrect</li>
+  <li>11 - Hardware error</li>
+  <li>12 - Watchdog error</li>
+  <li>13 - Over voltage</li>
+  <li>14 - Under voltage</li>
+  <li>15 - Over temperature</li>
+  <li>16 - Under temperature</li>
+  <li>17 - Hardware fault</li>
+  <li>18 - Standby shutdown</li>
+  <li>19 - Pre-charge charge error</li>
+  <li>20 - Safety contactor check error</li>
+  <li>21 - Pre-charge discharge error</li>
+  <li>22 - ADC error</li>
+  <li>23 - Slave error</li>
+  <li>24 - Slave warning</li>
+  <li>25 - Pre-charge error</li>
+  <li>26 - Safety contactor error</li>
+  <li>27 - Over current</li>
+  <li>28 - Slave update failed</li>
+  <li>29 - Slave update unavailable</li>
+  <li>30 - Calibration data lost</li>
+  <li>31 - Settings invalid</li>
+  <li>32 - BMS cable</li>
+  <li>33 - Reference failure</li>
+  <li>34 - Wrong system voltage</li>
+  <li>35 - Pre-charge timeout</li>
+</ul>
+</dd>
+  <dt class="optional">Automatic syncs (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/AutomaticSyncs</b>
+</dd>
+  <dt class="optional">Average discharge (Ah)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/AverageDischarge</b>
+</dd>
+  <dt class="optional">Charge cycles (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/ChargeCycles</b>
+</dd>
+  <dt class="optional">Charged Energy (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/ChargedEnergy</b>
+</dd>
+  <dt class="optional">Deepest discharge (Ah)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/DeepestDischarge</b>
+</dd>
+  <dt class="optional">Discharged Energy (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/DischargedEnergy</b>
+</dd>
+  <dt class="optional">Full discharges (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/FullDischarges</b>
+</dd>
+  <dt class="optional">High fused-voltage alarms (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/HighFusedVoltageAlarms</b>
+</dd>
+  <dt class="optional">High starter voltage alarms (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/HighStarterVoltageAlarms</b>
+</dd>
+  <dt class="optional">High voltage alarms (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/HighVoltageAlarms</b>
+</dd>
+  <dt class="optional">Last discharge (Ah)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/LastDischarge</b>
+</dd>
+  <dt class="optional">Low fused-voltage alarms (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/LowFusedVoltageAlarms</b>
+</dd>
+  <dt class="optional">Low starter voltage alarms (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/LowStarterVoltageAlarms</b>
+</dd>
+  <dt class="optional">Low voltage alarms (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/LowVoltageAlarms</b>
+</dd>
+  <dt class="optional">History; Max cell-voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/MaximumCellVoltage</b>
+</dd>
+  <dt class="optional">Maximum fused voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/MaximumFusedVoltage</b>
+</dd>
+  <dt class="optional">Maximum starter voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/MaximumStarterVoltage</b>
+</dd>
+  <dt class="optional">Maximum voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/MaximumVoltage</b>
+</dd>
+  <dt class="optional">History; Min cell-voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/MinimumCellVoltage</b>
+</dd>
+  <dt class="optional">Minimum fused voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/MinimumFusedVoltage</b>
+</dd>
+  <dt class="optional">Minimum starter voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/MinimumStarterVoltage</b>
+</dd>
+  <dt class="optional">Minimum voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/MinimumVoltage</b>
+</dd>
+  <dt class="optional">Time since last full charge (seconds)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/TimeSinceLastFullCharge</b>
+</dd>
+  <dt class="optional">Total Ah drawn (Ah)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/TotalAhDrawn</b>
+</dd>
+  <dt class="optional">Min discharge voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Info/BatteryLowVoltage</b>
+</dd>
+  <dt class="optional">CCL - Charge Current Limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Info/MaxChargeCurrent</b>
+</dd>
+  <dt class="optional">CVL - Charge Voltage Limit (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Info/MaxChargeVoltage</b>
+</dd>
+  <dt class="optional">DCL - Discharge Current Limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Info/MaxDischargeCurrent</b>
+</dd>
+  <dt class="optional">ATC (Allow to Charge)<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Io/AllowToCharge</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">ATD (Allow to Discharge)<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Io/AllowToDischarge</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">IO; external relay<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Io/ExternalRelay</b>
+<ul>
+  <li>0 - Inactive</li>
+  <li>1 - Active</li>
+</ul>
+</dd>
+  <dt class="optional">Relay status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Relay/0/State</b>
+<ul>
+  <li>0 - Open</li>
+  <li>1 - Closed</li>
+</ul>
+</dd>
+  <dt class="optional">State of charge (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Soc</b>
+</dd>
+  <dt class="optional">State of health (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Soh</b>
+</dd>
+  <dt class="optional">State<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/State</b>
+<ul>
+  <li>0 - Initializing (Wait start)</li>
+  <li>1 - Initializing (before boot)</li>
+  <li>2 - Initializing (Before boot delay)</li>
+  <li>3 - Initializing (Wait boot)</li>
+  <li>4 - Initializing</li>
+  <li>5 - Initializing (Measure battery voltage)</li>
+  <li>6 - Initializing (Calculate battery voltage)</li>
+  <li>7 - Initializing (Wait bus voltage)</li>
+  <li>8 - Initializing (Wait for lynx shunt)</li>
+  <li>9 - Running</li>
+  <li>10 - Error (10)</li>
+  <li>11 - Unused (11)</li>
+  <li>12 - Shutdown</li>
+  <li>13 - Slave updating</li>
+  <li>14 - Standby</li>
+  <li>15 - Going to run</li>
+  <li>16 - Pre-charging</li>
+</ul>
+</dd>
+  <dt class="optional">System; batteries parallel (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/System/BatteriesParallel</b>
+</dd>
+  <dt class="optional">System; batteries series (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/System/BatteriesSeries</b>
+</dd>
+  <dt class="optional">Maximum cell temperature (Degrees celsius)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/System/MaxCellTemperature</b>
+</dd>
+  <dt class="optional">System; maximum cell voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/System/MaxCellVoltage</b>
+</dd>
+  <dt class="optional">Minimum cell temperature (Degrees celsius)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/System/MinCellTemperature</b>
+</dd>
+  <dt class="optional">System; minimum cell voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/System/MinCellVoltage</b>
+</dd>
+  <dt class="optional">System; number of batteries (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/System/NrOfBatteries</b>
+</dd>
+  <dt class="optional">System; number of cells per battery (count)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/System/NrOfCellsPerBattery</b>
+</dd>
+  <dt class="optional">System-switch<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/SystemSwitch</b>
+<ul>
+  <li>0 - Disabled</li>
+  <li>1 - Enabled</li>
+</ul>
+</dd>
+  <dt class="optional">Time to go (h)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/TimeToGo</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-dcdc">
+<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is DC/DC, or a DC/DC controller which is interfaced to the Venus OS.</p>
+<h3>dcdc</h3>
+<dl class="message-properties">
+  <dt class="optional">Charger Error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/ChargerError</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Charger Overload<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Overload</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Charger high temperature<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Temperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Charger Status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ChargeEnable</b>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - On</li>
+</ul>
+</dd>
+  <dt class="optional">Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Power</b>
+</dd>
+  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Charger Mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>0 - Standalone</li>
+  <li>1 - Master</li>
+  <li>2 - Slave</li>
+</ul>
+</dd>
+  <dt class="optional">Charger State<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/State</b>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Bulk</li>
+  <li>2 - Absorbtion</li>
+  <li>5 - Float</li>
+  <li>7 - Ext. Control</li>
+  <li>8 - Disabled</li>
+  <li>9 - Fault</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-dcload">
+<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is a load.</p>
+<h3>dcload</h3>
+<dl class="message-properties">
+  <dt class="optional">High starter-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High battery temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low starter-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low battery temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Mid-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/MidVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Mid-point voltage of the battery bank (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/MidVoltage</b>
+</dd>
+  <dt class="optional">Mid-point deviation of the battery bank (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/MidVoltageDeviation</b>
+</dd>
+  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Power</b>
+</dd>
+  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b>
+</dd>
+  <dt class="optional">Total energy consumed (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/EnergyIn</b>
+</dd>
+  <dt class="optional">Relay status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Relay/0/State</b>
+<ul>
+  <li>0 - Open</li>
+  <li>1 - Closed</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-dcsource">
+<p>This node allows for monitoring the state of Battery Monitor Victron devices (BMV's) configured in Monitor Mode and DC meter type is a source.</p>
+<h3>dcsource</h3>
+<dl class="message-properties">
+  <dt class="optional">High starter-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High battery temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low starter-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low battery temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Mid-voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/MidVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Mid-point voltage of the battery bank (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/MidVoltage</b>
+</dd>
+  <dt class="optional">Mid-point deviation of the battery bank (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/MidVoltageDeviation</b>
+</dd>
+  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Power</b>
+</dd>
+  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b>
+</dd>
+  <dt class="optional">Total energy produced (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/EnergyOut</b>
+</dd>
+  <dt class="optional">Relay status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Relay/0/State</b>
+<ul>
+  <li>0 - Open</li>
+  <li>1 - Closed</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-dcsystem">
+<p>DC system input node is a DC measurement for loads in your system.</p>
+<h3>dcsystem</h3>
+<dl class="message-properties">
+  <dt class="optional">High auxiliary voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low auxiliary voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Battery current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Temperature (Degrees celsius)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Battery voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Auxiliary voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b>
+</dd>
+  <dt class="optional">Total energy consumed (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/EnergyIn</b>
+</dd>
+  <dt class="optional">Total energy produced (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/EnergyOut</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-digitalinput">
+<p>With this node it is possible to read the digital inputs from the Venus device. The node only shows the enabled digital inputs, so first make sure to enable the input from the Venus OS GUI (<i>Settings -> I/O -> digital inputs</i>) for the desired readout.</p><p>Depending on the selected type of input, different measurements become available.</p><p>Also see the section on <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/digital-inputs.html">digital inputs</a> in the Cerbo GX manual.</p>
+<h3>pulsemeter</h3>
+<dl class="message-properties">
+  <dt class="optional">Pulse meter aggregate<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Aggregate</b>
+</dd>
+  <dt class="optional">Pulse meter count<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Count</b>
+</dd>
+</dl>
+<h3>digitalinput</h3>
+<dl class="message-properties">
+  <dt class="optional">Digital input alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarm</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Digital input count<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Count</b>
+</dd>
+  <dt class="optional">Digital input product id<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/ProductId</b>
+</dd>
+  <dt class="optional">Digital input state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/State</b>
+<ul>
+  <li>0 - low</li>
+  <li>1 - high</li>
+  <li>2 - off</li>
+  <li>3 - on</li>
+  <li>4 - no</li>
+  <li>5 - yes</li>
+  <li>6 - open</li>
+  <li>7 - closed</li>
+  <li>8 - ok</li>
+  <li>9 - alarm</li>
+  <li>10 - running</li>
+  <li>11 - stopped</li>
+</ul>
+</dd>
+  <dt class="optional">Digital input type<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Type</b>
+<ul>
+  <li>0 - Disabled</li>
+  <li>1 - Pulse meter</li>
+  <li>2 - Door sensor</li>
+  <li>3 - Bilge pump</li>
+  <li>4 - Bilge alarm</li>
+  <li>5 - Burglar alarm</li>
+  <li>6 - Smoke alarm</li>
+  <li>7 - Fire alarm</li>
+  <li>8 - CO2 alarm</li>
+  <li>9 - Generic input</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-ess">
+<p>This node gives information on the energy storage system (ESS).</p>
+<h3>vebus</h3>
+<dl class="message-properties">
+  <dt class="optional">Disable charge<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Hub4/DisableCharge</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Disable feed-in<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Hub4/DisableFeedIn</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Feed in overvoltage<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Hub4/DoNotFeedInOvervoltage</b>
+<ul>
+  <li>0 - Yes</li>
+  <li>1 - No</li>
+</ul>
+</dd>
+  <dt class="optional">AC Power L1 setpoint (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L1/AcPowerSetpoint</b>
+</dd>
+  <dt class="optional">Maximum overvoltage feed-in power L1 (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L1/MaxFeedInPower</b>
+</dd>
+  <dt class="optional">AC Power L2 setpoint (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L2/AcPowerSetpoint</b>
+</dd>
+  <dt class="optional">Maximum overvoltage feed-in power L2 (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L2/MaxFeedInPower</b>
+</dd>
+  <dt class="optional">Maximum overvoltage feed-in power L3 (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L3/MaxFeedInPower</b>
+</dd>
+  <dt class="optional">AC Power L3 setpoint (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L3/AcPowerSetpoint</b>
+</dd>
+  <dt class="optional">Disable PV inverter<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/PvInverter/Disable</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">VE.Bus Reset<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/SystemReset</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+</dl>
+<h3>settings</h3>
+<dl class="message-properties">
+  <dt class="optional">Grid set-point (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/AcPowerSetPoint</b>
+</dd>
+  <dt class="optional">Minimum Discharge SOC (%)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/MinimumSocLimit</b>
+</dd>
+  <dt class="optional">Active SOC limit (%)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/SocLimit</b>
+</dd>
+  <dt class="optional">ESS state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/State</b>
+<ul>
+  <li>1 - BatteryLife enabled (GUI controlled)</li>
+  <li>2 - Optimized Mode /w BatteryLife: self consumption</li>
+  <li>3 - Optimized Mode /w BatteryLife: self consumption, SoC exceeds 85%</li>
+  <li>4 - Optimized Mode /w BatteryLife: self consumption, SoC at 100%</li>
+  <li>5 - Optimized Mode /w BatteryLife: SoC below dynamic SoC limit</li>
+  <li>6 - Optimized Mode /w BatteryLife: SoC has been below SoC limit for more than 24 hours. Charging the battery (5A)</li>
+  <li>7 - Optimized Mode /w BatteryLife: Inverter/Charger is in sustain mode</li>
+  <li>8 - Optimized Mode /w BatteryLife: recharging, SoC dropped by 5% or more below the minimum SoC</li>
+  <li>9 - 'Keep batteries charged' mode is enabled</li>
+  <li>10 - Optimized mode w/o BatteryLife: self consumption, SoC at or above minimum SoC</li>
+  <li>11 - Optimized mode w/o BatteryLife: self consumption, SoC is below minimum SoC</li>
+  <li>12 - Optimized mode w/o BatteryLife: recharging, SoC dropped by 5% or more below minimum SoC</li>
+</ul>
+</dd>
+  <dt class="optional">ESS mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/Hub4Mode</b>
+<ul>
+  <li>1 - Optimized mode or 'keep batteries charged' and phase compensation enabled</li>
+  <li>2 - Optimized mode or 'keep batteries charged' and phase compensation disabled</li>
+  <li>3 - External control</li>
+</ul>
+</dd>
+  <dt class="optional">Max inverter power (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/MaxDischargePower</b>
+</dd>
+  <dt class="optional">Feed-in excess solar charger power<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/OvervoltageFeedIn</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">PV Inverter zero feed-in (on/off)<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/PreventFeedback</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Charge current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeCurrent</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-evcharger">
+<p>EV charger input node</p>
+<h3>evcharger</h3>
+<dl class="message-properties">
+  <dt class="optional">Energy consumed by charger (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Energy/Forward</b>
+</dd>
+  <dt class="optional">L1 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Power</b>
+</dd>
+  <dt class="optional">L2 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Power</b>
+</dd>
+  <dt class="optional">L3 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Power</b>
+</dd>
+  <dt class="optional">Total power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Power</b>
+</dd>
+  <dt class="optional">Charging time (seconds)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/ChargingTime</b>
+</dd>
+  <dt class="optional">Charge current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Current</b>
+</dd>
+  <dt class="optional">Firmware version<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/FirmwareVersion</b>
+</dd>
+  <dt class="optional">Maximum charge current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/MaxCurrent</b>
+</dd>
+  <dt class="optional">Mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>0 - Manual</li>
+  <li>1 - Auto</li>
+</ul>
+</dd>
+  <dt class="optional">Model<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Model</b>
+</dd>
+  <dt class="optional">Product ID<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/ProductId</b>
+</dd>
+  <dt class="optional">Serial<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/Serial</b>
+</dd>
+  <dt class="optional">Set charge current (manual mode) (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/SetCurrent</b>
+</dd>
+  <dt class="optional">Start/stop charging (manual mode)<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/StartStop</b>
+<ul>
+  <li>0 - Stop</li>
+  <li>1 - Start</li>
+</ul>
+</dd>
+  <dt class="optional">Status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Status</b>
+<ul>
+  <li>0 - Disconnected</li>
+  <li>1 - Connected</li>
+  <li>2 - Charging</li>
+  <li>3 - Charged</li>
+  <li>4 - Waiting for sun</li>
+  <li>5 - Waiting for RFID</li>
+  <li>6 - Waiting for start</li>
+  <li>7 - Low SOC</li>
+  <li>8 - Ground fault</li>
+  <li>9 - Welded contacts</li>
+  <li>10 - CP Input shorted</li>
+  <li>11 - Residual current detected</li>
+  <li>12 - Under voltage detected</li>
+  <li>13 - Overvoltage detected</li>
+  <li>14 - Overheating detected</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-generator">
+<p>Generator input node for Fischer Panda generators. Also see <a href="https://github.com/victronenergy/venus/wiki/dbus#generator">here</a> for more information.</p>
+<h3>generator</h3>
+<dl class="message-properties">
+  <dt class="optional">Generator not detected at AC input alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Generator0/Alarms/NoGeneratorAtAcIn</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Generator remote error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Generator0/Error</b>
+<ul>
+  <li>0 - No Error</li>
+  <li>1 - Remote disabled</li>
+  <li>2 - Remote fault</li>
+</ul>
+</dd>
+  <dt class="optional">Condition that started the generator<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Generator0/RunningByConditionCode</b>
+<ul>
+  <li>0 - Stopped</li>
+  <li>1 - Manual</li>
+  <li>2 - TestRun</li>
+  <li>3 - LossOfComms</li>
+  <li>4 - Soc</li>
+  <li>5 - AcLoad</li>
+  <li>6 - BatteryCurrent</li>
+  <li>7 - BatteryVoltage</li>
+  <li>8 - InverterTemperatur</li>
+  <li>9 - InverterOverload</li>
+  <li>10 - StopOnAc1</li>
+</ul>
+</dd>
+  <dt class="optional">Runtime in seconds (seconds)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Generator0/Runtime</b>
+</dd>
+  <dt class="optional">Generator start/stop state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Generator0/State</b>
+<ul>
+  <li>0 - Stopped</li>
+  <li>1 - Running</li>
+  <li>10 - Error</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-genset">
+<p>This node is essentially an energy meter showing volts, amps, power, energy etc. It is comparable with the input-gridmeter.</p>
+<h3>genset</h3>
+<dl class="message-properties">
+  <dt class="optional">Phase 1 current (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Current</b>
+</dd>
+  <dt class="optional">Phase 1 frequency (Hz)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Frequency</b>
+</dd>
+  <dt class="optional">Phase 1 power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Power</b>
+</dd>
+  <dt class="optional">Phase 1 voltage (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Voltage</b>
+</dd>
+  <dt class="optional">Phase 2 current (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Current</b>
+</dd>
+  <dt class="optional">Phase 2 frequency (Hz)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Frequency</b>
+</dd>
+  <dt class="optional">Phase 2 power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Power</b>
+</dd>
+  <dt class="optional">Phase 2 voltage (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Voltage</b>
+</dd>
+  <dt class="optional">Phase 3 current (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Current</b>
+</dd>
+  <dt class="optional">Phase 3 frequency (Hz)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Frequency</b>
+</dd>
+  <dt class="optional">Phase 3 power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Power</b>
+</dd>
+  <dt class="optional">Phase 3 voltage (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Voltage</b>
+</dd>
+  <dt class="optional">Auto start<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/AutoStart</b>
+<ul>
+  <li>0 - Disabled</li>
+  <li>1 - Enabled</li>
+</ul>
+</dd>
+  <dt class="optional">Engine coolant temperature (Degrees celsius)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Engine/CoolantTemperature</b>
+</dd>
+  <dt class="optional">Engine exhaust temperature (Degrees celsius)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Engine/ExaustTemperature</b>
+</dd>
+  <dt class="optional">Engine load (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Engine/Load</b>
+</dd>
+  <dt class="optional">Engine operating hours (s)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Engine/OperatingHours</b>
+</dd>
+  <dt class="optional">Engine speed (RPM)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Engine/Speed</b>
+</dd>
+  <dt class="optional">Engine winding temperature (Degrees celsius)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Engine/WindingTemperature</b>
+</dd>
+  <dt class="optional">Error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ErrorCode</b>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - AC voltage L1 too low</li>
+  <li>2 - AC frequency L1 too low</li>
+  <li>3 - AC current too low</li>
+  <li>4 - AC power too low</li>
+  <li>5 - Emergency stop</li>
+  <li>6 - Servo current too low</li>
+  <li>7 - Oil pressure too low</li>
+  <li>8 - Engine temperature too low</li>
+  <li>9 - Winding temperature too low</li>
+  <li>10 - Exhaust temperature too low</li>
+  <li>13 - Starter current too low</li>
+  <li>14 - Glow current too low</li>
+  <li>15 - Glow current too low</li>
+  <li>16 - Fuel holding magnet current too low</li>
+  <li>17 - Stop solenoid hold coil current too low</li>
+  <li>18 - Stop solenoid pull coil current too low</li>
+  <li>19 - Optional DC out current too low</li>
+  <li>20 - 5V output voltage too low</li>
+  <li>21 - Boost output current too low</li>
+  <li>22 - Panel supply current too high</li>
+  <li>25 - Starter battery voltage too low</li>
+  <li>26 - Startup aborted (rotation too low)</li>
+  <li>28 - Rotation too low</li>
+  <li>29 - Power contactor current too low</li>
+  <li>30 - AC voltage L2 too low</li>
+  <li>31 - AC frequency L2 too low</li>
+  <li>32 - AC current L2 too low</li>
+  <li>33 - AC power L2 too low</li>
+  <li>34 - AC voltage L3 too low</li>
+  <li>35 - AC frequency L3 too low</li>
+  <li>36 - AC current L3 too low</li>
+  <li>37 - AC power L3 too low</li>
+  <li>62 - Fuel temperature too low</li>
+  <li>63 - Fuel level too low</li>
+  <li>65 - AC voltage L1 too high</li>
+  <li>66 - AC frequency too high</li>
+  <li>67 - AC current too high</li>
+  <li>68 - AC power too high</li>
+  <li>70 - Servo current too high</li>
+  <li>71 - Oil pressure too high</li>
+  <li>72 - Engine temperature too high</li>
+  <li>73 - Winding temperature too high</li>
+  <li>74 - Exhaust temperature too low</li>
+  <li>77 - Starter current too low</li>
+  <li>78 - Glow current too high</li>
+  <li>79 - Glow current too high</li>
+  <li>80 - Fuel holding magnet current too high</li>
+  <li>81 - Stop solenoid hold coil current too high</li>
+  <li>82 - Stop solenoid pull coil current too high</li>
+  <li>83 - Optional DC out current too high</li>
+  <li>84 - 5V output voltage too high</li>
+  <li>85 - Boost output current too high</li>
+  <li>89 - Starter battery voltage too high</li>
+  <li>90 - Startup aborted (rotation too high)</li>
+  <li>92 - Rotation too high</li>
+  <li>93 - Power contactor current too high</li>
+  <li>94 - AC voltage L2 too high</li>
+  <li>95 - AC frequency L2 too high</li>
+  <li>96 - AC current L2 too high</li>
+  <li>97 - AC power L2 too high</li>
+  <li>98 - AC voltage L3 too high</li>
+  <li>99 - AC frequency L3 too high</li>
+  <li>100 - AC current L3 too high</li>
+  <li>101 - AC power L3 too high</li>
+  <li>126 - Fuel temperature too high</li>
+  <li>127 - Fuel level too high</li>
+  <li>130 - Lost control unit</li>
+  <li>131 - Lost panel</li>
+  <li>132 - Service needed</li>
+  <li>133 - Lost 3-phase module</li>
+  <li>134 - Lost AGT module</li>
+  <li>135 - Synchronization failure</li>
+  <li>137 - Intake airfilter</li>
+  <li>139 - Lost sync. module</li>
+  <li>140 - Load-balance failed</li>
+  <li>141 - Sync-mode deactivated</li>
+  <li>142 - Engine controller</li>
+  <li>148 - Rotating field wrong</li>
+  <li>149 - Fuel level sensor lost</li>
+  <li>150 - Init failed</li>
+  <li>151 - Watchdog</li>
+  <li>152 - Out: winding</li>
+  <li>153 - Out: exhaust</li>
+  <li>154 - Out: Cyl. head</li>
+  <li>155 - Inverter over temperature</li>
+  <li>156 - Inverter overload</li>
+  <li>157 - Inverter communication lost</li>
+  <li>158 - Inverter sync failed</li>
+  <li>159 - CAN communication lost</li>
+  <li>160 - L1 overload</li>
+  <li>161 - L2 overload</li>
+  <li>162 - L3 overload</li>
+  <li>163 - DC overload</li>
+  <li>164 - DC overvoltage</li>
+  <li>165 - Emergency stop</li>
+  <li>166 - No connection</li>
+</ul>
+</dd>
+  <dt class="optional">Generator model<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/ProductId</b>
+</dd>
+  <dt class="optional">Starter voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/StarterVoltage</b>
+</dd>
+  <dt class="optional">Status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/StatusCode</b>
+<ul>
+  <li>0 - Standby</li>
+  <li>1 - Startup 1</li>
+  <li>2 - Startup 2</li>
+  <li>3 - Startup 3</li>
+  <li>4 - Startup 4</li>
+  <li>5 - Startup 5</li>
+  <li>6 - Startup 6</li>
+  <li>7 - Startup 7</li>
+  <li>8 - Running</li>
+  <li>9 - Stopping</li>
+  <li>10 - Error</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-gps">
+<p>GPS information can be obtained with this node. For an example usage see the <a href="https://github.com/victronenergy/node-red-contrib-victron/wiki/Example-Flows#location-based-scheduling">location based scheduling</a> example.</p>
+<h3>gps</h3>
+<dl class="message-properties">
+  <dt class="optional">Altitude (m)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Altitude</b>
+</dd>
+  <dt class="optional">Course (Deg)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Course</b>
+</dd>
+  <dt class="optional">Fix<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Fix</b>
+</dd>
+  <dt class="optional">Number of satellites<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/NrOfSatellites</b>
+</dd>
+  <dt class="optional">Latitude (LAT)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Position/Latitude</b>
+</dd>
+  <dt class="optional">Longitude (LNG)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Position/Longitude</b>
+</dd>
+  <dt class="optional">Speed (m/s)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Speed</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-gridmeter">
+<p>This node gives allows for monitoring the grid. See also <a href="https://www.victronenergy.com/accessories/energy-meter">energy meters</a> accessoires.</p>
+<h3>grid</h3>
+<dl class="message-properties">
+  <dt class="optional">Total Forward Energy (bought) (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Energy/Forward</b>
+</dd>
+  <dt class="optional">Total Reverse Energy (sold) (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Energy/Reverse</b>
+</dd>
+  <dt class="optional">L1 Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Current</b>
+</dd>
+  <dt class="optional">L1 Forward energy (bought) (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Energy/Forward</b>
+</dd>
+  <dt class="optional">L1 Reverse energy (sold) (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Energy/Reverse</b>
+</dd>
+  <dt class="optional">L1 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Power</b>
+</dd>
+  <dt class="optional">L1 Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Voltage</b>
+</dd>
+  <dt class="optional">L2 Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Current</b>
+</dd>
+  <dt class="optional">L2 Forward energy (bought) (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Energy/Forward</b>
+</dd>
+  <dt class="optional">L2 Reverse energy (sold) (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Energy/Reverse</b>
+</dd>
+  <dt class="optional">L2 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Power</b>
+</dd>
+  <dt class="optional">L2 Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Voltage</b>
+</dd>
+  <dt class="optional">L2 Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Current</b>
+</dd>
+  <dt class="optional">L3 Forward energy (bought) (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Energy/Forward</b>
+</dd>
+  <dt class="optional">L3 Reverse energy (sold) (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Energy/Reverse</b>
+</dd>
+  <dt class="optional">L3 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Power</b>
+</dd>
+  <dt class="optional">L3 Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Voltage</b>
+</dd>
+  <dt class="optional">Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Power</b>
+</dd>
+  <dt class="optional">Serial<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/Serial</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-inverter">
+<p>This node is for reading from an inverter.</p>
+<h3>inverter</h3>
+<dl class="message-properties">
+  <dt class="optional">Output current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/I</b>
+</dd>
+  <dt class="optional">Output power (W AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/P</b>
+</dd>
+  <dt class="optional">Output voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/V</b>
+</dd>
+  <dt class="optional">High temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High battery voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High AC-Out voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltageAcOut</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low temperature alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low battery voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low AC-Out voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltageAcOut</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Overload alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Overload</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Ripple alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Ripple</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Battery current (A DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Input voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Energy from battery to AC-out (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/InverterToAcOut</b>
+</dd>
+  <dt class="optional">Energy from AC-out to battery (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/OutToInverter</b>
+</dd>
+  <dt class="optional">Energy from solar to AC-out (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/SolarToAcOut</b>
+</dd>
+  <dt class="optional">Energy from solar to battery (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/SolarToBattery</b>
+</dd>
+  <dt class="optional">Firmware version<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/FirmwareVersion</b>
+</dd>
+  <dt class="optional">Maximum power for today on tracker 0 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/0/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for today on tracker 0 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/0/Yield</b>
+</dd>
+  <dt class="optional">Maximum power for today on tracker 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/1/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for today on tracker 1 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/1/Yield</b>
+</dd>
+  <dt class="optional">Maximum power for today on tracker 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/2/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for today on tracker 2 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/2/Yield</b>
+</dd>
+  <dt class="optional">Maximum power for today on tracker 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/3/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for today on tracker 3 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/3/Yield</b>
+</dd>
+  <dt class="optional">Maximum power for yesterday on tracker 0 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/0/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for yesterday on tracker 0 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/0/Yield</b>
+</dd>
+  <dt class="optional">Maximum power for yesterday on tracker 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/1/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for yesterday on tracker 1 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/1/Yield</b>
+</dd>
+  <dt class="optional">Maximum power for yesterday on tracker 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/2/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for yesterday on tracker 2 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/2/Yield</b>
+</dd>
+  <dt class="optional">Maximum power for yesterday on tracker 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/3/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for yesterday on tracker 3 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/3/Yield</b>
+</dd>
+  <dt class="optional">Mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>2 - Inverter on</li>
+  <li>4 - Off</li>
+  <li>5 - Low Power/ECO</li>
+</ul>
+</dd>
+  <dt class="optional">Inverter model<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/ProductId</b>
+</dd>
+  <dt class="optional">PV power for tracker 0 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/0/P</b>
+</dd>
+  <dt class="optional">PV voltage for tracker 0 (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/0/V</b>
+</dd>
+  <dt class="optional">PV power for tracker 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/1/P</b>
+</dd>
+  <dt class="optional">PV voltage for tracker 1 (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/1/V</b>
+</dd>
+  <dt class="optional">PV power for tracker 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/2/P</b>
+</dd>
+  <dt class="optional">PV voltage for tracker 2 (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/2/V</b>
+</dd>
+  <dt class="optional">PV power for tracker 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/3/P</b>
+</dd>
+  <dt class="optional">PV voltage for tracker 3 (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/3/V</b>
+</dd>
+  <dt class="optional">PV voltage (for single tracker units) (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/V</b>
+</dd>
+  <dt class="optional">Relay state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Relay/0/State</b>
+<ul>
+  <li>0 - Open</li>
+  <li>1 - Closed</li>
+</ul>
+</dd>
+  <dt class="optional">State<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/State</b>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Low Power</li>
+  <li>2 - Fault</li>
+  <li>9 - Inverting</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-meteo">
+<p>The <b>input-meteo</b> node allows for Solar Irradiance, Temperature and Wind Speed Sensors measuring.</p><p>More information and supported devices can be found in the <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-d4b7dfe9-4ee0-53bc-8959-c567ed63cebb">manual</a>.</p>
+<h3>meteo</h3>
+<dl class="message-properties">
+  <dt class="optional">Sensor cell temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/CellTemperature</b>
+</dd>
+  <dt class="optional">External temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/ExternalTemperature</b>
+</dd>
+  <dt class="optional">Solar Irradiance (W/m^2)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Irradiance</b>
+</dd>
+  <dt class="optional">Wind speed (m/s)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/WindSpeed</b>
+</dd>
+</dl>
+</script>
+
 <script type="text/x-red" data-help-name="victron-input-multi">
 <p>This is the Multi RS input node.</p>
 <h3>multi</h3>
 <dl class="message-properties">
-  <dt class="optional">Input voltage phase 1 (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L1/V</b>
+  <dt class="optional">Active AC input<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/ActiveInput</b>
+<ul>
+  <li>0 - AC Input 1</li>
+  <li>1 - AC Input 2</li>
+  <li>240 - Disconnected</li>
+</ul>
 </dd>
-  <dt class="optional">Input voltage phase 2 (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L2/V</b>
-</dd>
-  <dt class="optional">Input voltage phase 3 (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L3/V</b>
-</dd>
-  <dt class="optional">Input current phase 1 (A AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L1/I</b>
-</dd>
-  <dt class="optional">Input current phase 2 (A AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L2/I</b>
-</dd>
-  <dt class="optional">Input current phase 3 (A AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L3/I</b>
-</dd>
-  <dt class="optional">Input power phase 1 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L1/P</b>
-</dd>
-  <dt class="optional">Input power phase 2 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L2/P</b>
-</dd>
-  <dt class="optional">Input power phase 3 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/L3/P</b>
+  <dt class="optional">Ac input 1 current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/CurrentLimit</b>
 </dd>
   <dt class="optional">Input frequency (Hz)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Ac/In/1/L1/F</b>
 </dd>
-  <dt class="optional">Output voltage phase 1 (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/V</b>
+  <dt class="optional">Input current phase 1 (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L1/I</b>
 </dd>
-  <dt class="optional">Output voltage phase 2 (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L2/V</b>
+  <dt class="optional">Input power phase 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L1/P</b>
 </dd>
-  <dt class="optional">Output voltage phase 3 (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L3/V</b>
+  <dt class="optional">Input voltage phase 1 (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L1/V</b>
 </dd>
-  <dt class="optional">Output current phase 1 (A AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/I</b>
+  <dt class="optional">Input current phase 2 (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L2/I</b>
 </dd>
-  <dt class="optional">Output current phase 2 (A AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L2/I</b>
+  <dt class="optional">Input power phase 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L2/P</b>
 </dd>
-  <dt class="optional">Output current phase 3 (A AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L3/I</b>
+  <dt class="optional">Input voltage phase 2 (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L2/V</b>
 </dd>
-  <dt class="optional">Output power phase 1 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/P</b>
+  <dt class="optional">Input current phase 3 (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L3/I</b>
 </dd>
-  <dt class="optional">Output power phase 2 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L2/P</b>
+  <dt class="optional">Input power phase 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L3/P</b>
 </dd>
-  <dt class="optional">Output power phase 3 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L3/P</b>
-</dd>
-  <dt class="optional">Output frequency (Hz)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/F</b>
+  <dt class="optional">Input voltage phase 3 (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/L3/V</b>
 </dd>
   <dt class="optional">AC input 1 source type<span class="property-type">enum</dt>
   <dd>Dbus path: <b>/Ac/In/1/Type</b>
@@ -136,6 +2013,9 @@ Questions can also be asked on the Victron Energy community:
   <li>2 - Genset</li>
   <li>3 - Shore</li>
 </ul>
+</dd>
+  <dt class="optional">Ac input 2 current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/2/CurrentLimit</b>
 </dd>
   <dt class="optional">AC input 2 source type<span class="property-type">enum</dt>
   <dd>Dbus path: <b>/Ac/In/2/Type</b>
@@ -149,43 +2029,35 @@ Questions can also be asked on the Victron Energy community:
   <dt class="optional">Phase count (count)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Ac/NumberOfPhases</b>
 </dd>
-  <dt class="optional">Active AC input<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/ActiveInput</b>
-<ul>
-  <li>0 - AC Input 1</li>
-  <li>1 - AC Input 2</li>
-  <li>240 - Disconnected</li>
-</ul>
+  <dt class="optional">Output frequency (Hz)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/F</b>
 </dd>
-  <dt class="optional">Battery voltage (V DC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+  <dt class="optional">Output current phase 1 (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/I</b>
 </dd>
-  <dt class="optional">Battery current (A DC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
+  <dt class="optional">Output power phase 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/P</b>
 </dd>
-  <dt class="optional">Battery temperature (Degrees celsius)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+  <dt class="optional">Output voltage phase 1 (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/V</b>
 </dd>
-  <dt class="optional">Battery State of Charge (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Soc</b>
+  <dt class="optional">Output current phase 2 (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L2/I</b>
 </dd>
-  <dt class="optional">Inverter/Charger state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/State</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - Low Power</li>
-  <li>2 - Fault</li>
-  <li>3 - Bulk</li>
-  <li>4 - Absorption</li>
-  <li>5 - Float</li>
-  <li>6 - Storage</li>
-  <li>7 - Equalize</li>
-  <li>8 - Passthru</li>
-  <li>9 - Inverting</li>
-  <li>10 - Power assist</li>
-  <li>11 - Power supply</li>
-  <li>252 - Bulk protection</li>
-</ul>
+  <dt class="optional">Output power phase 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L2/P</b>
+</dd>
+  <dt class="optional">Output voltage phase 2 (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L2/V</b>
+</dd>
+  <dt class="optional">Output current phase 3 (A AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L3/I</b>
+</dd>
+  <dt class="optional">Output power phase 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L3/P</b>
+</dd>
+  <dt class="optional">Output voltage phase 3 (V AC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L3/V</b>
 </dd>
   <dt class="optional">Temperature alarm<span class="property-type">enum</dt>
   <dd>Dbus path: <b>/Alarms/HighTemperature</b>
@@ -251,52 +2123,14 @@ Questions can also be asked on the Victron Energy community:
   <li>2 - Alarm</li>
 </ul>
 </dd>
-  <dt class="optional">PV power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Yield/Power</b>
+  <dt class="optional">Battery current (A DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
 </dd>
-  <dt class="optional">User yield (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Yield/User</b>
+  <dt class="optional">Battery temperature (Degrees celsius)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
 </dd>
-  <dt class="optional">Relay on the Multi RS<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Relay/0/State</b>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul>
-</dd>
-  <dt class="optional">MPP operation mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/MppOperationMode</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - Voltage/current limited</li>
-  <li>2 - MPPT active</li>
-  <li>255 - Not available</li>
-</ul>
-</dd>
-  <dt class="optional">PV voltage (V DC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/V</b>
-</dd>
-  <dt class="optional">Error code<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/ErrorCode</b>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - Battery temperature too high</li>
-  <li>2 - Battery voltage too high</li>
-  <li>3 - Battery temperature sensor miswired (+)</li>
-  <li>4 - Battery temperature sensor miswired (-)</li>
-  <li>5 - Battery temperature sensor disconnected</li>
-  <li>6 - Battery voltage sense miswired (+)</li>
-  <li>7 - Battery voltage sense miswired (-)</li>
-  <li>8 - Battery voltage sense disconnected</li>
-  <li>9 - Battery voltage wire losses too high</li>
-  <li>17 - Charger temperature too high</li>
-  <li>18 - Charger over-current</li>
-  <li>19 - Charger current polarity reversed</li>
-  <li>20 - Bulk time limit reached</li>
-  <li>22 - Charger temperature sensor miswired</li>
-  <li>23 - Charger temperature sensor disconnected</li>
-  <li>34 - Input current too high</li>
-</ul>
+  <dt class="optional">Battery voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
 </dd>
   <dt class="optional">Energy from AC-in-1 to AC-out (kWh)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Energy/AcIn1ToAcOut</b>
@@ -340,242 +2174,82 @@ Questions can also be asked on the Victron Energy community:
   <dt class="optional">Energy from solar to battery (kWh)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Energy/SolarToBattery</b>
 </dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-acload">
-<p>This node allows for AC load monitoring. Measuring can be done by using an energy meter and assigning it the 'ac load' role.</p>
-<h3>acload</h3>
-<dl class="message-properties">
-  <dt class="optional">Serial number<span class="property-type">string</dt>
-  <dd>Dbus path: <b>/Serial</b>
-</dd>
-  <dt class="optional">L1 Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Power</b>
-</dd>
-  <dt class="optional">L2 Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Power</b>
-</dd>
-  <dt class="optional">L3 Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Power</b>
-</dd>
-  <dt class="optional">L1 Voltage (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Voltage</b>
-</dd>
-  <dt class="optional">L1 Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Current</b>
-</dd>
-  <dt class="optional">L2 Voltage (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Voltage</b>
-</dd>
-  <dt class="optional">L2 Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Current</b>
-</dd>
-  <dt class="optional">L3 Voltage (V AC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Voltage</b>
-</dd>
-  <dt class="optional">L3 Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Current</b>
-</dd>
-  <dt class="optional">L1 Energy (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Energy/Forward</b>
-</dd>
-  <dt class="optional">L2 Energy (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Energy/Forward</b>
-</dd>
-  <dt class="optional">L3 Energy (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Energy/Forward</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-digitalinput">
-<p>With this node it is possible to read the digital inputs from the Venus device. The node only shows the enabled digital inputs, so first make sure to enable the input from the Venus OS GUI (<i>Settings -> I/O -> digital inputs</i>) for the desired readout.</p><p>Depending on the selected type of input, different measurements become available.</p><p>Also see the section on <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/digital-inputs.html">digital inputs</a> in the Cerbo GX manual.</p>
-<h3>pulsemeter</h3>
-<dl class="message-properties">
-  <dt class="optional">Pulse meter aggregate<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Aggregate</b>
-</dd>
-  <dt class="optional">Pulse meter count<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Count</b>
-</dd>
-</dl>
-<h3>digitalinput</h3>
-<dl class="message-properties">
-  <dt class="optional">Digital input product id<span class="property-type">string</dt>
-  <dd>Dbus path: <b>/ProductId</b>
-</dd>
-  <dt class="optional">Digital input alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarm</b>
+  <dt class="optional">Error code<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ErrorCode</b>
 <ul>
-  <li>0 - No alarm</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
+  <li>0 - No error</li>
+  <li>1 - Battery temperature too high</li>
+  <li>2 - Battery voltage too high</li>
+  <li>3 - Battery temperature sensor miswired (+)</li>
+  <li>4 - Battery temperature sensor miswired (-)</li>
+  <li>5 - Battery temperature sensor disconnected</li>
+  <li>6 - Battery voltage sense miswired (+)</li>
+  <li>7 - Battery voltage sense miswired (-)</li>
+  <li>8 - Battery voltage sense disconnected</li>
+  <li>9 - Battery voltage wire losses too high</li>
+  <li>17 - Charger temperature too high</li>
+  <li>18 - Charger over-current</li>
+  <li>19 - Charger current polarity reversed</li>
+  <li>20 - Bulk time limit reached</li>
+  <li>22 - Charger temperature sensor miswired</li>
+  <li>23 - Charger temperature sensor disconnected</li>
+  <li>34 - Input current too high</li>
 </ul>
 </dd>
-  <dt class="optional">Digital input state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/State</b>
+  <dt class="optional">MPP operation mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/MppOperationMode</b>
 <ul>
-  <li>0 - low</li>
-  <li>1 - high</li>
-  <li>2 - off</li>
-  <li>3 - on</li>
-  <li>4 - no</li>
-  <li>5 - yes</li>
-  <li>6 - open</li>
-  <li>7 - closed</li>
-  <li>8 - ok</li>
-  <li>9 - alarm</li>
-  <li>10 - running</li>
-  <li>11 - stopped</li>
+  <li>0 - Off</li>
+  <li>1 - Voltage/current limited</li>
+  <li>2 - MPPT active</li>
+  <li>255 - Not available</li>
 </ul>
 </dd>
-  <dt class="optional">Digital input count<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Count</b>
+  <dt class="optional">PV voltage (V DC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/V</b>
 </dd>
-  <dt class="optional">Digital input type<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Type</b>
-<ul>
-  <li>0 - Disabled</li>
-  <li>1 - Pulse meter</li>
-  <li>2 - Door sensor</li>
-  <li>3 - Bilge pump</li>
-  <li>4 - Bilge alarm</li>
-  <li>5 - Burglar alarm</li>
-  <li>6 - Smoke alarm</li>
-  <li>7 - Fire alarm</li>
-  <li>8 - CO2 alarm</li>
-  <li>9 - Generic input</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-tank">
-<p>The input-tank node is for retrieving tank level sensor information.</p><p>Also see the <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-e4027d37-78e0-4433-1be4-3252d3b79152">manual</a> for more information.</p>
-<h3>tank</h3>
-<dl class="message-properties">
-  <dt class="optional">Tank capacity (m3)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Capacity</b>
-</dd>
-  <dt class="optional">Fluid remaining (m3)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Remaining</b>
-</dd>
-  <dt class="optional">Tank level (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Level</b>
-</dd>
-  <dt class="optional">Tank sensor status<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Status</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Disconnected</li>
-  <li>2 - Short circuited</li>
-  <li>3 - Unknown</li>
-</ul>
-</dd>
-  <dt class="optional">Fluid type<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/FluidType</b>
-<ul>
-  <li>0 - Fuel</li>
-  <li>1 - Fresh water</li>
-  <li>2 - Waste water</li>
-  <li>3 - Live well</li>
-  <li>4 - Oil</li>
-  <li>5 - Black water (sewage)</li>
-</ul>
-</dd>
-  <dt class="optional">Standard<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Standard</b>
-<ul>
-  <li>0 - European</li>
-  <li>1 - USA</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-temperature">
-<p>Like the other nodes, the <b>input-temperature</b> node reads the temperate information from the dbus. This means that source of the temperature sensor can obtain its information from different sources (e.g. directly connected probe or Bluetooth connected Ruuvi tag).</p><p>See the <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-4d5df29c-761e-cfcc-9e2c-8230f126e7bb">manual</a> for information on connecting a temperature sensor.</p>
-<h3>temperature</h3>
-<dl class="message-properties">
-  <dt class="optional">Temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Temperature</b>
-</dd>
-  <dt class="optional">Sensor status<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Status</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Disconnected</li>
-  <li>2 - Short circuited</li>
-  <li>3 - Reverse polarity</li>
-  <li>4 - Unknown</li>
-</ul>
-</dd>
-  <dt class="optional">Sensor type<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/TemperatureType</b>
-<ul>
-  <li>0 - Battery</li>
-  <li>1 - Fridge</li>
-  <li>2 - Generic</li>
-</ul>
-</dd>
-  <dt class="optional">Humidity (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Humidity</b>
-</dd>
-  <dt class="optional">Pressure (kPa)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pressure</b>
-</dd>
-  <dt class="optional">Sensor battery voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/BatteryVoltage</b>
-</dd>
-  <dt class="optional">Acceleration X (g)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/AccelX</b>
-</dd>
-  <dt class="optional">Acceleration Y (g)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/AccelY</b>
-</dd>
-  <dt class="optional">Acceleration Z (g)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/AccelZ</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-inverter">
-<p>This node is for reading from the inverter.</p>
-<h3>inverter</h3>
-<dl class="message-properties">
-  <dt class="optional">Input voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Output voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/V</b>
-</dd>
-  <dt class="optional">Output current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/I</b>
-</dd>
-  <dt class="optional">Mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>2 - Inverter on</li>
-  <li>4 - Off</li>
-  <li>5 - Low Power/ECO</li>
-</ul>
-</dd>
-  <dt class="optional">Relay state<span class="property-type">enum</dt>
+  <dt class="optional">Relay on the Multi RS<span class="property-type">enum</dt>
   <dd>Dbus path: <b>/Relay/0/State</b>
 <ul>
   <li>0 - Open</li>
   <li>1 - Closed</li>
 </ul>
 </dd>
-  <dt class="optional">State<span class="property-type">enum</dt>
+  <dt class="optional">Battery State of Charge (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Soc</b>
+</dd>
+  <dt class="optional">Inverter/Charger state<span class="property-type">enum</dt>
   <dd>Dbus path: <b>/State</b>
 <ul>
   <li>0 - Off</li>
   <li>1 - Low Power</li>
   <li>2 - Fault</li>
+  <li>3 - Bulk</li>
+  <li>4 - Absorption</li>
+  <li>5 - Float</li>
+  <li>6 - Storage</li>
+  <li>7 - Equalize</li>
+  <li>8 - Passthru</li>
   <li>9 - Inverting</li>
+  <li>10 - Power assist</li>
+  <li>11 - Power supply</li>
+  <li>252 - Bulk protection</li>
 </ul>
+</dd>
+  <dt class="optional">Switch position<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>1 - Charger Only</li>
+  <li>2 - Inverter Only</li>
+  <li>3 - On</li>
+  <li>4 - Off</li>
+</ul>
+</dd>
+  <dt class="optional">PV power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Yield/Power</b>
+</dd>
+  <dt class="optional">User yield (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Yield/User</b>
 </dd>
 </dl>
 </script>
@@ -584,41 +2258,67 @@ Questions can also be asked on the Victron Energy community:
 <p>This node is for obtaining information from the PV inverter.</p>
 <h3>pvinverter</h3>
 <dl class="message-properties">
-  <dt class="optional">L1 Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Voltage</b>
+  <dt class="optional">Total energy (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Energy/Forward</b>
 </dd>
   <dt class="optional">L1 Current (A)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Ac/L1/Current</b>
 </dd>
-  <dt class="optional">L1 Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Power</b>
-</dd>
   <dt class="optional">L1 Energy (kWh)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Ac/L1/Energy/Forward</b>
 </dd>
-  <dt class="optional">L2 Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Voltage</b>
+  <dt class="optional">L1 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Power</b>
+</dd>
+  <dt class="optional">L1 Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L1/Voltage</b>
 </dd>
   <dt class="optional">L2 Current (A)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Ac/L2/Current</b>
 </dd>
-  <dt class="optional">L2 Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Power</b>
-</dd>
   <dt class="optional">L2 Energy (kWh)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Ac/L2/Energy/Forward</b>
 </dd>
-  <dt class="optional">L3 Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Voltage</b>
+  <dt class="optional">L2 Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Power</b>
+</dd>
+  <dt class="optional">L2 Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L2/Voltage</b>
 </dd>
   <dt class="optional">L3 Current (A)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Ac/L3/Current</b>
 </dd>
+  <dt class="optional">L3 Energy (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Energy/Forward</b>
+</dd>
   <dt class="optional">L3 Power (W)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Ac/L3/Power</b>
 </dd>
-  <dt class="optional">L3 Energy (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Energy/Forward</b>
+  <dt class="optional">L3 Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/L3/Voltage</b>
+</dd>
+  <dt class="optional">Maximum Power Capacity (kW)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/MaxPower</b>
+</dd>
+  <dt class="optional">Total Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Power</b>
+</dd>
+  <dt class="optional">Error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ErrorCode</b>
+<ul>
+  <li>0 - No Error</li>
+</ul>
+</dd>
+  <dt class="optional">Position<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Position</b>
+<ul>
+  <li>0 - AC input 1</li>
+  <li>1 - AC output</li>
+  <li>2 - AC input 2</li>
+</ul>
+</dd>
+  <dt class="optional">Serial<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/Serial</b>
 </dd>
   <dt class="optional">Status<span class="property-type">enum</dt>
   <dd>Dbus path: <b>/StatusCode</b>
@@ -636,1559 +2336,6 @@ Questions can also be asked on the Victron Energy community:
   <li>10 - Error</li>
   <li>11 - Running (MPPT)</li>
   <li>12 - Running (Throttled)</li>
-</ul>
-</dd>
-  <dt class="optional">Error<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/ErrorCode</b>
-<ul>
-  <li>0 - No Error</li>
-</ul>
-</dd>
-  <dt class="optional">Total energy (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Energy/Forward</b>
-</dd>
-  <dt class="optional">Total Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Power</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-accharger">
-<p>The AC charger can be read with this node.</p>
-<h3>charger</h3>
-<dl class="message-properties">
-  <dt class="optional">Output 1 - voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Output 1 - current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
-</dd>
-  <dt class="optional">Output 1 - temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
-</dd>
-  <dt class="optional">Output 2 - voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b>
-</dd>
-  <dt class="optional">Output 2 - current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/1/Current</b>
-</dd>
-  <dt class="optional">Battery 1 temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/1/Temperature</b>
-</dd>
-  <dt class="optional">Output 3 - voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/2/Voltage</b>
-</dd>
-  <dt class="optional">Output 3 - current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/2/Current</b>
-</dd>
-  <dt class="optional">Battery 2 temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/2/Temperature</b>
-</dd>
-  <dt class="optional">AC Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/L1/I</b>
-</dd>
-  <dt class="optional">AC Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/L1/P</b>
-</dd>
-  <dt class="optional">AC Current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/CurrentLimit</b>
-</dd>
-  <dt class="optional">Charger on/off<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>1 - On</li>
-  <li>4 - Off</li>
-</ul>
-</dd>
-  <dt class="optional">Charge state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/State</b>
-<ul>
-  <li>0 - Off</li>
-  <li>2 - Fault</li>
-  <li>3 - Bulk</li>
-  <li>4 - Absorption</li>
-  <li>5 - Float</li>
-  <li>6 - Storage</li>
-  <li>7 - Equalize</li>
-  <li>11 - Power supply mode</li>
-  <li>246 - Repeated absorption</li>
-  <li>247 - Equalize</li>
-  <li>248 - Battery safe</li>
-</ul>
-</dd>
-  <dt class="optional">Error<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/ErrorCode</b>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - Err 1: Battery temperature too high</li>
-  <li>2 - Err 2: Battery voltage too high</li>
-  <li>3 - Err 3: Battery temperature sensor miswired (+)</li>
-  <li>4 - Err 3: Battery temperature sensor miswired (-)</li>
-  <li>5 - Err 5: Battery temperature sensor disconnected</li>
-  <li>6 - Err 6: Battery voltage sense miswired (+)</li>
-  <li>7 - Err 7: Battery voltage sense miswired (-)</li>
-  <li>8 - Err 8: Battery voltage sense disconnected</li>
-  <li>9 - Err 9: Battery voltage wire losses too high</li>
-  <li>17 - Err 17: Charger temperature too high</li>
-  <li>18 - Err 18: Charger over-current</li>
-  <li>19 - Err 19: Charger current polarity reversed</li>
-  <li>20 - Err 20: Bulk time limit reached</li>
-  <li>22 - Err 22: Charger temperature sensor miswired</li>
-  <li>23 - Err 23: Charger temperature sensor disconnected</li>
-  <li>34 - Err 34: Input current too high</li>
-  <li>67 - Err 67: No BMS</li>
-</ul>
-</dd>
-  <dt class="optional">Relay on the charger<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Relay/0/State</b>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul>
-</dd>
-  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Number of charger outputs<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/NrOfOutputs</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-solarcharger">
-<p>Information from the Solar charger can be read with this node.</p>
-<h3>solarcharger</h3>
-<dl class="message-properties">
-  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
-</dd>
-  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
-</dd>
-  <dt class="optional">Charger on/off<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>1 - On</li>
-  <li>4 - Off</li>
-</ul>
-</dd>
-  <dt class="optional">Charge state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/State</b>
-<ul>
-  <li>0 - Off</li>
-  <li>2 - Fault</li>
-  <li>3 - Bulk</li>
-  <li>4 - Absorption</li>
-  <li>5 - Float</li>
-  <li>6 - Storage</li>
-  <li>7 - Equalize</li>
-  <li>245 - Off</li>
-  <li>247 - Equalize</li>
-  <li>252 - Ext. Control</li>
-</ul>
-</dd>
-  <dt class="optional">PV voltage<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/V</b>
-</dd>
-  <dt class="optional">Tracker 1 power<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/0/P</b>
-</dd>
-  <dt class="optional">Tracker 1 voltage<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/0/V</b>
-</dd>
-  <dt class="optional">Tracker 2 power<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/1/P</b>
-</dd>
-  <dt class="optional">Tracker 2 voltage<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/1/V</b>
-</dd>
-  <dt class="optional">Tracker 3 power<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/2/P</b>
-</dd>
-  <dt class="optional">Tracker 3 voltage<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/2/V</b>
-</dd>
-  <dt class="optional">Tracker 4 power<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/3/P</b>
-</dd>
-  <dt class="optional">Tracker 4 voltage<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Pv/3/V</b>
-</dd>
-  <dt class="optional">PV Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Yield/Power</b>
-</dd>
-  <dt class="optional">Relay on the charger<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Relay/0/State</b>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul>
-</dd>
-  <dt class="optional">Low batt. voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High batt. voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Error code<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/ErrorCode</b>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - #1 - Battery temperature too high</li>
-  <li>2 - #2 - Battery voltage too high</li>
-  <li>3 - #3 - Battery temperature sensor miswired (+)</li>
-  <li>4 - #4 - Battery temperature sensor miswired (-)</li>
-  <li>5 - #5 - Battery temperature sensor disconnected</li>
-  <li>6 - #6 - Battery voltage sense miswired (+)</li>
-  <li>7 - #7 - Battery voltage sense miswired (-)</li>
-  <li>8 - #8 - Battery voltage sense disconnected</li>
-  <li>9 - #9 - Battery voltage wire losses too high</li>
-  <li>10 - #10 - Battery voltage too low</li>
-  <li>11 - #11 - Battery ripple voltage on terminals too high</li>
-  <li>12 - #12 - Battery low state of charge</li>
-  <li>13 - #13 - Battery mid-point voltage issue</li>
-  <li>14 - #14 - Battery temperature too low</li>
-  <li>17 - #17 - Charger temperature too high</li>
-  <li>18 - #18 - Charger over-current</li>
-  <li>19 - #19 - Charger current polarity reversed</li>
-  <li>20 - #20 - Max Bulk-time exceeded</li>
-  <li>21 - #21 - Charger current sensor issue</li>
-  <li>22 - #22 - Temperature sensor miswired</li>
-  <li>23 - #23 - Charger temperature sensor disconnected</li>
-  <li>24 - #24 - Charger internal fan not detected</li>
-  <li>25 - #25 - Charger internal fan over-current</li>
-  <li>26 - #26 - Charger terminal overheated</li>
-  <li>27 - #27 - Charger short circuit</li>
-  <li>28 - #28 - Charger issue with power stage</li>
-  <li>29 - #29 - Over-charge protection</li>
-  <li>31 - #31 - Input voltage out of range</li>
-  <li>32 - #32 - Input voltage too low</li>
-  <li>33 - #33 - Input voltage too high</li>
-  <li>34 - #34 - PV over current</li>
-  <li>35 - #35 - Input excessive power</li>
-  <li>36 - #36 - Input polarity issue</li>
-  <li>37 - #37 - Input voltage absent (mains removed, fuse blown?)</li>
-  <li>38 - #38 - Input shutdown due to battery over-voltage</li>
-  <li>39 - #39 - Input shutdown due to battery over-voltage</li>
-  <li>40 - #40 - Internal failure (PV Input failed to shutdown)</li>
-  <li>41 - #41 - Inverter shutdown (panel isolation resistance too low)</li>
-  <li>42 - #42 - Inverter shutdown (ground current too high: >30mA)</li>
-  <li>43 - #43 - Inverter shutdown (voltage over ground relay too high)</li>
-  <li>50 - #50 - Inverter overload (iit protection)</li>
-  <li>51 - #51 - Inverter temperature too high</li>
-  <li>52 - #52 - Inverter excessive current</li>
-  <li>53 - #53 - Inverter dc level (internal dc rail voltage)</li>
-  <li>54 - #54 - Inverter ac level (output voltage not ok)</li>
-  <li>55 - #55 - Inverter dc fail (dc on output)</li>
-  <li>56 - #56 - Inverter ac fail (shape wrong)*/</li>
-  <li>57 - #57 - Inverter ac on output (inverter only)</li>
-  <li>58 - #58 - Inverter bridge fault (hardware signal)</li>
-  <li>59 - #59 - ACIN1 relay test fault</li>
-  <li>60 - #60 - ACIN2 relay test fault</li>
-  <li>65 - #65 - Device disappeared during parallel operation (broken cable?)</li>
-  <li>66 - #66 - Incompatible device encountered for parallel operation (e.g. old firmware/different settings)</li>
-  <li>67 - #67 - No BMS</li>
-  <li>68 - #68 - Network misconfigured</li>
-  <li>113 - #113 - Non-volatile storage write error</li>
-  <li>114 - #114 - CPU temperature to high</li>
-  <li>115 - #115 - CAN/SCI communication lost (when critical)</li>
-  <li>116 - #116 - Calibration data lost</li>
-  <li>117 - #117 - Incompatible firmware encountered</li>
-  <li>118 - #118 - Incompatible hardware encountered</li>
-  <li>119 - #119 - Settings data lost</li>
-  <li>120 - #120 - Reference voltage failure</li>
-  <li>121 - #121 - Tester fail</li>
-  <li>122 - #122 - Non-volatile history data invalid/corrupted</li>
-  <li>200 - #200 - Internal error</li>
-  <li>201 - #201 - Internal error</li>
-  <li>203 - #203 - Internal error</li>
-  <li>205 - #205 - Internal error</li>
-  <li>212 - #212 - Internal error</li>
-  <li>215 - #215 - Internal error</li>
-</ul>
-</dd>
-  <dt class="optional">Load state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Load/State</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - On</li>
-</ul>
-</dd>
-  <dt class="optional">Load current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Load/I</b>
-</dd>
-  <dt class="optional">Yield since reset (kWh)<span class="property-type">string</dt>
-  <dd>Dbus path: <b>/Yield/User</b>
-</dd>
-  <dt class="optional">Yield since last update (kWh)<span class="property-type">string</dt>
-  <dd>Dbus path: <b>/Yield/System</b>
-</dd>
-  <dt class="optional">MPP operation mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/MppOperationMode</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - Voltage or current limited</li>
-  <li>2 - MPPT Tracker active</li>
-  <li>255 - Not available</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-battery">
-<p>This node allows for monitoring the state of the battery.</p>
-<h3>battery</h3>
-<dl class="message-properties">
-  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b>
-</dd>
-  <dt class="optional">Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
-</dd>
-  <dt class="optional">Consumed Amphours (Ah)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/ConsumedAmphours</b>
-</dd>
-  <dt class="optional">State of charge (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Soc</b>
-</dd>
-  <dt class="optional">Time to go (h)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/TimeToGo</b>
-</dd>
-  <dt class="optional">Relay status<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Relay/0/State</b>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul>
-</dd>
-  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
-</dd>
-  <dt class="optional">Mid-point voltage of the battery bank (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/MidVoltage</b>
-</dd>
-  <dt class="optional">Mid-point deviation of the battery bank (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/MidVoltageDeviation</b>
-</dd>
-  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low starter-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High starter-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low state-of-charge alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowSoc</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low battery temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High battery temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Mid-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/MidVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Fuse blown alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/FuseBlown</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High internal-temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighInternalTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">State of health (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Soh</b>
-</dd>
-  <dt class="optional">CVL - Charge Voltage Limit (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Info/MaxChargeVoltage</b>
-</dd>
-  <dt class="optional">DVL - Discharge Voltage Limit (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Info/MaxDischargeVoltage</b>
-</dd>
-  <dt class="optional">CCL - Charge Current Limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Info/MaxChargeCurrent</b>
-</dd>
-  <dt class="optional">DCL - Discharge Current Limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Info/MaxDischargeCurrent</b>
-</dd>
-  <dt class="optional">Cell Imbalance alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/CellImbalance</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High charge current alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighChargeCurrent</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High discharge current alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighDischargeCurrent</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Internal error alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/InternalFailure</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High charge temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighChargeTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low charge temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowChargeTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Power</b>
-</dd>
-  <dt class="optional">ATC (Allow to Charge)<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Io/AllowToCharge</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">ATD (Allow to Discharge)<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Io/AllowToDischarge</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-gridmeter">
-<p>This node gives allows for monitoring the grid. See also <a href="https://www.victronenergy.com/accessories/energy-meter">energy meters</a> accessoires.</p>
-<h3>grid</h3>
-<dl class="message-properties">
-  <dt class="optional">Total Forward Energy (bought) (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Energy/Forward</b>
-</dd>
-  <dt class="optional">Total Reverse Energy (sold) (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Energy/Reverse</b>
-</dd>
-  <dt class="optional">Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Power</b>
-</dd>
-  <dt class="optional">L1 Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Current</b>
-</dd>
-  <dt class="optional">L1 Forward energy (bought) (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Energy/Forward</b>
-</dd>
-  <dt class="optional">L1 Reverse energy (sold) (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Energy/Reverse</b>
-</dd>
-  <dt class="optional">L1 Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Power</b>
-</dd>
-  <dt class="optional">L1 Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L1/Voltage</b>
-</dd>
-  <dt class="optional">L2 Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Current</b>
-</dd>
-  <dt class="optional">L2 Forward energy (bought) (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Energy/Forward</b>
-</dd>
-  <dt class="optional">L2 Reverse energy (sold) (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Energy/Reverse</b>
-</dd>
-  <dt class="optional">L2 Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Power</b>
-</dd>
-  <dt class="optional">L2 Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L2/Voltage</b>
-</dd>
-  <dt class="optional">L2 Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Current</b>
-</dd>
-  <dt class="optional">L3 Forward energy (bought) (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Energy/Forward</b>
-</dd>
-  <dt class="optional">L3 Reverse energy (sold) (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Energy/Reverse</b>
-</dd>
-  <dt class="optional">L3 Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Power</b>
-</dd>
-  <dt class="optional">L3 Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/L3/Voltage</b>
-</dd>
-  <dt class="optional">Device type<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/DeviceType</b>
-<ul>
-</ul>
-</dd>
-  <dt class="optional">Error code<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/ErrorCode</b>
-<ul>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-vebus">
-<p>Information from VE.Bus connected devices can be obtained with this node.</p>
-<h3>vebus</h3>
-<dl class="message-properties">
-  <dt class="optional">Input voltage phase 1 (VAC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L1/V</b>
-</dd>
-  <dt class="optional">Input voltage phase 2 (VAC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L2/V</b>
-</dd>
-  <dt class="optional">Input voltage phase 3 (VAC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L3/V</b>
-</dd>
-  <dt class="optional">Input current phase 1 (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L1/I</b>
-</dd>
-  <dt class="optional">Input current phase 2 (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L2/I</b>
-</dd>
-  <dt class="optional">Input current phase 3 (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L3/I</b>
-</dd>
-  <dt class="optional">Input frequency 1 (Hz)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L1/F</b>
-</dd>
-  <dt class="optional">Input frequency 2 (Hz)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L2/F</b>
-</dd>
-  <dt class="optional">Input frequency 3 (Hz)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L3/F</b>
-</dd>
-  <dt class="optional">Input power 1 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L1/P</b>
-</dd>
-  <dt class="optional">Input power 2 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L2/P</b>
-</dd>
-  <dt class="optional">Input power 3 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/L3/P</b>
-</dd>
-  <dt class="optional">Input 1 current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/CurrentLimit</b>
-</dd>
-  <dt class="optional">Input 1 current limit is adjustable<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Ac/In/1/CurrentLimitIsAdjustable</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">Input 2 current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/2/CurrentLimit</b>
-</dd>
-  <dt class="optional">Input 2 current limit is adjustable<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Ac/In/2/CurrentLimitIsAdjustable</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">Output voltage phase 1 (VAC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/V</b>
-</dd>
-  <dt class="optional">Output voltage phase 2 (VAC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L2/V</b>
-</dd>
-  <dt class="optional">Output voltage phase 3 (VAC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L3/V</b>
-</dd>
-  <dt class="optional">Output current phase 1 (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/I</b>
-</dd>
-  <dt class="optional">Output current phase 2 (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L2/I</b>
-</dd>
-  <dt class="optional">Output current phase 3 (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L3/I</b>
-</dd>
-  <dt class="optional">Output frequency (Hz)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/F</b>
-</dd>
-  <dt class="optional">Output power 1 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L1/P</b>
-</dd>
-  <dt class="optional">Output power 2 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L2/P</b>
-</dd>
-  <dt class="optional">Output power 3 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Out/L3/P</b>
-</dd>
-  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
-</dd>
-  <dt class="optional">Temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
-</dd>
-  <dt class="optional">Phase count<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/NumberOfPhases</b>
-</dd>
-  <dt class="optional">Active input<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/ActiveInput</b>
-<ul>
-  <li>0 - AC Input 1</li>
-  <li>1 - AC Input 2</li>
-  <li>240 - Disconnected</li>
-</ul>
-</dd>
-  <dt class="optional">VE.Bus state of charge (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Soc</b>
-</dd>
-  <dt class="optional">VE.Bus state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/State</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - Low Power</li>
-  <li>2 - Fault</li>
-  <li>3 - Bulk</li>
-  <li>4 - Absorption</li>
-  <li>5 - Float</li>
-  <li>6 - Storage</li>
-  <li>7 - Equalize</li>
-  <li>8 - Passthru</li>
-  <li>9 - Inverting</li>
-  <li>10 - Power assist</li>
-  <li>11 - Power supply</li>
-  <li>252 - Bulk protect</li>
-</ul>
-</dd>
-  <dt class="optional">VE.Bus Error<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/VebusError</b>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - VE.Bus Error 1: Device is switched off because one of the other phases in the system has switched off</li>
-  <li>2 - VE.Bus Error 2: New and old types MK2 are mixed in the system</li>
-  <li>3 - VE.Bus Error 3: Not all, or more than, the expected devices were found in the system</li>
-  <li>4 - VE.Bus Error 4: No other device whatsoever detected</li>
-  <li>5 - VE.Bus Error 5: Overvoltage on AC-out</li>
-  <li>6 - VE.Bus Error 6: Error in DDC Program</li>
-  <li>7 - VE.Bus Error 7:  BMS connected, which requires an Assistant, but no assistant found</li>
-  <li>8 - VE.Bus Error 8: Ground relay test failed</li>
-  <li>9 - VE.Bus Error 9</li>
-  <li>10 - VE.Bus Error 10: System time synchronisation problem occurred</li>
-  <li>11 - VE.Bus Error 11: Relay test fault</li>
-  <li>12 - VE.Bus Error 12</li>
-  <li>13 - VE.Bus Error 13</li>
-  <li>14 - VE.Bus Error 14: Device cannot transmit data</li>
-  <li>15 - VE.Bus Error 15</li>
-  <li>16 - VE.Bus Error 16: Awaiting configuration or dongle missing</li>
-  <li>17 - VE.Bus Error 17: Phase master missing</li>
-  <li>18 - VE.Bus Error 18: AC Overvoltage on the output of a slave has occurred while already switched off</li>
-  <li>19 - VE.Bus Error 19</li>
-  <li>20 - VE.Bus Error 20</li>
-  <li>21 - VE.Bus Error 21</li>
-  <li>22 - VE.Bus Error 22: This device cannot function as slave</li>
-  <li>23 - VE.Bus Error 23</li>
-  <li>24 - VE.Bus Error 24: Switch-over system protection initiated</li>
-  <li>25 - VE.Bus Error 25: Firmware incompatibility. The firmware of one of the connected device is not sufficiently up to date to operate in conjunction with this device</li>
-  <li>26 - VE.Bus Error 26: Internal error</li>
-  <li>27 - VE.Bus Error 27</li>
-  <li>28 - VE.Bus Error 28</li>
-  <li>29 - VE.Bus Error 29</li>
-  <li>30 - VE.Bus Error 30</li>
-  <li>31 - VE.Bus Error 31</li>
-  <li>32 - VE.Bus Error 32</li>
-</ul>
-</dd>
-  <dt class="optional">Grid lost alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/GridLost</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Phase Rotation<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/PhaseRotation</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-</ul>
-</dd>
-  <dt class="optional">Temperature<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low battery<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowBattery</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Overload<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/Overload</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Switch Position<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>1 - Charger Only</li>
-  <li>2 - Inverter Only</li>
-  <li>3 - On</li>
-  <li>4 - Off</li>
-</ul>
-</dd>
-  <dt class="optional">Mode is adjustable<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/ModeIsAdjustable</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">Energy AcIn1 to Inverter (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/AcIn1ToInverter</b>
-</dd>
-  <dt class="optional">Energy ACIn2 to Inverter (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/AcIn2ToInverter</b>
-</dd>
-  <dt class="optional">Energy ACIn1 to AcOut (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/AcIn1ToAcOut</b>
-</dd>
-  <dt class="optional">Energy ACIn2 to AcOut (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/AcIn2ToAcOut</b>
-</dd>
-  <dt class="optional">Energy Inverter to AcIn1 (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/InverterToAcIn1</b>
-</dd>
-  <dt class="optional">Energy Inverter to AcIn2 (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/InverterToAcIn2</b>
-</dd>
-  <dt class="optional">Energy AcOut to AcIn1 (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/AcOutToAcIn1</b>
-</dd>
-  <dt class="optional">Energy AcOut to AcIn2 (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/AcOutToAcIn2</b>
-</dd>
-  <dt class="optional">Inverter To AcOut (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/InverterToAcOut</b>
-</dd>
-  <dt class="optional">AcOut to Inverter (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Energy/OutToInverter</b>
-</dd>
-  <dt class="optional">BMS allows battery to be charged<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Bms/AllowToCharge</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">BMS allows battery to be discharged<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Bms/AllowToDischarge</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-gps">
-<p>GPS information can be obtained with this node. For an example usage see the <a href="https://github.com/victronenergy/node-red-contrib-victron/wiki/Example-Flows#location-based-scheduling">location based scheduling</a> example.</p>
-<h3>gps</h3>
-<dl class="message-properties">
-  <dt class="optional">Altitude (m)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Altitude</b>
-</dd>
-  <dt class="optional">Course (Deg)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Course</b>
-</dd>
-  <dt class="optional">Fix<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Fix</b>
-</dd>
-  <dt class="optional">Number of satellites<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/NrOfSatellites</b>
-</dd>
-  <dt class="optional">Latitude (LAT)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Position/Latitude</b>
-</dd>
-  <dt class="optional">Longitude (LNG)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Position/Longitude</b>
-</dd>
-  <dt class="optional">Speed (m/s)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Speed</b>
-</dd>
-  <dt class="optional">UTC Timestamp<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/UtcTimestamp</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-ess">
-<p>This node gives information on the energy storage system (ESS).</p>
-<h3>vebus</h3>
-<dl class="message-properties">
-  <dt class="optional">Disable feed-in<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Hub4/DisableFeedIn</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">Disable charge<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Hub4/DisableCharge</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">AC Power L1 setpoint (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L1/AcPowerSetpoint</b>
-</dd>
-  <dt class="optional">AC Power L2 setpoint (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L2/AcPowerSetpoint</b>
-</dd>
-  <dt class="optional">AC Power L3 setpoint (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L3/AcPowerSetpoint</b>
-</dd>
-</dl>
-<h3>settings</h3>
-<dl class="message-properties">
-  <dt class="optional">ESS mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/Hub4Mode</b>
-<ul>
-  <li>1 - Optimized mode or 'keep batteries charged' and phase compensation enabled</li>
-  <li>2 - Optimized mode or 'keep batteries charged' and phase compensation disabled</li>
-  <li>3 - External control</li>
-</ul>
-</dd>
-  <dt class="optional">Grid set-point (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/AcPowerSetPoint</b>
-</dd>
-  <dt class="optional">Minimum Discharge SOC (%)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/MinimumSocLimit</b>
-</dd>
-  <dt class="optional">Active SOC limit (%)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/SocLimit</b>
-</dd>
-  <dt class="optional">ESS state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/State</b>
-<ul>
-  <li>1 - BatteryLife enabled (GUI controlled)</li>
-  <li>2 - Optimized Mode /w BatteryLife: self consumption</li>
-  <li>3 - Optimized Mode /w BatteryLife: self consumption, SoC exceeds 85%</li>
-  <li>4 - Optimized Mode /w BatteryLife: self consumption, SoC at 100%</li>
-  <li>5 - Optimized Mode /w BatteryLife: SoC below dynamic SoC limit</li>
-  <li>6 - Optimized Mode /w BatteryLife: SoC has been below SoC limit for more than 24 hours. Charging the battery (5A)</li>
-  <li>7 - Optimized Mode /w BatteryLife: Inverter/Charger is in sustain mode</li>
-  <li>8 - Optimized Mode /w BatteryLife: recharging, SoC dropped by 5% or more below the minimum SoC</li>
-  <li>9 - 'Keep batteries charged' mode is enabled</li>
-  <li>10 - Optimized mode w/o BatteryLife: self consumption, SoC at or above minimum SoC</li>
-  <li>11 - Optimized mode w/o BatteryLife: self consumption, SoC is below minimum SoC</li>
-  <li>12 - Optimized mode w/o BatteryLife: recharging, SoC dropped by 5% or more below minimum SoC</li>
-</ul>
-</dd>
-  <dt class="optional">ESS mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/Hub4Mode</b>
-<ul>
-  <li>1 - Optimized mode or 'keep batteries charged' and phase compensation enabled</li>
-  <li>2 - Optimized mode or 'keep batteries charged' and phase compensation disabled</li>
-  <li>3 - External control</li>
-</ul>
-</dd>
-  <dt class="optional">Max inverter power (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/MaxDischargePower</b>
-</dd>
-  <dt class="optional">Feed-in excess solar charger power<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/OvervoltageFeedIn</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">PV Inverter zero feed-in (on/off)<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/PreventFeedback</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">Charge current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeCurrent</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-meteo">
-<p>The <b>input-meteo</b> node allows for Solar Irradiance, Temperature and Wind Speed Sensors measuring.</p><p>More information and supported devices can be found in the <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-d4b7dfe9-4ee0-53bc-8959-c567ed63cebb">manual</a>.</p>
-<h3>meteo</h3>
-<dl class="message-properties">
-  <dt class="optional">Solar Irradiance (W/m^2)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Irradiance</b>
-</dd>
-  <dt class="optional">Wind speed (m/s)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/WindSpeed</b>
-</dd>
-  <dt class="optional">Sensor cell temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/CellTemperature</b>
-</dd>
-  <dt class="optional">External temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/ExternalTemperature</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-system">
-<p>This input node takes is for retrieving information from the <tt>com.victronenergy.system</tt> dbus path.</p>
-<h3>system</h3>
-<dl class="message-properties">
-  <dt class="optional">AC-Input<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/Source</b>
-<ul>
-  <li>0 - Not available</li>
-  <li>1 - Grid</li>
-  <li>2 - Generator</li>
-  <li>3 - Shore</li>
-  <li>240 - Inverting</li>
-</ul>
-</dd>
-  <dt class="optional">AC Consumption on Input L1<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ConsumptionOnInput/L1/Power</b>
-</dd>
-  <dt class="optional">AC Consumption on Input L2<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ConsumptionOnInput/L2/Power</b>
-</dd>
-  <dt class="optional">AC Consumption on Input L3<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ConsumptionOnInput/L3/Power</b>
-</dd>
-  <dt class="optional">AC Consumption on Input Number Of Phases<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Ac/ConsumptionOnInput/NumberOfPhases</b>
-</dd>
-  <dt class="optional">AC Consumption on Output L1<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ConsumptionOnOutput/L1/Power</b>
-</dd>
-  <dt class="optional">AC Consumption on Output L2<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ConsumptionOnOutput/L2/Power</b>
-</dd>
-  <dt class="optional">AC Consumption on Output L3<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/ConsumptionOnOutput/L3/Power</b>
-</dd>
-  <dt class="optional">AC Consumption on Output Number Of Phases<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Ac/ConsumptionOnOutput/NumberOfPhases</b>
-</dd>
-  <dt class="optional">Genset L1 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Genset/L1/Power</b>
-</dd>
-  <dt class="optional">Genset L2 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Genset/L2/Power</b>
-</dd>
-  <dt class="optional">Genset L3 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Genset/L3/Power</b>
-</dd>
-  <dt class="optional">Genset Number Of Phases<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Ac/Genset/NumberOfPhases</b>
-</dd>
-  <dt class="optional">Genset Device Type<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Genset/DeviceType</b>
-</dd>
-  <dt class="optional">Grid L1 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Grid/L1/Power</b>
-</dd>
-  <dt class="optional">Grid L2 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Grid/L2/Power</b>
-</dd>
-  <dt class="optional">Grid L3 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Grid/L3/Power</b>
-</dd>
-  <dt class="optional">Grid Number Of Phases<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Ac/Grid/NumberOfPhases</b>
-</dd>
-  <dt class="optional">Grid Device Type<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/Grid/DeviceType</b>
-</dd>
-  <dt class="optional">PV Power AC-tied on Generator L1<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnGenset/L1/Power</b>
-</dd>
-  <dt class="optional">PV Power AC-tied on Generator L2<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnGenset/L2/Power</b>
-</dd>
-  <dt class="optional">PV Power AC-tied on Generator L3<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnGenset/L3/Power</b>
-</dd>
-  <dt class="optional">PV Power AC-tied on Generator Number Of Phases<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Ac/PvOnGenset/NumberOfPhases</b>
-</dd>
-  <dt class="optional">PV - AC-coupled on input L1 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnGrid/L1/Power</b>
-</dd>
-  <dt class="optional">PV - AC-coupled on input L2 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnGrid/L2/Power</b>
-</dd>
-  <dt class="optional">PV - AC-coupled on input L3 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnGrid/L3/Power</b>
-</dd>
-  <dt class="optional">PV - AC-coupled on input Number Of Phases<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Ac/PvOnGrid/NumberOfPhases</b>
-</dd>
-  <dt class="optional">PV - AC-coupled on output L1 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnOutput/L1/Power</b>
-</dd>
-  <dt class="optional">PV - AC-coupled on output L2 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnOutput/L2/Power</b>
-</dd>
-  <dt class="optional">PV - AC-coupled on output L3 (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/PvOnOutput/L3/Power</b>
-</dd>
-  <dt class="optional">PV - AC-coupled on output Number Of Phases<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Ac/PvOnOutput/NumberOfPhases</b>
-</dd>
-  <dt class="optional">Battery Consumed Amphours (Ah)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Battery/ConsumedAmphours</b>
-</dd>
-  <dt class="optional">Battery current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Battery/Current</b>
-</dd>
-  <dt class="optional">Battery Power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Battery/Power</b>
-</dd>
-  <dt class="optional">Battery State of Charge (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Battery/Soc</b>
-</dd>
-  <dt class="optional">Battery state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Dc/Battery/State</b>
-<ul>
-  <li>0 - idle</li>
-  <li>1 - charging</li>
-  <li>2 - discharging</li>
-</ul>
-</dd>
-  <dt class="optional">Battery Time to Go (h)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Battery/TimeToGo</b>
-</dd>
-  <dt class="optional">Battery voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Battery/Voltage</b>
-</dd>
-  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Battery/Temperature</b>
-</dd>
-  <dt class="optional">AC-Chargers - power (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Dc/Charger/Power</b>
-</dd>
-  <dt class="optional">MPPTs - power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Pv/Power</b>
-</dd>
-  <dt class="optional">MPPTs - current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Pv/Current</b>
-</dd>
-  <dt class="optional">DC System (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/System/Power</b>
-</dd>
-  <dt class="optional">VE.Bus charge current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Vebus/Current</b>
-</dd>
-  <dt class="optional">VE.Bus charge power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/Vebus/Power</b>
-</dd>
-  <dt class="optional">Buzzer State<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Buzzer/State</b>
-</dd>
-  <dt class="optional">Time grid (s)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Timers/TimeOnGrid</b>
-</dd>
-  <dt class="optional">Time generator (s)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Timers/TimeOnGenerator</b>
-</dd>
-  <dt class="optional">Time inverting (s)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Timers/TimeOnInverter</b>
-</dd>
-  <dt class="optional">Time off (s)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Timers/TimeOff</b>
-</dd>
-  <dt class="optional">System type<span class="property-type">string</dt>
-  <dd>Dbus path: <b>/SystemType</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-dcsource">
-<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is a source.</p>
-<h3>dcsource</h3>
-<dl class="message-properties">
-  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b>
-</dd>
-  <dt class="optional">Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
-</dd>
-  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Power</b>
-</dd>
-  <dt class="optional">Relay status<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Relay/0/State</b>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul>
-</dd>
-  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
-</dd>
-  <dt class="optional">Mid-point voltage of the battery bank (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/MidVoltage</b>
-</dd>
-  <dt class="optional">Mid-point deviation of the battery bank (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/MidVoltageDeviation</b>
-</dd>
-  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low starter-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High starter-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low battery temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High battery temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Mid-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/MidVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-dcload">
-<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is a load.</p>
-<h3>dcload</h3>
-<dl class="message-properties">
-  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b>
-</dd>
-  <dt class="optional">Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
-</dd>
-  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Power</b>
-</dd>
-  <dt class="optional">Relay status<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Relay/0/State</b>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul>
-</dd>
-  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
-</dd>
-  <dt class="optional">Mid-point voltage of the battery bank (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/MidVoltage</b>
-</dd>
-  <dt class="optional">Mid-point deviation of the battery bank (%)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/MidVoltageDeviation</b>
-</dd>
-  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low starter-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High starter-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low battery temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High battery temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Mid-voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/MidVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-alternator">
-<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is Alternator or an alternator controller which is interfaced to the Venus OS.</p>
-<h3>alternator</h3>
-<dl class="message-properties">
-  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
-</dd>
-  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Power</b>
-</dd>
-  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
-</dd>
-  <dt class="optional">Auxiliary voltage (V DC)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b>
-</dd>
-  <dt class="optional">Alternator RPM<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/AlterntorRPM</b>
-</dd>
-  <dt class="optional">Engine RPM<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/EngineRPM</b>
-</dd>
-  <dt class="optional">Alternator Field Drive %<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/FieldDrive</b>
-</dd>
-  <dt class="optional">Alterntor Charging Status<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/AlternatorStatus</b>
-<ul>
-  <li>0 - Not Charging</li>
-  <li>1 - Charing</li>
-  <li>2 - Error</li>
-  <li>3 - Not Available</li>
-</ul>
-</dd>
-  <dt class="optional">Charger Status<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/ChargeEnable</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - On</li>
-</ul>
-</dd>
-  <dt class="optional">Charger Mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>0 - Standalone</li>
-  <li>1 - Master</li>
-  <li>2 - Slave</li>
-</ul>
-</dd>
-  <dt class="optional">Charger State<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/State</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - Bulk</li>
-  <li>2 - Absorbtion</li>
-  <li>5 - Float</li>
-  <li>7 - Ext. Control</li>
-  <li>8 - Disabled</li>
-  <li>9 - Fault</li>
-</ul>
-</dd>
-  <dt class="optional">Total energy produced (kWh)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/History/EnergyOut</b>
-</dd>
-  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Charger Error<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/ChargerError</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Charger Overload<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/Overload</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Charger high temperature<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/Temperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Alternator Error<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/AlternatorError</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low auxiliary voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowStarterVoltage</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High auxiliary voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighStarterVoltage</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Low temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowTemperature</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">High temperature alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
-<ul>
-  <li>0 - Ok</li>
-  <li>1 - Warning</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-dcdc">
-<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is DC/DC, or a DC/DC controller which is interfaced to the Venus OS.</p>
-<h3>dcdc</h3>
-<dl class="message-properties">
-  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b>
-</dd>
-  <dt class="optional">Current (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b>
-</dd>
-  <dt class="optional">Battery power (W)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Power</b>
-</dd>
-  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Dc/0/Temperature</b>
-</dd>
-  <dt class="optional">Charger Status<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/ChargeEnable</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - On</li>
-</ul>
-</dd>
-  <dt class="optional">Charger Mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>0 - Standalone</li>
-  <li>1 - Master</li>
-  <li>2 - Slave</li>
-</ul>
-</dd>
-  <dt class="optional">Charger State<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/State</b>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - Bulk</li>
-  <li>2 - Absorbtion</li>
-  <li>5 - Float</li>
-  <li>7 - Ext. Control</li>
-  <li>8 - Disabled</li>
-  <li>9 - Fault</li>
-</ul>
-</dd>
-  <dt class="optional">Low voltage alarm<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Charger Error<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/ChargerError</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Charger Overload<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/Overload</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
-</ul>
-</dd>
-  <dt class="optional">Charger high temperature<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Alarms/Temperature</b>
-<ul>
-  <li>0 - No alarm</li>
-  <li>2 - Alarm</li>
 </ul>
 </dd>
 </dl>
@@ -2269,6 +2416,1169 @@ Questions can also be asked on the Victron Energy community:
 </dl>
 </script>
 
+<script type="text/x-red" data-help-name="victron-input-solarcharger">
+<p>Information from the Solar charger can be read with this node.</p>
+<h3>solarcharger</h3>
+<dl class="message-properties">
+  <dt class="optional">Alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Alarm</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">High batt. voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low batt. voltage alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowVoltage</b>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Equalization pending<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Equalization/Pending</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+  <li>2 - Error</li>
+  <li>3 - Unavailable- Unknown</li>
+</ul>
+</dd>
+  <dt class="optional">Equalization time remaining (seconds)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Equalization/TimeRemaining</b>
+</dd>
+  <dt class="optional">Error code<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ErrorCode</b>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - #1 - Battery temperature too high</li>
+  <li>2 - #2 - Battery voltage too high</li>
+  <li>3 - #3 - Battery temperature sensor miswired (+)</li>
+  <li>4 - #4 - Battery temperature sensor miswired (-)</li>
+  <li>5 - #5 - Battery temperature sensor disconnected</li>
+  <li>6 - #6 - Battery voltage sense miswired (+)</li>
+  <li>7 - #7 - Battery voltage sense miswired (-)</li>
+  <li>8 - #8 - Battery voltage sense disconnected</li>
+  <li>9 - #9 - Battery voltage wire losses too high</li>
+  <li>10 - #10 - Battery voltage too low</li>
+  <li>11 - #11 - Battery ripple voltage on terminals too high</li>
+  <li>12 - #12 - Battery low state of charge</li>
+  <li>13 - #13 - Battery mid-point voltage issue</li>
+  <li>14 - #14 - Battery temperature too low</li>
+  <li>17 - #17 - Charger temperature too high</li>
+  <li>18 - #18 - Charger over-current</li>
+  <li>19 - #19 - Charger current polarity reversed</li>
+  <li>20 - #20 - Max Bulk-time exceeded</li>
+  <li>21 - #21 - Charger current sensor issue</li>
+  <li>22 - #22 - Temperature sensor miswired</li>
+  <li>23 - #23 - Charger temperature sensor disconnected</li>
+  <li>24 - #24 - Charger internal fan not detected</li>
+  <li>25 - #25 - Charger internal fan over-current</li>
+  <li>26 - #26 - Charger terminal overheated</li>
+  <li>27 - #27 - Charger short circuit</li>
+  <li>28 - #28 - Charger issue with power stage</li>
+  <li>29 - #29 - Over-charge protection</li>
+  <li>31 - #31 - Input voltage out of range</li>
+  <li>32 - #32 - Input voltage too low</li>
+  <li>33 - #33 - Input voltage too high</li>
+  <li>34 - #34 - PV over current</li>
+  <li>35 - #35 - Input excessive power</li>
+  <li>36 - #36 - Input polarity issue</li>
+  <li>37 - #37 - Input voltage absent (mains removed, fuse blown?)</li>
+  <li>38 - #38 - Input shutdown due to battery over-voltage</li>
+  <li>39 - #39 - Input shutdown due to battery over-voltage</li>
+  <li>40 - #40 - Internal failure (PV Input failed to shutdown)</li>
+  <li>41 - #41 - Inverter shutdown (panel isolation resistance too low)</li>
+  <li>42 - #42 - Inverter shutdown (ground current too high: >30mA)</li>
+  <li>43 - #43 - Inverter shutdown (voltage over ground relay too high)</li>
+  <li>50 - #50 - Inverter overload (iit protection)</li>
+  <li>51 - #51 - Inverter temperature too high</li>
+  <li>52 - #52 - Inverter excessive current</li>
+  <li>53 - #53 - Inverter dc level (internal dc rail voltage)</li>
+  <li>54 - #54 - Inverter ac level (output voltage not ok)</li>
+  <li>55 - #55 - Inverter dc fail (dc on output)</li>
+  <li>56 - #56 - Inverter ac fail (shape wrong)*/</li>
+  <li>57 - #57 - Inverter ac on output (inverter only)</li>
+  <li>58 - #58 - Inverter bridge fault (hardware signal)</li>
+  <li>59 - #59 - ACIN1 relay test fault</li>
+  <li>60 - #60 - ACIN2 relay test fault</li>
+  <li>65 - #65 - Device disappeared during parallel operation (broken cable?)</li>
+  <li>66 - #66 - Incompatible device encountered for parallel operation (e.g. old firmware/different settings)</li>
+  <li>67 - #67 - No BMS</li>
+  <li>68 - #68 - Network misconfigured</li>
+  <li>113 - #113 - Non-volatile storage write error</li>
+  <li>114 - #114 - CPU temperature to high</li>
+  <li>115 - #115 - CAN/SCI communication lost (when critical)</li>
+  <li>116 - #116 - Calibration data lost</li>
+  <li>117 - #117 - Incompatible firmware encountered</li>
+  <li>118 - #118 - Incompatible hardware encountered</li>
+  <li>119 - #119 - Settings data lost</li>
+  <li>120 - #120 - Reference voltage failure</li>
+  <li>121 - #121 - Tester fail</li>
+  <li>122 - #122 - Non-volatile history data invalid/corrupted</li>
+  <li>200 - #200 - Internal error</li>
+  <li>201 - #201 - Internal error</li>
+  <li>203 - #203 - Internal error</li>
+  <li>205 - #205 - Internal error</li>
+  <li>212 - #212 - Internal error</li>
+  <li>215 - #215 - Internal error</li>
+</ul>
+</dd>
+  <dt class="optional">Maximum charge power today (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/MaxPower</b>
+</dd>
+  <dt class="optional">Maximum charge power today for tracker 0 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/0/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for tracker 0 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/0/Yield</b>
+</dd>
+  <dt class="optional">Maximum charge power today for tracker 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/1/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for tracker 1 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/1/Yield</b>
+</dd>
+  <dt class="optional">Maximum charge power today for tracker 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/2/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for tracker 2 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/2/Yield</b>
+</dd>
+  <dt class="optional">Maximum charge power today for tracker 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/3/MaxPower</b>
+</dd>
+  <dt class="optional">Yield today for tracker 3 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Pv/3/Yield</b>
+</dd>
+  <dt class="optional">Yield today (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/0/Yield</b>
+</dd>
+  <dt class="optional">Maximum charge power yesterday (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/MaxPower</b>
+</dd>
+  <dt class="optional">Maximum charge power yesterday tracker 0 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/0/MaxPower</b>
+</dd>
+  <dt class="optional">Yield yesterday for tracker 0 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/0/Yield</b>
+</dd>
+  <dt class="optional">Maximum charge power yesterday tracker 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/1/MaxPower</b>
+</dd>
+  <dt class="optional">Yield yesterday for tracker 1 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/1/Yield</b>
+</dd>
+  <dt class="optional">Maximum charge power yesterday tracker 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/2/MaxPower</b>
+</dd>
+  <dt class="optional">Yield yesterday for tracker 2 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/2/Yield</b>
+</dd>
+  <dt class="optional">Maximum charge power yesterday tracker 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/3/MaxPower</b>
+</dd>
+  <dt class="optional">Yield yesterday for tracker 3 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Pv/3/Yield</b>
+</dd>
+  <dt class="optional">Yield yesterday (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/History/Daily/1/Yield</b>
+</dd>
+  <dt class="optional">Load state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Load/State</b>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - On</li>
+</ul>
+</dd>
+  <dt class="optional">Charger on/off<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>1 - On</li>
+  <li>4 - Off</li>
+</ul>
+</dd>
+  <dt class="optional">MPP operation mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/MppOperationMode</b>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Voltage or current limited</li>
+  <li>2 - MPPT Tracker active</li>
+  <li>255 - Not available</li>
+</ul>
+</dd>
+  <dt class="optional">Position<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Position</b>
+<ul>
+  <li>0 - AC input 1</li>
+  <li>1 - AC output</li>
+  <li>2 - AC input 2</li>
+</ul>
+</dd>
+  <dt class="optional">Tracker 1 power<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/0/P</b>
+</dd>
+  <dt class="optional">Tracker 1 voltage<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/0/V</b>
+</dd>
+  <dt class="optional">Tracker 2 power<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/1/P</b>
+</dd>
+  <dt class="optional">Tracker 2 voltage<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/1/V</b>
+</dd>
+  <dt class="optional">Tracker 3 power<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/2/P</b>
+</dd>
+  <dt class="optional">Tracker 3 voltage<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/2/V</b>
+</dd>
+  <dt class="optional">Tracker 4 power<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/3/P</b>
+</dd>
+  <dt class="optional">Tracker 4 voltage<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/3/V</b>
+</dd>
+  <dt class="optional">PV voltage<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pv/V</b>
+</dd>
+  <dt class="optional">Relay on the charger<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Relay/0/State</b>
+<ul>
+  <li>0 - Open</li>
+  <li>1 - Closed</li>
+</ul>
+</dd>
+  <dt class="optional">Charge state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/State</b>
+<ul>
+  <li>0 - Off</li>
+  <li>2 - Fault</li>
+  <li>3 - Bulk</li>
+  <li>4 - Absorption</li>
+  <li>5 - Float</li>
+  <li>6 - Storage</li>
+  <li>7 - Equalize</li>
+  <li>245 - Off</li>
+  <li>247 - Equalize</li>
+  <li>252 - Ext. Control</li>
+</ul>
+</dd>
+  <dt class="optional">PV Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Yield/Power</b>
+</dd>
+  <dt class="optional">Yield since last update (kWh)<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/Yield/System</b>
+</dd>
+  <dt class="optional">Yield since reset (kWh)<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/Yield/User</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-system">
+<p>This input node takes is for retrieving information from the <tt>com.victronenergy.system</tt> dbus path.</p>
+<h3>system</h3>
+<dl class="message-properties">
+  <dt class="optional">AC-Input<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/Source</b>
+<ul>
+  <li>0 - Not available</li>
+  <li>1 - Grid</li>
+  <li>2 - Generator</li>
+  <li>3 - Shore</li>
+  <li>240 - Inverting</li>
+</ul>
+</dd>
+  <dt class="optional">AC Consumption L1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Consumption/L1/Power</b>
+</dd>
+  <dt class="optional">AC Consumption L2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Consumption/L2/Power</b>
+</dd>
+  <dt class="optional">AC Consumption L3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Consumption/L3/Power</b>
+</dd>
+  <dt class="optional">AC Consumption on Input Number Of Phases<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Ac/ConsumptionOnInput/NumberOfPhases</b>
+</dd>
+  <dt class="optional">AC Consumption on Output L1<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ConsumptionOnOutput/L1/Power</b>
+</dd>
+  <dt class="optional">AC Consumption on Output L2<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ConsumptionOnOutput/L2/Power</b>
+</dd>
+  <dt class="optional">AC Consumption on Output L3<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ConsumptionOnOutput/L3/Power</b>
+</dd>
+  <dt class="optional">AC Consumption on Output Number Of Phases<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Ac/ConsumptionOnOutput/NumberOfPhases</b>
+</dd>
+  <dt class="optional">Genset Device Type<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Genset/DeviceType</b>
+</dd>
+  <dt class="optional">Genset L1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Genset/L1/Power</b>
+</dd>
+  <dt class="optional">Genset L2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Genset/L2/Power</b>
+</dd>
+  <dt class="optional">Genset L3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Genset/L3/Power</b>
+</dd>
+  <dt class="optional">Genset Number Of Phases<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Ac/Genset/NumberOfPhases</b>
+</dd>
+  <dt class="optional">Grid Device Type<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Grid/DeviceType</b>
+</dd>
+  <dt class="optional">Grid L1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Grid/L1/Power</b>
+</dd>
+  <dt class="optional">Grid L2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Grid/L2/Power</b>
+</dd>
+  <dt class="optional">Grid L3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Grid/L3/Power</b>
+</dd>
+  <dt class="optional">Grid Number Of Phases<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Ac/Grid/NumberOfPhases</b>
+</dd>
+  <dt class="optional">PV Power AC-tied on Generator L1<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnGenset/L1/Power</b>
+</dd>
+  <dt class="optional">PV Power AC-tied on Generator L2<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnGenset/L2/Power</b>
+</dd>
+  <dt class="optional">PV Power AC-tied on Generator L3<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnGenset/L3/Power</b>
+</dd>
+  <dt class="optional">PV Power AC-tied on Generator Number Of Phases<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Ac/PvOnGenset/NumberOfPhases</b>
+</dd>
+  <dt class="optional">PV - AC-coupled on input L1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnGrid/L1/Power</b>
+</dd>
+  <dt class="optional">PV - AC-coupled on input L2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnGrid/L2/Power</b>
+</dd>
+  <dt class="optional">PV - AC-coupled on input L3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnGrid/L3/Power</b>
+</dd>
+  <dt class="optional">PV - AC-coupled on input Number Of Phases<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Ac/PvOnGrid/NumberOfPhases</b>
+</dd>
+  <dt class="optional">PV - AC-coupled on output L1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnOutput/L1/Power</b>
+</dd>
+  <dt class="optional">PV - AC-coupled on output L2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnOutput/L2/Power</b>
+</dd>
+  <dt class="optional">PV - AC-coupled on output L3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/PvOnOutput/L3/Power</b>
+</dd>
+  <dt class="optional">PV - AC-coupled on output Number Of Phases<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Ac/PvOnOutput/NumberOfPhases</b>
+</dd>
+  <dt class="optional">Buzzer State<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Buzzer/State</b>
+</dd>
+  <dt class="optional">Battery Consumed Amphours (Ah)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Battery/ConsumedAmphours</b>
+</dd>
+  <dt class="optional">Battery current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Battery/Current</b>
+</dd>
+  <dt class="optional">Battery Power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Battery/Power</b>
+</dd>
+  <dt class="optional">Battery State of Charge (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Battery/Soc</b>
+</dd>
+  <dt class="optional">Battery state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Dc/Battery/State</b>
+<ul>
+  <li>0 - idle</li>
+  <li>1 - charging</li>
+  <li>2 - discharging</li>
+</ul>
+</dd>
+  <dt class="optional">Battery temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Battery/Temperature</b>
+</dd>
+  <dt class="optional">Battery Time to Go (h)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Battery/TimeToGo</b>
+</dd>
+  <dt class="optional">Battery voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Battery/Voltage</b>
+</dd>
+  <dt class="optional">AC-Chargers - power (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Dc/Charger/Power</b>
+</dd>
+  <dt class="optional">MPPTs - current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Pv/Current</b>
+</dd>
+  <dt class="optional">MPPTs - power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Pv/Power</b>
+</dd>
+  <dt class="optional">DC System (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/System/Power</b>
+</dd>
+  <dt class="optional">VE.Bus charge current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Vebus/Current</b>
+</dd>
+  <dt class="optional">VE.Bus charge power (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/Vebus/Power</b>
+</dd>
+  <dt class="optional">Serial (System)<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/Serial</b>
+</dd>
+  <dt class="optional">System type<span class="property-type">string</dt>
+  <dd>Dbus path: <b>/SystemType</b>
+</dd>
+  <dt class="optional">Time off (s)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Timers/TimeOff</b>
+</dd>
+  <dt class="optional">Time generator (s)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Timers/TimeOnGenerator</b>
+</dd>
+  <dt class="optional">Time grid (s)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Timers/TimeOnGrid</b>
+</dd>
+  <dt class="optional">Time inverting (s)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Timers/TimeOnInverter</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-tank">
+<p>The input-tank node is for retrieving tank level sensor information.</p><p>Also see the <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-e4027d37-78e0-4433-1be4-3252d3b79152">manual</a> for more information.</p>
+<h3>tank</h3>
+<dl class="message-properties">
+  <dt class="optional">Tank capacity (m3)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Capacity</b>
+</dd>
+  <dt class="optional">Fluid type<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/FluidType</b>
+<ul>
+  <li>0 - Fuel</li>
+  <li>1 - Fresh water</li>
+  <li>2 - Waste water</li>
+  <li>3 - Live well</li>
+  <li>4 - Oil</li>
+  <li>5 - Black water (sewage)</li>
+</ul>
+</dd>
+  <dt class="optional">Tank level (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Level</b>
+</dd>
+  <dt class="optional">Product ID<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/ProductId</b>
+</dd>
+  <dt class="optional">Fluid remaining (m3)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Remaining</b>
+</dd>
+  <dt class="optional">Standard<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Standard</b>
+<ul>
+  <li>0 - European</li>
+  <li>1 - USA</li>
+</ul>
+</dd>
+  <dt class="optional">Tank sensor status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Status</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Disconnected</li>
+  <li>2 - Short circuited</li>
+  <li>3 - Unknown</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-temperature">
+<p>Like the other nodes, the <b>input-temperature</b> node reads the temperate information from the dbus. This means that source of the temperature sensor can obtain its information from different sources (e.g. directly connected probe or Bluetooth connected Ruuvi tag).</p><p>See the <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-4d5df29c-761e-cfcc-9e2c-8230f126e7bb">manual</a> for information on connecting a temperature sensor.</p>
+<h3>temperature</h3>
+<dl class="message-properties">
+  <dt class="optional">Acceleration X (g)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/AccelX</b>
+</dd>
+  <dt class="optional">Acceleration Y (g)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/AccelY</b>
+</dd>
+  <dt class="optional">Acceleration Z (g)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/AccelZ</b>
+</dd>
+  <dt class="optional">Sensor battery voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/BatteryVoltage</b>
+</dd>
+  <dt class="optional">Humidity (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Humidity</b>
+</dd>
+  <dt class="optional">Temperature offset<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Offset</b>
+</dd>
+  <dt class="optional">Pressure (kPa)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Pressure</b>
+</dd>
+  <dt class="optional">Product ID<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/ProductId</b>
+</dd>
+  <dt class="optional">Temperature scale factor<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Scale</b>
+</dd>
+  <dt class="optional">Sensor status<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Status</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Disconnected</li>
+  <li>2 - Short circuited</li>
+  <li>3 - Reverse polarity</li>
+  <li>4 - Unknown</li>
+</ul>
+</dd>
+  <dt class="optional">Temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Temperature</b>
+</dd>
+  <dt class="optional">Sensor type<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/TemperatureType</b>
+<ul>
+  <li>0 - Battery</li>
+  <li>1 - Fridge</li>
+  <li>2 - Generic</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-input-vebus">
+<p>Information from VE.Bus connected devices can be obtained with this node.</p>
+<h3>vebus</h3>
+<dl class="message-properties">
+  <dt class="optional">Active input<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/ActiveInput</b>
+<ul>
+  <li>0 - AC Input 1</li>
+  <li>1 - AC Input 2</li>
+  <li>240 - Disconnected</li>
+</ul>
+</dd>
+  <dt class="optional">Input frequency 1 (Hz)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L1/F</b>
+</dd>
+  <dt class="optional">Input current phase 1 (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L1/I</b>
+</dd>
+  <dt class="optional">Input power 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L1/P</b>
+</dd>
+  <dt class="optional">Input voltage phase 1 (VAC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L1/V</b>
+</dd>
+  <dt class="optional">Input frequency 2 (Hz)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L2/F</b>
+</dd>
+  <dt class="optional">Input current phase 2 (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L2/I</b>
+</dd>
+  <dt class="optional">Input power 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L2/P</b>
+</dd>
+  <dt class="optional">Input voltage phase 2 (VAC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L2/V</b>
+</dd>
+  <dt class="optional">Input frequency 3 (Hz)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L3/F</b>
+</dd>
+  <dt class="optional">Input current phase 3 (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L3/I</b>
+</dd>
+  <dt class="optional">Input power 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L3/P</b>
+</dd>
+  <dt class="optional">Input voltage phase 3 (VAC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/L3/V</b>
+</dd>
+  <dt class="optional">Input 1 current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/CurrentLimit</b>
+</dd>
+  <dt class="optional">Input 1 current limit is adjustable<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Ac/In/1/CurrentLimitIsAdjustable</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Input 2 current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/2/CurrentLimit</b>
+</dd>
+  <dt class="optional">Input 2 current limit is adjustable<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Ac/In/2/CurrentLimitIsAdjustable</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Phase count<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/NumberOfPhases</b>
+</dd>
+  <dt class="optional">Output frequency (Hz)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/F</b>
+</dd>
+  <dt class="optional">Output current phase 1 (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/I</b>
+</dd>
+  <dt class="optional">Output power 1 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/P</b>
+</dd>
+  <dt class="optional">Output voltage phase 1 (VAC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L1/V</b>
+</dd>
+  <dt class="optional">Output current phase 2 (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L2/I</b>
+</dd>
+  <dt class="optional">Output power 2 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L2/P</b>
+</dd>
+  <dt class="optional">Output voltage phase 2 (VAC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L2/V</b>
+</dd>
+  <dt class="optional">Output current phase 3 (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L3/I</b>
+</dd>
+  <dt class="optional">Output power 3 (W)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L3/P</b>
+</dd>
+  <dt class="optional">Output voltage phase 3 (VAC)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/Out/L3/V</b>
+</dd>
+  <dt class="optional">AC input 1 ignored<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Ac/State/IgnoreAcIn1</b>
+<ul>
+  <li>0 - AC input not ignored</li>
+  <li>1 - AC input ignored</li>
+</ul>
+</dd>
+  <dt class="optional">AC input 2 ignored<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Ac/State/IgnoreAcIn2</b>
+<ul>
+  <li>0 - AC input not ignored</li>
+  <li>1 - AC input ignored</li>
+</ul>
+</dd>
+  <dt class="optional">Grid lost alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/GridLost</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Temperature<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/HighTemperature</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Temperature alarm L1<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L1/HighTemperature</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low battery alarm L1<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L1/LowBattery</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Overload alarm L1<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L1/Overload</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Ripple alarm L1<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L1/Ripple</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Temperature alarm L2<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L2/HighTemperature</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low battery alarm L2<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L2/LowBattery</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Overload alarm L2<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L2/Overload</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Ripple alarm L2<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L2/Ripple</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Temperature alarm L3<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L3/HighTemperature</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low battery alarm L3<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L3/LowBattery</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Overload alarm L3<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L3/Overload</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Ripple alarm L3<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/L3/Ripple</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Low battery<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/LowBattery</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Overload<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/Overload</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Phase Rotation<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/PhaseRotation</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+</ul>
+</dd>
+  <dt class="optional">Temperatur sensor alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/TemperatureSensor</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">Voltage sensor alarm<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Alarms/VoltageSensor</b>
+<ul>
+  <li>0 - Ok</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul>
+</dd>
+  <dt class="optional">BMS allows battery to be charged<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Bms/AllowToCharge</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">BMS allows battery to be discharged<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Bms/AllowToDischarge</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">VE.Bus BMS is expected<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Bms/BmsExpected</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">VE.Bus BMS error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Bms/Error</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b>
+</dd>
+  <dt class="optional">Temperature (C)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Temperature</b>
+</dd>
+  <dt class="optional">Voltage (V)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b>
+</dd>
+  <dt class="optional">Energy ACIn1 to AcOut (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/AcIn1ToAcOut</b>
+</dd>
+  <dt class="optional">Energy AcIn1 to Inverter (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/AcIn1ToInverter</b>
+</dd>
+  <dt class="optional">Energy ACIn2 to AcOut (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/AcIn2ToAcOut</b>
+</dd>
+  <dt class="optional">Energy ACIn2 to Inverter (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/AcIn2ToInverter</b>
+</dd>
+  <dt class="optional">Energy AcOut to AcIn1 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/AcOutToAcIn1</b>
+</dd>
+  <dt class="optional">Energy AcOut to AcIn2 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/AcOutToAcIn2</b>
+</dd>
+  <dt class="optional">Energy Inverter to AcIn1 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/InverterToAcIn1</b>
+</dd>
+  <dt class="optional">Energy Inverter to AcIn2 (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/InverterToAcIn2</b>
+</dd>
+  <dt class="optional">Inverter To AcOut (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/InverterToAcOut</b>
+</dd>
+  <dt class="optional">AcOut to Inverter (kWh)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Energy/OutToInverter</b>
+</dd>
+  <dt class="optional">Switch Position<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>1 - Charger Only</li>
+  <li>2 - Inverter Only</li>
+  <li>3 - On</li>
+  <li>4 - Off</li>
+</ul>
+</dd>
+  <dt class="optional">Mode is adjustable<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/ModeIsAdjustable</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">VE.Bus state of charge (%)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Soc</b>
+</dd>
+  <dt class="optional">VE.Bus state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/State</b>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Low Power</li>
+  <li>2 - Fault</li>
+  <li>3 - Bulk</li>
+  <li>4 - Absorption</li>
+  <li>5 - Float</li>
+  <li>6 - Storage</li>
+  <li>7 - Equalize</li>
+  <li>8 - Passthru</li>
+  <li>9 - Inverting</li>
+  <li>10 - Power assist</li>
+  <li>11 - Power supply</li>
+  <li>252 - Bulk protect</li>
+</ul>
+</dd>
+  <dt class="optional">VE.Bus Error<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/VebusError</b>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - VE.Bus Error 1: Device is switched off because one of the other phases in the system has switched off</li>
+  <li>2 - VE.Bus Error 2: New and old types MK2 are mixed in the system</li>
+  <li>3 - VE.Bus Error 3: Not all, or more than, the expected devices were found in the system</li>
+  <li>4 - VE.Bus Error 4: No other device whatsoever detected</li>
+  <li>5 - VE.Bus Error 5: Overvoltage on AC-out</li>
+  <li>6 - VE.Bus Error 6: Error in DDC Program</li>
+  <li>7 - VE.Bus Error 7:  BMS connected, which requires an Assistant, but no assistant found</li>
+  <li>8 - VE.Bus Error 8: Ground relay test failed</li>
+  <li>9 - VE.Bus Error 9</li>
+  <li>10 - VE.Bus Error 10: System time synchronisation problem occurred</li>
+  <li>11 - VE.Bus Error 11: Relay test fault</li>
+  <li>12 - VE.Bus Error 12</li>
+  <li>13 - VE.Bus Error 13</li>
+  <li>14 - VE.Bus Error 14: Device cannot transmit data</li>
+  <li>15 - VE.Bus Error 15</li>
+  <li>16 - VE.Bus Error 16: Awaiting configuration or dongle missing</li>
+  <li>17 - VE.Bus Error 17: Phase master missing</li>
+  <li>18 - VE.Bus Error 18: AC Overvoltage on the output of a slave has occurred while already switched off</li>
+  <li>19 - VE.Bus Error 19</li>
+  <li>20 - VE.Bus Error 20</li>
+  <li>21 - VE.Bus Error 21</li>
+  <li>22 - VE.Bus Error 22: This device cannot function as slave</li>
+  <li>23 - VE.Bus Error 23</li>
+  <li>24 - VE.Bus Error 24: Switch-over system protection initiated</li>
+  <li>25 - VE.Bus Error 25: Firmware incompatibility. The firmware of one of the connected device is not sufficiently up to date to operate in conjunction with this device</li>
+  <li>26 - VE.Bus Error 26: Internal error</li>
+  <li>27 - VE.Bus Error 27</li>
+  <li>28 - VE.Bus Error 28</li>
+  <li>29 - VE.Bus Error 29</li>
+  <li>30 - VE.Bus Error 30</li>
+  <li>31 - VE.Bus Error 31</li>
+  <li>32 - VE.Bus Error 32</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-output-accharger">
+<p>This node is for controlling the AC charger.</p>
+<h3>charger</h3>
+<dl class="message-properties">
+  <dt class="optional">AC Current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/CurrentLimit</b>
+</dd>
+  <dt class="optional">Charger on/off<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>1 - On</li>
+  <li>4 - Off</li>
+</ul>
+</dd>
+  <dt class="optional">Relay on the charger<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Relay/0/State</b>
+<ul>
+  <li>0 - Open</li>
+  <li>1 - Closed</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-output-ess">
+<p>This node allows for controlling the Energy Storage System (ESS).</p>
+<h3>vebus</h3>
+<dl class="message-properties">
+  <dt class="optional">Disable charge<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Hub4/DisableCharge</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Disable feed-in<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Hub4/DisableFeedIn</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Feed in overvoltage<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Hub4/DoNotFeedInOvervoltage</b>
+<ul>
+  <li>0 - Yes</li>
+  <li>1 - No</li>
+</ul>
+</dd>
+  <dt class="optional">AC Power L1 setpoint (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L1/AcPowerSetpoint</b>
+</dd>
+  <dt class="optional">Maximum overvoltage feed-in power L1 (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L1/MaxFeedInPower</b>
+</dd>
+  <dt class="optional">AC Power L2 setpoint (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L2/AcPowerSetpoint</b>
+</dd>
+  <dt class="optional">Maximum overvoltage feed-in power L2 (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L2/MaxFeedInPower</b>
+</dd>
+  <dt class="optional">AC Power L3 setpoint (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L3/AcPowerSetpoint</b>
+</dd>
+  <dt class="optional">Maximum overvoltage feed-in power L3 (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Hub4/L3/MaxFeedInPower</b>
+</dd>
+  <dt class="optional">Disable PV inverter<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/PvInverter/Disable</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">VE.Bus Reset<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/SystemReset</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+</dl>
+<h3>settings</h3>
+<dl class="message-properties">
+  <dt class="optional">Grid set-point (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/AcPowerSetPoint</b>
+</dd>
+  <dt class="optional">Minimum Discharge SOC (%)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/MinimumSocLimit</b>
+</dd>
+  <dt class="optional">ESS state<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/State</b>
+<ul>
+  <li>1 - BatteryLife enabled (GUI controlled)</li>
+  <li>2 - Optimized Mode /w BatteryLife: self consumption</li>
+  <li>3 - Optimized Mode /w BatteryLife: self consumption, SoC exceeds 85%</li>
+  <li>4 - Optimized Mode /w BatteryLife: self consumption, SoC at 100%</li>
+  <li>5 - Optimized Mode /w BatteryLife: SoC below dynamic SoC limit</li>
+  <li>6 - Optimized Mode /w BatteryLife: SoC has been below SoC limit for more than 24 hours. Charging the battery (5A)</li>
+  <li>7 - Optimized Mode /w BatteryLife: Inverter/Charger is in sustain mode</li>
+  <li>8 - Optimized Mode /w BatteryLife: recharging, SoC dropped by 5% or more below the minimum SoC</li>
+  <li>9 - 'Keep batteries charged' mode is enabled</li>
+  <li>10 - Optimized mode w/o BatteryLife: self consumption, SoC at or above minimum SoC</li>
+  <li>11 - Optimized mode w/o BatteryLife: self consumption, SoC is below minimum SoC</li>
+  <li>12 - Optimized mode w/o BatteryLife: recharging, SoC dropped by 5% or more below minimum SoC</li>
+</ul>
+</dd>
+  <dt class="optional">ESS mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/Hub4Mode</b>
+<ul>
+  <li>1 - Optimized mode or 'keep batteries charged' and phase compensation enabled</li>
+  <li>2 - Optimized mode or 'keep batteries charged' and phase compensation disabled</li>
+  <li>3 - External control</li>
+</ul>
+</dd>
+  <dt class="optional">Max inverter power (W)<span class="property-type">integer</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/MaxDischargePower</b>
+</dd>
+  <dt class="optional">Feed-in excess solar charger power<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/OvervoltageFeedIn</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">PV Inverter zero feed-in (on/off)<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/PreventFeedback</b>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul>
+</dd>
+  <dt class="optional">Charge current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeCurrent</b>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-output-evcharger">
+<p>With this node the ev charger can be controlled.</p>
+<h3>evcharger</h3>
+<dl class="message-properties">
+  <dt class="optional">Maximum charge current (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/MaxCurrent</b>
+</dd>
+  <dt class="optional">Mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>0 - Manual</li>
+  <li>1 - Auto</li>
+</ul>
+</dd>
+  <dt class="optional">Set charge current (manual mode) (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/SetCurrent</b>
+</dd>
+  <dt class="optional">Start/stop charging (manual mode)<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/StartStop</b>
+<ul>
+  <li>0 - Stop</li>
+  <li>1 - Start</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-output-inverter">
+<p>This node can be used for controlling the inverter.</p>
+<h3>inverter</h3>
+<dl class="message-properties">
+  <dt class="optional">Mode<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>2 - Inverter on</li>
+  <li>4 - Off</li>
+  <li>5 - Low Power/ECO</li>
+</ul>
+</dd>
+</dl>
+</script>
+
+<script type="text/x-red" data-help-name="victron-output-multi">
+<p>Multi RS output node.</p>
+<h3>multi</h3>
+<dl class="message-properties">
+  <dt class="optional">Ac input 1 current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/1/CurrentLimit</b>
+</dd>
+  <dt class="optional">Ac input 2 current limit (A)<span class="property-type">float</dt>
+  <dd>Dbus path: <b>/Ac/In/2/CurrentLimit</b>
+</dd>
+  <dt class="optional">Switch position<span class="property-type">enum</dt>
+  <dd>Dbus path: <b>/Mode</b>
+<ul>
+  <li>1 - Charger Only</li>
+  <li>2 - Inverter Only</li>
+  <li>3 - On</li>
+  <li>4 - Off</li>
+</ul>
+</dd>
+</dl>
+</script>
+
 <script type="text/x-red" data-help-name="victron-output-relay">
 <p>The relays of the Venus device can be controled with this node. Make sure to set the relay(s) to <b>Manual</b> via the Venus OS GUI first. </p>
 <h3>system</h3>
@@ -2344,67 +3654,6 @@ Questions can also be asked on the Victron Energy community:
 </dl>
 </script>
 
-<script type="text/x-red" data-help-name="victron-output-vebus">
-<p>This output node is for writing to VE.Bus connected devices.</p>
-<h3>vebus</h3>
-<dl class="message-properties">
-  <dt class="optional">Switch Position<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>1 - Charger Only</li>
-  <li>2 - Inverter Only</li>
-  <li>3 - On</li>
-  <li>4 - Off</li>
-</ul>
-</dd>
-  <dt class="optional">Input 1 current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/CurrentLimit</b>
-</dd>
-  <dt class="optional">Input 2 current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/2/CurrentLimit</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-inverter">
-<p>This node can be used for controlling the inverter.</p>
-<h3>inverter</h3>
-<dl class="message-properties">
-  <dt class="optional">Mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>2 - Inverter on</li>
-  <li>4 - Off</li>
-  <li>5 - Low Power/ECO</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-accharger">
-<p>This node is for controlling the AC charger.</p>
-<h3>charger</h3>
-<dl class="message-properties">
-  <dt class="optional">AC Current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/CurrentLimit</b>
-</dd>
-  <dt class="optional">Charger on/off<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>1 - On</li>
-  <li>4 - Off</li>
-</ul>
-</dd>
-  <dt class="optional">Relay on the charger<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Relay/0/State</b>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul>
-</dd>
-</dl>
-</script>
-
 <script type="text/x-red" data-help-name="victron-output-solarcharger">
 <p>With this node the solar charger can be switched on and off.</p>
 <h3>solarcharger</h3>
@@ -2413,142 +3662,6 @@ Questions can also be asked on the Victron Energy community:
   <dd>Dbus path: <b>/Mode</b>
 <ul>
   <li>1 - On</li>
-  <li>4 - Off</li>
-</ul>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-ess">
-<p>This node allows for controlling the Energy Storage System (ESS).</p>
-<h3>vebus</h3>
-<dl class="message-properties">
-  <dt class="optional">Disable feed-in<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Hub4/DisableFeedIn</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">Disable charge<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Hub4/DisableCharge</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">Disable PV inverter<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/PvInverter/Disable</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">AC Power L1 setpoint (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L1/AcPowerSetpoint</b>
-</dd>
-  <dt class="optional">Maximum overvoltage feed-in power L1 (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L1/MaxFeedInPower</b>
-</dd>
-  <dt class="optional">AC Power L2 setpoint (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L2/AcPowerSetpoint</b>
-</dd>
-  <dt class="optional">Maximum overvoltage feed-in power L2 (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L2/MaxFeedInPower</b>
-</dd>
-  <dt class="optional">AC Power L3 setpoint (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L3/AcPowerSetpoint</b>
-</dd>
-  <dt class="optional">Maximum overvoltage feed-in power L3 (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Hub4/L3/MaxFeedInPower</b>
-</dd>
-  <dt class="optional">Feed in overvoltage<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Hub4/DoNotFeedInOvervoltage</b>
-<ul>
-  <li>0 - Yes</li>
-  <li>1 - No</li>
-</ul>
-</dd>
-  <dt class="optional">VE.Bus Reset<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/SystemReset</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-</dl>
-<h3>settings</h3>
-<dl class="message-properties">
-  <dt class="optional">Grid set-point (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/AcPowerSetPoint</b>
-</dd>
-  <dt class="optional">Minimum Discharge SOC (%)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/MinimumSocLimit</b>
-</dd>
-  <dt class="optional">ESS state<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/State</b>
-<ul>
-  <li>1 - BatteryLife enabled (GUI controlled)</li>
-  <li>2 - Optimized Mode /w BatteryLife: self consumption</li>
-  <li>3 - Optimized Mode /w BatteryLife: self consumption, SoC exceeds 85%</li>
-  <li>4 - Optimized Mode /w BatteryLife: self consumption, SoC at 100%</li>
-  <li>5 - Optimized Mode /w BatteryLife: SoC below dynamic SoC limit</li>
-  <li>6 - Optimized Mode /w BatteryLife: SoC has been below SoC limit for more than 24 hours. Charging the battery (5A)</li>
-  <li>7 - Optimized Mode /w BatteryLife: Inverter/Charger is in sustain mode</li>
-  <li>8 - Optimized Mode /w BatteryLife: recharging, SoC dropped by 5% or more below the minimum SoC</li>
-  <li>9 - 'Keep batteries charged' mode is enabled</li>
-  <li>10 - Optimized mode w/o BatteryLife: self consumption, SoC at or above minimum SoC</li>
-  <li>11 - Optimized mode w/o BatteryLife: self consumption, SoC is below minimum SoC</li>
-  <li>12 - Optimized mode w/o BatteryLife: recharging, SoC dropped by 5% or more below minimum SoC</li>
-</ul>
-</dd>
-  <dt class="optional">ESS mode<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/Hub4Mode</b>
-<ul>
-  <li>1 - Optimized mode or 'keep batteries charged' and phase compensation enabled</li>
-  <li>2 - Optimized mode or 'keep batteries charged' and phase compensation disabled</li>
-  <li>3 - External control</li>
-</ul>
-</dd>
-  <dt class="optional">Max inverter power (W)<span class="property-type">integer</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/MaxDischargePower</b>
-</dd>
-  <dt class="optional">Feed-in excess solar charger power<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/OvervoltageFeedIn</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">PV Inverter zero feed-in (on/off)<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/PreventFeedback</b>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul>
-</dd>
-  <dt class="optional">Charge current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeCurrent</b>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-multi">
-<p>Multi RS output node.</p>
-<h3>multi</h3>
-<dl class="message-properties">
-  <dt class="optional">Ac input 1 current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/1/CurrentLimit</b>
-</dd>
-  <dt class="optional">Ac input 2 current limit (A)<span class="property-type">float</dt>
-  <dd>Dbus path: <b>/Ac/In/2/CurrentLimit</b>
-</dd>
-  <dt class="optional">Switch position<span class="property-type">enum</dt>
-  <dd>Dbus path: <b>/Mode</b>
-<ul>
-  <li>1 - Charger Only</li>
-  <li>2 - Inverter Only</li>
-  <li>3 - On</li>
   <li>4 - Off</li>
 </ul>
 </dd>

--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -336,10 +336,10 @@
     registerInputNode('victron-input-dcsource', 'DC Source', 'input-dcsource');
     registerInputNode('victron-input-dcsystem', 'DC System', 'input-dcsystem');
     registerInputNode('victron-input-digitalinput', 'Digital Input', 'input-digitalinput');
+    registerInputNode('victron-input-genset', 'Energy Meter', 'input-genset');
     registerInputNode('victron-input-ess', 'ESS', 'input-ess');
     registerInputNode('victron-input-evcharger', 'EV Charger', 'input-evcharger');
     registerInputNode('victron-input-generator', 'Generator', 'input-generator');
-    registerInputNode('victron-input-genset', 'Energy Meter', 'input-genset');
     registerInputNode('victron-input-gps', 'GPS', 'input-gps');
     registerInputNode('victron-input-gridmeter', 'Grid Meter', 'input-gridmeter');
     registerInputNode('victron-input-inverter', 'Inverter', 'input-inverter');

--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -328,14 +328,18 @@
     }
 
     registerInputNode('victron-input-accharger', 'AC Charger', 'input-accharger');
-    registerInputNode('victron-input-alternator', 'Alternator', 'input-alternator');
     registerInputNode('victron-input-acload', 'AC Load', 'input-acload');
+    registerInputNode('victron-input-alternator', 'Alternator', 'input-alternator');
     registerInputNode('victron-input-battery', 'Battery Monitor', 'input-battery');
     registerInputNode('victron-input-dcdc', 'DC/DC Converter', 'input-dcdc');
     registerInputNode('victron-input-dcload', 'DC Load', 'input-dcload');
     registerInputNode('victron-input-dcsource', 'DC Source', 'input-dcsource');
+    registerInputNode('victron-input-dcsystem', 'DC System', 'input-dcsystem');
     registerInputNode('victron-input-digitalinput', 'Digital Input', 'input-digitalinput');
     registerInputNode('victron-input-ess', 'ESS', 'input-ess');
+    registerInputNode('victron-input-evcharger', 'EV Charger', 'input-evcharger');
+    registerInputNode('victron-input-generator', 'Generator', 'input-generator');
+    registerInputNode('victron-input-genset', 'Energy Meter', 'input-genset');
     registerInputNode('victron-input-gps', 'GPS', 'input-gps');
     registerInputNode('victron-input-gridmeter', 'Grid Meter', 'input-gridmeter');
     registerInputNode('victron-input-inverter', 'Inverter', 'input-inverter');
@@ -351,11 +355,11 @@
 
     registerOutputNode('victron-output-accharger', 'AC Charger', 'output-accharger');
     registerOutputNode('victron-output-ess', 'ESS', 'output-ess');
+    registerOutputNode('victron-output-evcharger', 'EV Charger', 'output-evcharger');
     registerOutputNode('victron-output-inverter', 'Inverter', 'output-inverter');
     registerOutputNode('victron-output-multi', 'Multi', 'output-multi');
     registerOutputNode('victron-output-relay', 'Relay', 'output-relay');
     registerOutputNode('victron-output-solarcharger', 'Solar Charger', 'output-solarcharger');
-    registerOutputNode('victron-output-vebus', 'VE.Bus System', 'output-vebus');
 
 </script>
 

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -83,8 +83,12 @@ module.exports = function (RED) {
     RED.nodes.registerType('victron-input-dcdc', BaseInputNode);
     RED.nodes.registerType('victron-input-dcload', BaseInputNode);
     RED.nodes.registerType('victron-input-dcsource', BaseInputNode);
-    RED.nodes.registerType('victron-input-ess', BaseInputNode);
+    RED.nodes.registerType('victron-input-dcsystem', BaseInputNode);
     RED.nodes.registerType('victron-input-digitalinput', BaseInputNode);
+    RED.nodes.registerType('victron-input-ess', BaseInputNode);
+    RED.nodes.registerType('victron-input-evcharger', BaseInputNode);
+    RED.nodes.registerType('victron-input-generator', BaseInputNode);
+    RED.nodes.registerType('victron-input-genset', BaseInputNode);
     RED.nodes.registerType('victron-input-gps', BaseInputNode);
     RED.nodes.registerType('victron-input-gridmeter', BaseInputNode);
     RED.nodes.registerType('victron-input-inverter', BaseInputNode);
@@ -101,9 +105,9 @@ module.exports = function (RED) {
     // Output nodes
     RED.nodes.registerType('victron-output-accharger', BaseOutputNode);
     RED.nodes.registerType('victron-output-ess', BaseOutputNode);
+    RED.nodes.registerType('victron-output-evcharger', BaseOutputNode);
     RED.nodes.registerType('victron-output-inverter', BaseOutputNode);
     RED.nodes.registerType('victron-output-multi', BaseOutputNode);
     RED.nodes.registerType('victron-output-relay', BaseOutputNode);
     RED.nodes.registerType('victron-output-solarcharger', BaseOutputNode);
-    RED.nodes.registerType('victron-output-vebus', BaseOutputNode);
 }

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -1,4 +1,479 @@
 {
+    "input-dcsystem": {
+       "help": "<p>DC system input node is a DC measurement for loads in your system.</p>",
+       "dcsystem": [
+          {
+              "path": "/Dc/0/Voltage",
+              "type": "float",
+              "name": "Battery voltage (V DC)"
+          },
+          {
+              "path": "/Dc/0/Current",
+              "type": "float",
+              "name": "Battery current (A)"
+          },
+          {
+              "path": "/Dc/1/Voltage",
+              "type": "float",
+              "name": "Auxiliary voltage (V DC)"
+          },
+          {
+              "path": "/Dc/0/Temperature",
+              "type": "float",
+              "name": "Temperature (Degrees celsius)"
+          },
+          {
+              "path": "/History/EnergyOut",
+              "type": "float",
+              "name": "Total energy produced (kWh)"
+          },
+          {
+              "path": "/History/EnergyIn",
+              "type": "float",
+              "name": "Total energy consumed (kWh)"
+          },
+          {
+              "path": "/Alarms/LowVoltage",
+              "type": "enum",
+              "name": "Low voltage alarm",
+              "enum": {
+                  "0": "No alarm",
+                  "1": "Warning",
+                  "2": "Alarm"
+              }
+          },
+          {
+              "path": "/Alarms/HighVoltage",
+              "type": "enum",
+              "name": "High voltage alarm",
+              "enum": {
+                  "0": "No alarm",
+                  "1": "Warning",
+                  "2": "Alarm"
+              }
+          },
+          {
+              "path": "/Alarms/LowStarterVoltage",
+              "type": "enum",
+              "name": "Low auxiliary voltage alarm",
+              "enum": {
+                  "0": "Ok",
+                  "1": "Warning",
+                  "2": "Alarm"
+              }
+          },
+          {
+              "path": "/Alarms/HighStarterVoltage",
+              "type": "enum",
+              "name": "High auxiliary voltage alarm",
+              "enum": {
+                  "0": "Ok",
+                  "1": "Warning",
+                  "2": "Alarm"
+              }
+          },
+          {
+              "path": "/Alarms/LowTemperature",
+              "type": "enum",
+              "name": "Low temperature alarm",
+              "enum": {
+                  "0": "Ok",
+                  "1": "Warning",
+                  "2": "Alarm"
+              }
+          },
+          {
+              "path": "/Alarms/HighTemperature",
+              "type": "enum",
+              "name": "High temperature alarm",
+              "enum": {
+                  "0": "Ok",
+                  "1": "Warning",
+                  "2": "Alarm"
+              }
+          }
+       ]
+    },
+    "input-evcharger": {
+       "help": "<p>EV charger input node</p>",
+       "evcharger": [
+          {
+              "path": "/ProductId",
+              "type": "float",
+              "name": "Product ID"
+          },
+          {
+              "path": "/FirmwareVersion",
+              "type": "float",
+              "name": "Firmware version"
+          },
+          {
+              "path": "/Serial",
+              "type": "string",
+              "name": "Serial"
+          },
+          {
+              "path": "/Model",
+              "type": "float",
+              "name": "Model"
+          },
+          {
+              "path": "/Ac/Energy/Forward",
+              "type": "float",
+              "name": "Energy consumed by charger (kWh)"
+          },
+          {
+              "path": "/Ac/L1/Power",
+              "type": "float",
+              "name": "L1 Power (W)"
+          },
+          {
+              "path": "/Ac/L2/Power",
+              "type": "float",
+              "name": "L2 Power (W)"
+          },
+          {
+              "path": "/Ac/L3/Power",
+              "type": "float",
+              "name": "L3 Power (W)"
+          },
+          {
+              "path": "/Ac/Power",
+              "type": "float",
+              "name": "Total power (W)"
+          },
+          {
+              "path": "/ChargingTime",
+              "type": "float",
+              "name": "Charging time (seconds)"
+          },
+          {
+              "path": "/Current",
+              "type": "float",
+              "name": "Charge current (A)"
+          },
+          {
+              "path": "/Status",
+              "type": "enum",
+              "name": "Status",
+              "enum": {
+                  "0": "Disconnected",
+                  "1": "Connected",
+                  "2": "Charging",
+                  "3": "Charged",
+                  "4": "Waiting for sun",
+                  "5": "Waiting for RFID",
+                  "6": "Waiting for start",
+                  "7": "Low SOC",
+                  "8": "Ground fault",
+                  "9": "Welded contacts",
+                  "10": "CP Input shorted",
+                  "11": "Residual current detected",
+                  "12": "Under voltage detected",
+                  "13": "Overvoltage detected",
+                  "14": "Overheating detected"
+              }
+          }
+       ]
+    },
+    "input-genset": {
+       "help": "<p>This node is essentially an energy meter showing volts, amps, power, energy etc. It is comparable with the input-gridmeter.</p>",
+       "genset": [
+          {
+              "path": "/Ac/L1/Voltage",
+              "type": "float",
+              "name": "Phase 1 voltage (V AC)"
+          },
+          {
+              "path": "/Ac/L2/Voltage",
+              "type": "float",
+              "name": "Phase 2 voltage (V AC)"
+          },
+          {
+              "path": "/Ac/L3/Voltage",
+              "type": "float",
+              "name": "Phase 3 voltage (V AC)"
+          },
+          {
+              "path": "/Ac/L1/Current",
+              "type": "float",
+              "name": "Phase 1 current (A AC)"
+          },
+          {
+              "path": "/Ac/L2/Current",
+              "type": "float",
+              "name": "Phase 2 current (A AC)"
+          },
+          {
+              "path": "/Ac/L3/Current",
+              "type": "float",
+              "name": "Phase 3 current (A AC)"
+          },
+          {
+              "path": "/Ac/L1/Power",
+              "type": "float",
+              "name": "Phase 1 power (W)"
+          },
+          {
+              "path": "/Ac/L2/Power",
+              "type": "float",
+              "name": "Phase 2 power (W)"
+          },
+          {
+              "path": "/Ac/L3/Power",
+              "type": "float",
+              "name": "Phase 3 power (W)"
+          },
+          {
+              "path": "/Ac/L1/Frequency",
+              "type": "float",
+              "name": "Phase 1 frequency (Hz)"
+          },
+          {
+              "path": "/Ac/L2/Frequency",
+              "type": "float",
+              "name": "Phase 2 frequency (Hz)"
+          },
+          {
+              "path": "/Ac/L3/Frequency",
+              "type": "float",
+              "name": "Phase 3 frequency (Hz)"
+          },
+          {
+              "path": "/ProductId",
+              "type": "float",
+              "name": "Generator model"
+          },
+          {
+              "path": "/StatusCode",
+              "type": "enum",
+              "name": "Status",
+              "enum": {
+                  "0": "Standby",
+                  "1": "Startup 1",
+                  "2": "Startup 2",
+                  "3": "Startup 3",
+                  "4": "Startup 4",
+                  "5": "Startup 5",
+                  "6": "Startup 6",
+                  "7": "Startup 7",
+                  "8": "Running",
+                  "9": "Stopping",
+                  "10": "Error"
+              }
+          },
+          {
+              "path": "/ErrorCode",
+              "type": "enum",
+              "name": "Error",
+              "enum": {
+                  "0": "No error",
+                  "1": "AC voltage L1 too low",
+                  "2": "AC frequency L1 too low",
+                  "3": "AC current too low",
+                  "4": "AC power too low",
+                  "5": "Emergency stop",
+                  "6": "Servo current too low",
+                  "7": "Oil pressure too low",
+                  "8": "Engine temperature too low",
+                  "9": "Winding temperature too low",
+                  "10": "Exhaust temperature too low",
+                  "13": "Starter current too low",
+                  "14": "Glow current too low",
+                  "15": "Glow current too low",
+                  "16": "Fuel holding magnet current too low",
+                  "17": "Stop solenoid hold coil current too low",
+                  "18": "Stop solenoid pull coil current too low",
+                  "19": "Optional DC out current too low",
+                  "20": "5V output voltage too low",
+                  "21": "Boost output current too low",
+                  "22": "Panel supply current too high",
+                  "25": "Starter battery voltage too low",
+                  "26": "Startup aborted (rotation too low)",
+                  "28": "Rotation too low",
+                  "29": "Power contactor current too low",
+                  "30": "AC voltage L2 too low",
+                  "31": "AC frequency L2 too low",
+                  "32": "AC current L2 too low",
+                  "33": "AC power L2 too low",
+                  "34": "AC voltage L3 too low",
+                  "35": "AC frequency L3 too low",
+                  "36": "AC current L3 too low",
+                  "37": "AC power L3 too low",
+                  "62": "Fuel temperature too low",
+                  "63": "Fuel level too low",
+                  "65": "AC voltage L1 too high",
+                  "66": "AC frequency too high",
+                  "67": "AC current too high",
+                  "68": "AC power too high",
+                  "70": "Servo current too high",
+                  "71": "Oil pressure too high",
+                  "72": "Engine temperature too high",
+                  "73": "Winding temperature too high",
+                  "74": "Exhaust temperature too low",
+                  "77": "Starter current too low",
+                  "78": "Glow current too high",
+                  "79": "Glow current too high",
+                  "80": "Fuel holding magnet current too high",
+                  "81": "Stop solenoid hold coil current too high",
+                  "82": "Stop solenoid pull coil current too high",
+                  "83": "Optional DC out current too high",
+                  "84": "5V output voltage too high",
+                  "85": "Boost output current too high",
+                  "89": "Starter battery voltage too high",
+                  "90": "Startup aborted (rotation too high)",
+                  "92": "Rotation too high",
+                  "93": "Power contactor current too high",
+                  "94": "AC voltage L2 too high",
+                  "95": "AC frequency L2 too high",
+                  "96": "AC current L2 too high",
+                  "97": "AC power L2 too high",
+                  "98": "AC voltage L3 too high",
+                  "99": "AC frequency L3 too high",
+                  "100": "AC current L3 too high",
+                  "101": "AC power L3 too high",
+                  "126": "Fuel temperature too high",
+                  "127": "Fuel level too high",
+                  "130": "Lost control unit",
+                  "131": "Lost panel",
+                  "132": "Service needed",
+                  "133": "Lost 3-phase module",
+                  "134": "Lost AGT module",
+                  "135": "Synchronization failure",
+                  "137": "Intake airfilter",
+                  "139": "Lost sync. module",
+                  "140": "Load-balance failed",
+                  "141": "Sync-mode deactivated",
+                  "142": "Engine controller",
+                  "148": "Rotating field wrong",
+                  "149": "Fuel level sensor lost",
+                  "150": "Init failed",
+                  "151": "Watchdog",
+                  "152": "Out: winding",
+                  "153": "Out: exhaust",
+                  "154": "Out: Cyl. head",
+                  "155": "Inverter over temperature",
+                  "156": "Inverter overload",
+                  "157": "Inverter communication lost",
+                  "158": "Inverter sync failed",
+                  "159": "CAN communication lost",
+                  "160": "L1 overload",
+                  "161": "L2 overload",
+                  "162": "L3 overload",
+                  "163": "DC overload",
+                  "164": "DC overvoltage",
+                  "165": "Emergency stop",
+                  "166": "No connection"
+              }
+          },
+          {
+              "path": "/AutoStart",
+              "type": "enum",
+              "name": "Auto start",
+              "enum": {
+                  "0": "Disabled",
+                  "1": "Enabled"
+              }
+          },
+          {
+              "path": "/Engine/Load",
+              "type": "float",
+              "name": "Engine load (%)"
+          },
+          {
+              "path": "/Engine/Speed",
+              "type": "float",
+              "name": "Engine speed (RPM)"
+          },
+          {
+              "path": "/Engine/OperatingHours",
+              "type": "float",
+              "name": "Engine operating hours (s)"
+          },
+          {
+              "path": "/Engine/CoolantTemperature",
+              "type": "float",
+              "name": "Engine coolant temperature (Degrees celsius)"
+          },
+          {
+              "path": "/Engine/WindingTemperature",
+              "type": "float",
+              "name": "Engine winding temperature (Degrees celsius)"
+          },
+          {
+              "path": "/Engine/ExaustTemperature",
+              "type": "float",
+              "name": "Engine exhaust temperature (Degrees celsius)"
+          },
+          {
+              "path": "/StarterVoltage",
+              "type": "float",
+              "name": "Starter voltage (V DC)"
+          }
+       ]
+    },
+    "input-generator": {
+        "help": "<p>Generator input node for Fischer Panda generators. Also see <a href=\"https://github.com/victronenergy/venus/wiki/dbus#generator\">here</a> for more information.</p>",
+        "generator": [
+            {
+                "path": "/Generator0/RunningByConditionCode",
+                "type": "enum",
+                "name": "Condition that started the generator",
+                "enum": {
+                    "0": "Stopped",
+                    "1": "Manual",
+                    "2": "TestRun",
+                    "3": "LossOfComms",
+                    "4": "Soc",
+                    "5": "AcLoad",
+                    "6": "BatteryCurrent",
+                    "7": "BatteryVoltage",
+                    "8": "InverterTemperatur",
+                    "9": "InverterOverload",
+                    "10": "StopOnAc1"
+                }
+            },
+            {
+                "path": "/Generator0/Runtime",
+                "type": "float",
+                "name": "Runtime in seconds (seconds)"
+            },
+            {
+                "path": "/Generator0/Runtime",
+                "type": "float",
+                "name": "Runtime in seconds (seconds)"
+            },
+            {
+                "path": "/Generator0/State",
+                "type": "enum",
+                "name": "Generator start/stop state",
+                "enum": {
+                    "0": "Stopped",
+                    "1": "Running",
+                    "10": "Error"
+                }
+            },
+            {
+                "path": "/Generator0/Error",
+                "type": "enum",
+                "name": "Generator remote error",
+                "enum": {
+                    "0": "No Error",
+                    "1": "Remote disabled",
+                    "2": "Remote fault"
+                }
+            },
+            {
+                "path": "/Generator0/Alarms/NoGeneratorAtAcIn",
+                "type": "enum",
+                "name": "Generator not detected at AC input alarm",
+                "enum": {
+                    "0": "No alarm",
+                    "2": "Alarm"
+                }
+            }
+        ]
+    },
     "input-multi": {
         "help": "<p>This is the Multi RS input node.</p>",
         "multi": [
@@ -4034,149 +4509,6 @@
             }
         ]
     },
-    "output-vebus": {
-        "help": "<p>This output node is for writing to VE.Bus connected devices.</p>",
-        "vebus": [
-            {
-                "path": "/Mode",
-                "type": "enum",
-                "name": "Switch Position",
-                "enum": {
-                    "1": "Charger Only",
-                    "2": "Inverter Only",
-                    "3": "On",
-                    "4": "Off"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Ac/ActiveIn/CurrentLimit",
-                "type": "float",
-                "name": "Active input current limit (A)",
-                "writable": true
-            },
-            {
-                "path": "/Ac/In/1/CurrentLimit",
-                "type": "float",
-                "name": "Input 1 current limit (A)",
-                "writable": true
-            },
-            {
-                "path": "/Ac/In/2/CurrentLimit",
-                "type": "float",
-                "name": "Input 2 current limit (A)",
-                "writable": true
-            },
-            {
-                "path": "/Soc",
-                "type": "float",
-                "name": "VE.Bus state of charge (%)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L1/AcPowerSetpoint",
-                "type": "float",
-                "name": "ESS power setpoint phase 1 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L2/AcPowerSetpoint",
-                "type": "float",
-                "name": "ESS power setpoint phase 2 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L3/AcPowerSetpoint",
-                "type": "float",
-                "name": "ESS power setpoint phase 3 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/DoNotFeedInOvervoltage",
-                "type": "enum",
-                "name": "Feed DC overvoltage into grid",
-                "enum": {
-                    "0": "Feed in overvoltage",
-                    "1": "Do not feed in overvoltage"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L1/MaxFeedInPower",
-                "type": "float",
-                "name": "Maximum overvoltage feed-in power L1 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L2/MaxFeedInPower",
-                "type": "float",
-                "name": "Maximum overvoltage feed-in power L2 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L3/MaxFeedInPower",
-                "type": "float",
-                "name": "Maximum overvoltage feed-in power L3 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/TargetPowerIsMaxFeedIn",
-                "type": "enum",
-                "name": "AcPowerSetpoint acts as feed-in limit",
-                "enum": {
-                    "0": "AcPowerSetpoint interpreted normally",
-                    "1": "AcPowerSetpoint is OvervoltageFeedIn limit"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Hub4/DisableCharge",
-                "type": "enum",
-                "name": "ESS disable charge flag phase",
-                "enum": {
-                    "0": "Charge allowed",
-                    "1": "Charge disabled"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Hub4/DisableFeedIn",
-                "type": "enum",
-                "name": "ESS disable feedback flag phase",
-                "enum": {
-                    "0": "Feed in allowed",
-                    "1": "Feed in disabled"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Hub4/FixSolarOffsetTo100mV",
-                "type": "enum",
-                "name": "Solar offset voltage",
-                "enum": {
-                    "0": "OvervoltageFeedIn uses 1V offset",
-                    "1": "OvervoltageFeedIn uses 0.1V offset"
-                },
-                "writable": true
-            },
-            {
-                "path": "/SystemReset",
-                "type": "float",
-                "name": "VE.Bus Reset (1=VE.Bus reset)",
-                "writable": true
-            },
-            {
-                "path": "/PvInverter/Disable",
-                "type": "enum",
-                "name": "Disable PV inverter",
-                "enum": {
-                    "0": "PV enabled",
-                    "1": "PV disabled"
-                },
-                "writable": true
-            }
-        ]
-    },
     "output-inverter": {
         "help": "<p>This node can be used for controlling the inverter.</p>",
         "inverter": [
@@ -4435,5 +4767,43 @@
                 "writable": true
             }
         ]
+    },
+    "output-evcharger": {
+        "help": "<p>With this node the ev charger can be controlled.</p>",
+        "evcharger": [
+          {
+              "path": "/MaxCurrent",
+              "type": "float",
+              "name": "Maximum charge current (A)",
+              "writable": true
+          },
+          {
+              "path": "/Mode",
+              "type": "enum",
+              "name": "Mode",
+              "enum": {
+                  "0": "Manual",
+                  "1": "Auto"
+              },
+              "writable": true
+          },
+          {
+              "path": "/SetCurrent",
+              "type": "float",
+              "name": "Set charge current (manual mode) (A)",
+              "writable": true
+          },
+          {
+              "path": "/StartStop",
+              "type": "enum",
+              "name": "Start/stop charging (manual mode)",
+              "enum": {
+                  "0": "Stop",
+                  "1": "Start"
+              },
+              "writable": true
+          }
+        ]
     }
+ 
 }

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -1,4809 +1,4883 @@
 {
-    "input-dcsystem": {
-       "help": "<p>DC system input node is a DC measurement for loads in your system.</p>",
-       "dcsystem": [
-          {
-              "path": "/Dc/0/Voltage",
-              "type": "float",
-              "name": "Battery voltage (V DC)"
-          },
-          {
-              "path": "/Dc/0/Current",
-              "type": "float",
-              "name": "Battery current (A)"
-          },
-          {
-              "path": "/Dc/1/Voltage",
-              "type": "float",
-              "name": "Auxiliary voltage (V DC)"
-          },
-          {
-              "path": "/Dc/0/Temperature",
-              "type": "float",
-              "name": "Temperature (Degrees celsius)"
-          },
-          {
-              "path": "/History/EnergyOut",
-              "type": "float",
-              "name": "Total energy produced (kWh)"
-          },
-          {
-              "path": "/History/EnergyIn",
-              "type": "float",
-              "name": "Total energy consumed (kWh)"
-          },
-          {
-              "path": "/Alarms/LowVoltage",
-              "type": "enum",
-              "name": "Low voltage alarm",
-              "enum": {
-                  "0": "No alarm",
-                  "1": "Warning",
-                  "2": "Alarm"
-              }
-          },
-          {
-              "path": "/Alarms/HighVoltage",
-              "type": "enum",
-              "name": "High voltage alarm",
-              "enum": {
-                  "0": "No alarm",
-                  "1": "Warning",
-                  "2": "Alarm"
-              }
-          },
-          {
-              "path": "/Alarms/LowStarterVoltage",
-              "type": "enum",
-              "name": "Low auxiliary voltage alarm",
-              "enum": {
-                  "0": "Ok",
-                  "1": "Warning",
-                  "2": "Alarm"
-              }
-          },
-          {
-              "path": "/Alarms/HighStarterVoltage",
-              "type": "enum",
-              "name": "High auxiliary voltage alarm",
-              "enum": {
-                  "0": "Ok",
-                  "1": "Warning",
-                  "2": "Alarm"
-              }
-          },
-          {
-              "path": "/Alarms/LowTemperature",
-              "type": "enum",
-              "name": "Low temperature alarm",
-              "enum": {
-                  "0": "Ok",
-                  "1": "Warning",
-                  "2": "Alarm"
-              }
-          },
-          {
-              "path": "/Alarms/HighTemperature",
-              "type": "enum",
-              "name": "High temperature alarm",
-              "enum": {
-                  "0": "Ok",
-                  "1": "Warning",
-                  "2": "Alarm"
-              }
-          }
-       ]
-    },
-    "input-evcharger": {
-       "help": "<p>EV charger input node</p>",
-       "evcharger": [
-          {
-              "path": "/ProductId",
-              "type": "float",
-              "name": "Product ID"
-          },
-          {
-              "path": "/FirmwareVersion",
-              "type": "float",
-              "name": "Firmware version"
-          },
-          {
-              "path": "/Serial",
-              "type": "string",
-              "name": "Serial"
-          },
-          {
-              "path": "/Model",
-              "type": "float",
-              "name": "Model"
-          },
-          {
-              "path": "/Ac/Energy/Forward",
-              "type": "float",
-              "name": "Energy consumed by charger (kWh)"
-          },
-          {
-              "path": "/Ac/L1/Power",
-              "type": "float",
-              "name": "L1 Power (W)"
-          },
-          {
-              "path": "/Ac/L2/Power",
-              "type": "float",
-              "name": "L2 Power (W)"
-          },
-          {
-              "path": "/Ac/L3/Power",
-              "type": "float",
-              "name": "L3 Power (W)"
-          },
-          {
-              "path": "/Ac/Power",
-              "type": "float",
-              "name": "Total power (W)"
-          },
-          {
-              "path": "/ChargingTime",
-              "type": "float",
-              "name": "Charging time (seconds)"
-          },
-          {
-              "path": "/Current",
-              "type": "float",
-              "name": "Charge current (A)"
-          },
-          {
-              "path": "/Status",
-              "type": "enum",
-              "name": "Status",
-              "enum": {
-                  "0": "Disconnected",
-                  "1": "Connected",
-                  "2": "Charging",
-                  "3": "Charged",
-                  "4": "Waiting for sun",
-                  "5": "Waiting for RFID",
-                  "6": "Waiting for start",
-                  "7": "Low SOC",
-                  "8": "Ground fault",
-                  "9": "Welded contacts",
-                  "10": "CP Input shorted",
-                  "11": "Residual current detected",
-                  "12": "Under voltage detected",
-                  "13": "Overvoltage detected",
-                  "14": "Overheating detected"
-              }
-          }
-       ]
-    },
-    "input-genset": {
-       "help": "<p>This node is essentially an energy meter showing volts, amps, power, energy etc. It is comparable with the input-gridmeter.</p>",
-       "genset": [
-          {
-              "path": "/Ac/L1/Voltage",
-              "type": "float",
-              "name": "Phase 1 voltage (V AC)"
-          },
-          {
-              "path": "/Ac/L2/Voltage",
-              "type": "float",
-              "name": "Phase 2 voltage (V AC)"
-          },
-          {
-              "path": "/Ac/L3/Voltage",
-              "type": "float",
-              "name": "Phase 3 voltage (V AC)"
-          },
-          {
-              "path": "/Ac/L1/Current",
-              "type": "float",
-              "name": "Phase 1 current (A AC)"
-          },
-          {
-              "path": "/Ac/L2/Current",
-              "type": "float",
-              "name": "Phase 2 current (A AC)"
-          },
-          {
-              "path": "/Ac/L3/Current",
-              "type": "float",
-              "name": "Phase 3 current (A AC)"
-          },
-          {
-              "path": "/Ac/L1/Power",
-              "type": "float",
-              "name": "Phase 1 power (W)"
-          },
-          {
-              "path": "/Ac/L2/Power",
-              "type": "float",
-              "name": "Phase 2 power (W)"
-          },
-          {
-              "path": "/Ac/L3/Power",
-              "type": "float",
-              "name": "Phase 3 power (W)"
-          },
-          {
-              "path": "/Ac/L1/Frequency",
-              "type": "float",
-              "name": "Phase 1 frequency (Hz)"
-          },
-          {
-              "path": "/Ac/L2/Frequency",
-              "type": "float",
-              "name": "Phase 2 frequency (Hz)"
-          },
-          {
-              "path": "/Ac/L3/Frequency",
-              "type": "float",
-              "name": "Phase 3 frequency (Hz)"
-          },
-          {
-              "path": "/ProductId",
-              "type": "float",
-              "name": "Generator model"
-          },
-          {
-              "path": "/StatusCode",
-              "type": "enum",
-              "name": "Status",
-              "enum": {
-                  "0": "Standby",
-                  "1": "Startup 1",
-                  "2": "Startup 2",
-                  "3": "Startup 3",
-                  "4": "Startup 4",
-                  "5": "Startup 5",
-                  "6": "Startup 6",
-                  "7": "Startup 7",
-                  "8": "Running",
-                  "9": "Stopping",
-                  "10": "Error"
-              }
-          },
-          {
-              "path": "/ErrorCode",
-              "type": "enum",
-              "name": "Error",
-              "enum": {
-                  "0": "No error",
-                  "1": "AC voltage L1 too low",
-                  "2": "AC frequency L1 too low",
-                  "3": "AC current too low",
-                  "4": "AC power too low",
-                  "5": "Emergency stop",
-                  "6": "Servo current too low",
-                  "7": "Oil pressure too low",
-                  "8": "Engine temperature too low",
-                  "9": "Winding temperature too low",
-                  "10": "Exhaust temperature too low",
-                  "13": "Starter current too low",
-                  "14": "Glow current too low",
-                  "15": "Glow current too low",
-                  "16": "Fuel holding magnet current too low",
-                  "17": "Stop solenoid hold coil current too low",
-                  "18": "Stop solenoid pull coil current too low",
-                  "19": "Optional DC out current too low",
-                  "20": "5V output voltage too low",
-                  "21": "Boost output current too low",
-                  "22": "Panel supply current too high",
-                  "25": "Starter battery voltage too low",
-                  "26": "Startup aborted (rotation too low)",
-                  "28": "Rotation too low",
-                  "29": "Power contactor current too low",
-                  "30": "AC voltage L2 too low",
-                  "31": "AC frequency L2 too low",
-                  "32": "AC current L2 too low",
-                  "33": "AC power L2 too low",
-                  "34": "AC voltage L3 too low",
-                  "35": "AC frequency L3 too low",
-                  "36": "AC current L3 too low",
-                  "37": "AC power L3 too low",
-                  "62": "Fuel temperature too low",
-                  "63": "Fuel level too low",
-                  "65": "AC voltage L1 too high",
-                  "66": "AC frequency too high",
-                  "67": "AC current too high",
-                  "68": "AC power too high",
-                  "70": "Servo current too high",
-                  "71": "Oil pressure too high",
-                  "72": "Engine temperature too high",
-                  "73": "Winding temperature too high",
-                  "74": "Exhaust temperature too low",
-                  "77": "Starter current too low",
-                  "78": "Glow current too high",
-                  "79": "Glow current too high",
-                  "80": "Fuel holding magnet current too high",
-                  "81": "Stop solenoid hold coil current too high",
-                  "82": "Stop solenoid pull coil current too high",
-                  "83": "Optional DC out current too high",
-                  "84": "5V output voltage too high",
-                  "85": "Boost output current too high",
-                  "89": "Starter battery voltage too high",
-                  "90": "Startup aborted (rotation too high)",
-                  "92": "Rotation too high",
-                  "93": "Power contactor current too high",
-                  "94": "AC voltage L2 too high",
-                  "95": "AC frequency L2 too high",
-                  "96": "AC current L2 too high",
-                  "97": "AC power L2 too high",
-                  "98": "AC voltage L3 too high",
-                  "99": "AC frequency L3 too high",
-                  "100": "AC current L3 too high",
-                  "101": "AC power L3 too high",
-                  "126": "Fuel temperature too high",
-                  "127": "Fuel level too high",
-                  "130": "Lost control unit",
-                  "131": "Lost panel",
-                  "132": "Service needed",
-                  "133": "Lost 3-phase module",
-                  "134": "Lost AGT module",
-                  "135": "Synchronization failure",
-                  "137": "Intake airfilter",
-                  "139": "Lost sync. module",
-                  "140": "Load-balance failed",
-                  "141": "Sync-mode deactivated",
-                  "142": "Engine controller",
-                  "148": "Rotating field wrong",
-                  "149": "Fuel level sensor lost",
-                  "150": "Init failed",
-                  "151": "Watchdog",
-                  "152": "Out: winding",
-                  "153": "Out: exhaust",
-                  "154": "Out: Cyl. head",
-                  "155": "Inverter over temperature",
-                  "156": "Inverter overload",
-                  "157": "Inverter communication lost",
-                  "158": "Inverter sync failed",
-                  "159": "CAN communication lost",
-                  "160": "L1 overload",
-                  "161": "L2 overload",
-                  "162": "L3 overload",
-                  "163": "DC overload",
-                  "164": "DC overvoltage",
-                  "165": "Emergency stop",
-                  "166": "No connection"
-              }
-          },
-          {
-              "path": "/AutoStart",
-              "type": "enum",
-              "name": "Auto start",
-              "enum": {
-                  "0": "Disabled",
-                  "1": "Enabled"
-              }
-          },
-          {
-              "path": "/Engine/Load",
-              "type": "float",
-              "name": "Engine load (%)"
-          },
-          {
-              "path": "/Engine/Speed",
-              "type": "float",
-              "name": "Engine speed (RPM)"
-          },
-          {
-              "path": "/Engine/OperatingHours",
-              "type": "float",
-              "name": "Engine operating hours (s)"
-          },
-          {
-              "path": "/Engine/CoolantTemperature",
-              "type": "float",
-              "name": "Engine coolant temperature (Degrees celsius)"
-          },
-          {
-              "path": "/Engine/WindingTemperature",
-              "type": "float",
-              "name": "Engine winding temperature (Degrees celsius)"
-          },
-          {
-              "path": "/Engine/ExaustTemperature",
-              "type": "float",
-              "name": "Engine exhaust temperature (Degrees celsius)"
-          },
-          {
-              "path": "/StarterVoltage",
-              "type": "float",
-              "name": "Starter voltage (V DC)"
-          }
-       ]
-    },
-    "input-generator": {
-        "help": "<p>Generator input node for Fischer Panda generators. Also see <a href=\"https://github.com/victronenergy/venus/wiki/dbus#generator\">here</a> for more information.</p>",
-        "generator": [
-            {
-                "path": "/Generator0/RunningByConditionCode",
-                "type": "enum",
-                "name": "Condition that started the generator",
-                "enum": {
-                    "0": "Stopped",
-                    "1": "Manual",
-                    "2": "TestRun",
-                    "3": "LossOfComms",
-                    "4": "Soc",
-                    "5": "AcLoad",
-                    "6": "BatteryCurrent",
-                    "7": "BatteryVoltage",
-                    "8": "InverterTemperatur",
-                    "9": "InverterOverload",
-                    "10": "StopOnAc1"
-                }
-            },
-            {
-                "path": "/Generator0/Runtime",
-                "type": "float",
-                "name": "Runtime in seconds (seconds)"
-            },
-            {
-                "path": "/Generator0/Runtime",
-                "type": "float",
-                "name": "Runtime in seconds (seconds)"
-            },
-            {
-                "path": "/Generator0/State",
-                "type": "enum",
-                "name": "Generator start/stop state",
-                "enum": {
-                    "0": "Stopped",
-                    "1": "Running",
-                    "10": "Error"
-                }
-            },
-            {
-                "path": "/Generator0/Error",
-                "type": "enum",
-                "name": "Generator remote error",
-                "enum": {
-                    "0": "No Error",
-                    "1": "Remote disabled",
-                    "2": "Remote fault"
-                }
-            },
-            {
-                "path": "/Generator0/Alarms/NoGeneratorAtAcIn",
-                "type": "enum",
-                "name": "Generator not detected at AC input alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            }
-        ]
-    },
-    "input-multi": {
-        "help": "<p>This is the Multi RS input node.</p>",
-        "multi": [
-            {
-                "path" : "/Ac/In/1/L1/V",
-                "type" : "float",
-                "name" : "Input voltage phase 1 (V AC)"
-            },
-            {
-                "path" : "/Ac/In/1/L2/V",
-                "type" : "float",
-                "name" : "Input voltage phase 2 (V AC)"
-            },
-            {
-                "path" : "/Ac/In/1/L3/V",
-                "type" : "float",
-                "name" : "Input voltage phase 3 (V AC)"
-            },
-            {
-                "path" : "/Ac/In/1/L1/I",
-                "type" : "float",
-                "name" : "Input current phase 1 (A AC)"
-            },
-            {
-                "path" : "/Ac/In/1/L2/I",
-                "type" : "float",
-                "name" : "Input current phase 2 (A AC)"
-            },
-            {
-                "path" : "/Ac/In/1/L3/I",
-                "type" : "float",
-                "name" : "Input current phase 3 (A AC)"
-            },
-            {
-                "path" : "/Ac/In/1/L1/P",
-                "type" : "float",
-                "name" : "Input power phase 1 (W)"
-            },
-            {
-                "path" : "/Ac/In/1/L2/P",
-                "type" : "float",
-                "name" : "Input power phase 2 (W)"
-            },
-            {
-                "path" : "/Ac/In/1/L3/P",
-                "type" : "float",
-                "name" : "Input power phase 3 (W)"
-            },
-            {
-                "path" : "/Ac/In/1/L1/F",
-                "type" : "float",
-                "name" : "Input frequency (Hz)"
-            },
-            {
-                "path" : "/Ac/Out/L1/V",
-                "type" : "float",
-                "name" : "Output voltage phase 1 (V AC)"
-            },
-            {
-                "path" : "/Ac/Out/L2/V",
-                "type" : "float",
-                "name" : "Output voltage phase 2 (V AC)"
-            },
-            {
-                "path" : "/Ac/Out/L3/V",
-                "type" : "float",
-                "name" : "Output voltage phase 3 (V AC)"
-            },
-            {
-                "path" : "/Ac/Out/L1/I",
-                "type" : "float",
-                "name" : "Output current phase 1 (A AC)"
-            },
-            {
-                "path" : "/Ac/Out/L2/I",
-                "type" : "float",
-                "name" : "Output current phase 2 (A AC)"
-            },
-            {
-                "path" : "/Ac/Out/L3/I",
-                "type" : "float",
-                "name" : "Output current phase 3 (A AC)"
-            },
-            {
-                "path" : "/Ac/Out/L1/P",
-                "type" : "float",
-                "name" : "Output power phase 1 (W)"
-            },
-            {
-                "path" : "/Ac/Out/L2/P",
-                "type" : "float",
-                "name" : "Output power phase 2 (W)"
-            },
-            {
-                "path" : "/Ac/Out/L3/P",
-                "type" : "float",
-                "name" : "Output power phase 3 (W)"
-            },
-            {
-                "path" : "/Ac/Out/L1/F",
-                "type" : "float",
-                "name" : "Output frequency (Hz)"
-            },
-            {
-                "path" : "/Ac/In/1/Type",
-                "type" : "enum",
-                "name" : "AC input 1 source type",
-                "enum" : {
-                    "0" : "Unused",
-                    "1" : "Grid",
-                    "2" : "Genset",
-                    "3" : "Shore"
-                }
-            },
-            {
-                "path" : "/Ac/In/2/Type",
-                "type" : "enum",
-                "name" : "AC input 2 source type",
-                "enum" : {
-                    "0" : "Unused",
-                    "1" : "Grid",
-                    "2" : "Genset",
-                    "3" : "Shore"
-                }
-            },
-            {
-                "path" : "/Ac/NumberOfPhases",
-                "type" : "float",
-                "name" : "Phase count (count)"
-            },
-            {
-                "path" : "/Ac/ActiveIn/ActiveInput",
-                "type" : "enum",
-                "name" : "Active AC input",
-                "enum" : {
-                    "0" : "AC Input 1",
-                    "1" : "AC Input 2",
-                    "240" : "Disconnected"
-                }
-            },
-            {
-                "path" : "/Dc/0/Voltage",
-                "type" : "float",
-                "name" : "Battery voltage (V DC)"
-            },
-            {
-                "path" : "/Dc/0/Current",
-                "type" : "float",
-                "name" : "Battery current (A DC)"
-            },
-            {
-                "path" : "/Dc/0/Temperature",
-                "type" : "float",
-                "name" : "Battery temperature (Degrees celsius)"
-            },
-            {
-                "path" : "/Soc",
-                "type" : "float",
-                "name" : "Battery State of Charge (%)"
-            },
-            {
-                "path" : "/State",
-                "type" : "enum",
-                "name" : "Inverter/Charger state",
-                "enum" : {
-                    "0" : "Off",
-                    "1" : "Low Power",
-                    "2" : "Fault",
-                    "3" : "Bulk",
-                    "4" : "Absorption",
-                    "5" : "Float",
-                    "6" : "Storage",
-                    "7" : "Equalize",
-                    "8" : "Passthru",
-                    "9" : "Inverting",
-                    "10" : "Power assist",
-                    "11" : "Power supply",
-                    "252" : "Bulk protection"
-                }
-            },
-            {
-                "path" : "/Alarms/HighTemperature",
-                "type" : "enum",
-                "name" : "Temperature alarm",
-                "enum" : {
-                    "0" : "Ok",
-                    "1" : "Warning",
-                    "2" : "Alarm"
-                }
-            },
-            {
-                "path" : "/Alarms/HighVoltage",
-                "type" : "enum",
-                "name" : "High voltage alarm",
-                "enum" : {
-                    "0" : "Ok",
-                    "1" : "Warning",
-                    "2" : "Alarm"
-                }
-            },
-            {
-                "path" : "/Alarms/HighVoltageAcOut",
-                "type" : "enum",
-                "name" : "High AC-Out voltage alarm",
-                "enum" : {
-                    "0" : "Ok",
-                    "1" : "Warning",
-                    "2" : "Alarm"
-                }
-            },
-            {
-                "path" : "/Alarms/LowTemperature",
-                "type" : "enum",
-                "name" : "Low battery temperature alarm",
-                "enum" : {
-                    "0" : "Ok",
-                    "1" : "Warning",
-                    "2" : "Alarm"
-                }
-            },
-            {
-                "path" : "/Alarms/LowVoltage",
-                "type" : "enum",
-                "name" : "Low voltage alarm",
-                "enum" : {
-                    "0" : "Ok",
-                    "1" : "Warning",
-                    "2" : "Alarm"
-                }
-            },
-            {
-                "path" : "/Alarms/LowVoltageAcOut",
-                "type" : "enum",
-                "name" : "Low AC-Out voltage alarm",
-                "enum" : {
-                    "0" : "Ok",
-                    "1" : "Warning",
-                    "2" : "Alarm"
-                }
-            },
-            {
-                "path" : "/Alarms/Overload",
-                "type" : "enum",
-                "name" : "Overload alarm",
-                "enum" : {
-                    "0" : "Ok",
-                    "1" : "Warning",
-                    "2" : "Alarm"
-                }
-            },
-            {
-                "path" : "/Alarms/Ripple",
-                "type" : "enum",
-                "name" : "High DC ripple alarm",
-                "enum" : {
-                    "0" : "Ok",
-                    "1" : "Warning",
-                    "2" : "Alarm"
-                }
-            },
-            {
-                "path" : "/Yield/Power",
-                "type" : "float",
-                "name" : "PV power (W)"
-            },
-            {
-                "path" : "/Yield/User",
-                "type" : "float",
-                "name" : "User yield (kWh)"
-            },
-            {
-                "path" : "/Relay/0/State",
-                "type" : "enum",
-                "name" : "Relay on the Multi RS",
-                "enum" : {
-                    "0" : "Open",
-                    "1" : "Closed"
-                }
-            },
-            {
-                "path" : "/MppOperationMode",
-                "type" : "enum",
-                "name" : "MPP operation mode",
-                "enum" : {
-                    "0" : "Off",
-                    "1" : "Voltage/current limited",
-                    "2" : "MPPT active",
-                    "255" : "Not available"
-                }
-            },
-            {
-                "path" : "/Pv/V",
-                "type" : "float",
-                "name" : "PV voltage (V DC)"
-            },
-            {
-                "path" : "/ErrorCode",
-                "type" : "enum",
-                "name" : "Error code",
-                "enum" : {
-                    "0" : "No error",
-                    "1" : "Battery temperature too high",
-                    "2" : "Battery voltage too high",
-                    "3" : "Battery temperature sensor miswired (+)",
-                    "4" : "Battery temperature sensor miswired (-)",
-                    "5" : "Battery temperature sensor disconnected",
-                    "6" : "Battery voltage sense miswired (+)",
-                    "7" : "Battery voltage sense miswired (-)",
-                    "8" : "Battery voltage sense disconnected",
-                    "9" : "Battery voltage wire losses too high",
-                    "17" : "Charger temperature too high",
-                    "18" : "Charger over-current",
-                    "19" : "Charger current polarity reversed",
-                    "20" : "Bulk time limit reached",
-                    "22" : "Charger temperature sensor miswired",
-                    "23" : "Charger temperature sensor disconnected",
-                    "34" : "Input current too high"
-                }
-            },
-            {
-                "path" : "/Energy/AcIn1ToAcOut",
-                "type" : "float",
-                "name" : "Energy from AC-in-1 to AC-out (kWh)"
-            },
-            {
-                "path" : "/Energy/AcIn1ToInverter",
-                "type" : "float",
-                "name" : "Energy from AC-in-1 to battery (kWh)"
-            },
-            {
-                "path" : "/Energy/AcIn2ToAcOut",
-                "type" : "float",
-                "name" : "Energy from AC-in-2 to AC-out (kWh)"
-            },
-            {
-                "path" : "/Energy/AcIn2ToInverter",
-                "type" : "float",
-                "name" : "Energy from AC-in-2 to battery (kWh)"
-            },
-            {
-                "path" : "/Energy/AcOutToAcIn1",
-                "type" : "float",
-                "name" : "Energy from AC-out to AC-in-1 (kWh)"
-            },
-            {
-                "path" : "/Energy/AcOutToAcIn2",
-                "type" : "float",
-                "name" : "Energy from AC-out to AC-in-2 (kWh)"
-            },
-            {
-                "path" : "/Energy/InverterToAcIn1",
-                "type" : "float",
-                "name" : "Energy from battery to AC-in-1 (kWh)"
-            },
-            {
-                "path" : "/Energy/InverterToAcIn2",
-                "type" : "float",
-                "name" : "Energy from battery to AC-in-2 (kWh)"
-            },
-            {
-                "path" : "/Energy/InverterToAcOut",
-                "type" : "float",
-                "name" : "Energy from battery to AC-out (kWh)"
-            },
-            {
-                "path" : "/Energy/OutToInverter",
-                "type" : "float",
-                "name" : "Energy from AC-out to battery (kWh)"
-            },
-            {
-                "path" : "/Energy/SolarToAcIn1",
-                "type" : "float",
-                "name" : "Energy from solar to AC-in-1 (kWh)"
-            },
-            {
-                "path" : "/Energy/SolarToAcIn2",
-                "type" : "float",
-                "name" : "Energy from solar to AC-in-2 (kWh)"
-            },
-            {
-                "path" : "/Energy/SolarToAcOut",
-                "type" : "float",
-                "name" : "Energy from solar to AC-out (kWh)"
-            },
-            {
-                "path" : "/Energy/SolarToBattery",
-                "type" : "float",
-                "name" : "Energy from solar to battery (kWh)"
-            }
-        ]
-    },
-    "input-acload": {
-      "help": "<p>This node allows for AC load monitoring. Measuring can be done by using an energy meter and assigning it the 'ac load' role.</p>",
-      "acload": [
-            {
-                "path" : "/Serial",
-                "type" : "string",
-                "name" : "Serial number"
-            },
-            {
-                "path" : "/Ac/L1/Power",
-                "type" : "float",
-                "name" : "L1 Power (W)"
-            },
-            {
-                "path" : "/Ac/L2/Power",
-                "type" : "float",
-                "name" : "L2 Power (W)"
-            },
-            {
-                "path" : "/Ac/L3/Power",
-                "type" : "float",
-                "name" : "L3 Power (W)"
-            },
-            {
-                "path" : "/Ac/L1/Voltage",
-                "type" : "float",
-                "name" : "L1 Voltage (V AC)"
-            },
-            {
-                "path" : "/Ac/L1/Current",
-                "type" : "float",
-                "name" : "L1 Current (A)"
-            },
-            {
-                "path" : "/Ac/L2/Voltage",
-                "type" : "float",
-                "name" : "L2 Voltage (V AC)"
-            },
-            {
-                "path" : "/Ac/L2/Current",
-                "type" : "float",
-                "name" : "L2 Current (A)"
-            },
-            {
-                "path" : "/Ac/L3/Voltage",
-                "type" : "float",
-                "name" : "L3 Voltage (V AC)"
-            },
-            {
-                "path" : "/Ac/L3/Current",
-                "type" : "float",
-                "name" : "L3 Current (A)"
-            },
-            {
-                "path" : "/Ac/L1/Energy/Forward",
-                "type" : "float",
-                "name" : "L1 Energy (kWh)"
-            },
-            {
-                "path" : "/Ac/L2/Energy/Forward",
-                "type" : "float",
-                "name" : "L2 Energy (kWh)"
-            },
-            {
-                "path" : "/Ac/L3/Energy/Forward",
-                "type" : "float",
-                "name" : "L3 Energy (kWh)"
-            }
-      ]
-    },
-    "input-digitalinput": {
-        "help": "<p>With this node it is possible to read the digital inputs from the Venus device. The node only shows the enabled digital inputs, so first make sure to enable the input from the Venus OS GUI (<i>Settings -> I/O -> digital inputs</i>) for the desired readout.</p><p>Depending on the selected type of input, different measurements become available.</p><p>Also see the section on <a href=\"https://www.victronenergy.com/media/pg/Cerbo_GX/en/digital-inputs.html\">digital inputs</a> in the Cerbo GX manual.</p>",
-        "pulsemeter": [
-            {
-                "path": "/Aggregate",
-                "type": "float",
-                "name": "Pulse meter aggregate"
-            },
-            {
-                "path": "/Count",
-                "type": "float",
-                "name": "Pulse meter count"
-            }
-        ],
-        "digitalinput": [
-            {
-                "path": "/ProductId",
-                "type": "string",
-                "name": "Digital input product id"
-            },
-            {
-                "path": "/Alarm",
-                "type": "enum",
-                "name": "Digital input alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/State",
-                "type": "enum",
-                "name": "Digital input state",
-                "enum": {
-                    "0": "low",
-                    "1": "high",
-                    "2": "off",
-                    "3": "on",
-                    "4": "no",
-                    "5": "yes",
-                    "6": "open",
-                    "7": "closed",
-                    "8": "ok",
-                    "9": "alarm",
-                    "10": "running",
-                    "11": "stopped"
-                }
-            },
-            {
-                "path": "/Count",
-                "type": "float",
-                "name": "Digital input count"
-            },
-            {
-                "path": "/Type",
-                "type": "enum",
-                "name": "Digital input type",
-                "enum": {
-                    "0": "Disabled",
-                    "1": "Pulse meter",
-                    "2": "Door sensor",
-                    "3": "Bilge pump",
-                    "4": "Bilge alarm",
-                    "5": "Burglar alarm",
-                    "6": "Smoke alarm",
-                    "7": "Fire alarm",
-                    "8": "CO2 alarm",
-                    "9": "Generic input"
-                }
-            }
-        ]
-    },
-    "input-tank": {
-        "help": "<p>The input-tank node is for retrieving tank level sensor information.</p><p>Also see the <a href=\"https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-e4027d37-78e0-4433-1be4-3252d3b79152\">manual</a> for more information.</p>",
-        "tank": [
-            {
-                "path": "/Capacity",
-                "type": "float",
-                "name": "Tank capacity (m3)"
-            },
-            {
-                "path": "/Remaining",
-                "type": "float",
-                "name": "Fluid remaining (m3)"
-            },
-            {
-                "path": "/Level",
-                "type": "float",
-                "name": "Tank level (%)"
-            },
-            {
-                "path": "/Status",
-                "type": "enum",
-                "name": "Tank sensor status",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Disconnected",
-                    "2": "Short circuited",
-                    "3": "Unknown"
-                }
-            },
-            {
-                "path": "/FluidType",
-                "type": "enum",
-                "name": "Fluid type",
-                "enum": {
-                    "0": "Fuel",
-                    "1": "Fresh water",
-                    "2": "Waste water",
-                    "3": "Live well",
-                    "4": "Oil",
-                    "5": "Black water (sewage)"
-                }
-            },
-            {
-                "path": "/Standard",
-                "type": "enum",
-                "name": "Standard",
-                "enum": {
-                    "0": "European",
-                    "1": "USA"
-                }
-            },
-            {
-                "path": "/ProductId",
-                "type": "float",
-                "name": "Product ID"
-            }
-        ]
-    },
-    "input-temperature": {
-        "help": "<p>Like the other nodes, the <b>input-temperature</b> node reads the temperate information from the dbus. This means that source of the temperature sensor can obtain its information from different sources (e.g. directly connected probe or Bluetooth connected Ruuvi tag).</p><p>See the <a href=\"https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-4d5df29c-761e-cfcc-9e2c-8230f126e7bb\">manual</a> for information on connecting a temperature sensor.</p>",
-        "temperature": [
-            {
-                "path": "/Temperature",
-                "type": "float",
-                "name": "Temperature (C)"
-            },
-            {
-                "path": "/Status",
-                "type": "enum",
-                "name": "Sensor status",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Disconnected",
-                    "2": "Short circuited",
-                    "3": "Reverse polarity",
-                    "4": "Unknown"
-                }
-            },
-            {
-                "path": "/TemperatureType",
-                "type": "enum",
-                "name": "Sensor type",
-                "enum": {
-                    "0": "Battery",
-                    "1": "Fridge",
-                    "2": "Generic"
-                }
-            },
-            {
-                "path": "/Humidity",
-                "type": "float",
-                "name": "Humidity (%)"
-            },
-            {
-                "path": "/Pressure",
-                "type": "float",
-                "name": "Pressure (kPa)"
-            },
-            {
-                "path": "/BatteryVoltage",
-                "type": "float",
-                "name": "Sensor battery voltage (V)"
-            },
-            {
-                "path": "/AccelX",
-                "type": "float",
-                "name": "Acceleration X (g)"
-            },
-            {
-                "path": "/AccelY",
-                "type": "float",
-                "name": "Acceleration Y (g)"
-            },
-            {
-                "path": "/AccelZ",
-                "type": "float",
-                "name": "Acceleration Z (g)"
-            },
-            {
-                "path": "/ProductId",
-                "type": "float",
-                "name": "Product ID"
-            },
-            {
-                "path": "/Scale",
-                "type": "float",
-                "name": "Temperature scale factor"
-            },
-            {
-                "path": "/Offset",
-                "type": "float",
-                "name": "Temperature offset"
-            }
-        ]
-    },
-    "input-inverter": {
-        "help": "<p>This node is for reading from an inverter.</p>",
-        "inverter": [
-            {
-                "path": "/Dc/0/Voltage",
-                "type": "float",
-                "name": "Input voltage (V)"
-            },
-            {
-                "path": "/Dc/0/Current",
-                "type": "float",
-                "name": "Battery current (A DC)"
-            },
-            {
-                "path": "/Ac/Out/L1/V",
-                "type": "float",
-                "name": "Output voltage (V)"
-            },
-            {
-                "path": "/Ac/Out/L1/I",
-                "type": "float",
-                "name": "Output current (A)"
-            },
-            {
-                "path": "/Ac/Out/L1/P",
-                "type": "float",
-                "name": "Output power (W AC)"
-            },
-            {
-                "path": "/Mode",
-                "type": "enum",
-                "name": "Mode",
-                "enum": {
-                    "2": "Inverter on",
-                    "4": "Off",
-                    "5": "Low Power/ECO"
-                }
-            },
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            },
-            {
-                "path": "/State",
-                "type": "enum",
-                "name": "State",
-                "enum": {
-                    "0": "Off",
-                    "1": "Low Power",
-                    "2": "Fault",
-                    "9": "Inverting"
-                }
-            },
-            {
-                "path": "/Alarms/HighTemperature",
-                "type": "enum",
-                "name": "High temperature alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighVoltage",
-                "type": "enum",
-                "name": "High battery voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighVoltageAcOut",
-                "type": "enum",
-                "name": "High AC-Out voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowTemperature",
-                "type": "enum",
-                "name": "Low temperature alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowVoltage",
-                "type": "enum",
-                "name": "Low battery voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowVoltageAcOut",
-                "type": "enum",
-                "name": "Low AC-Out voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/Overload",
-                "type": "enum",
-                "name": "Overload alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/Ripple",
-                "type": "enum",
-                "name": "Ripple alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/FirmwareVersion",
-                "type": "float",
-                "name": "Firmware version"
-            },
-            {
-                "path": "/ProductId",
-                "type": "float",
-                "name": "Inverter model"
-            },
-            {
-                "path": "/Energy/InverterToAcOut",
-                "type": "float",
-                "name": "Energy from battery to AC-out (kWh)"
-            },
-            {
-                "path": "/Energy/OutToInverter",
-                "type": "float",
-                "name": "Energy from AC-out to battery (kWh)"
-            },
-            {
-                "path": "/Energy/SolarToAcOut",
-                "type": "float",
-                "name": "Energy from solar to AC-out (kWh)"
-            },
-            {
-                "path": "/Energy/SolarToBattery",
-                "type": "float",
-                "name": "Energy from solar to battery (kWh)"
-            },
-            {
-                "path": "/Pv/V",
-                "type": "float",
-                "name": "PV voltage (for single tracker units) (V DC)"
-            },
-            {
-                "path": "/Pv/0/V",
-                "type": "float",
-                "name": "PV voltage for tracker 0 (V DC)"
-            },
-            {
-                "path": "/Pv/1/V",
-                "type": "float",
-                "name": "PV voltage for tracker 1 (V DC)"
-            },
-            {
-                "path": "/Pv/2/V",
-                "type": "float",
-                "name": "PV voltage for tracker 2 (V DC)"
-            },
-            {
-                "path": "/Pv/3/V",
-                "type": "float",
-                "name": "PV voltage for tracker 3 (V DC)"
-            },
-            {
-                "path": "/Pv/0/P",
-                "type": "float",
-                "name": "PV power for tracker 0 (W)"
-            },
-            {
-                "path": "/Pv/1/P",
-                "type": "float",
-                "name": "PV power for tracker 1 (W)"
-            },
-            {
-                "path": "/Pv/2/P",
-                "type": "float",
-                "name": "PV power for tracker 2 (W)"
-            },
-            {
-                "path": "/Pv/3/P",
-                "type": "float",
-                "name": "PV power for tracker 3 (W)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/0/Yield",
-                "type": "float",
-                "name": "Yield today for today on tracker 0 (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/1/Yield",
-                "type": "float",
-                "name": "Yield today for today on tracker 1 (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/2/Yield",
-                "type": "float",
-                "name": "Yield today for today on tracker 2 (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/3/Yield",
-                "type": "float",
-                "name": "Yield today for today on tracker 3 (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/0/Yield",
-                "type": "float",
-                "name": "Yield today for yesterday on tracker 0 (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/1/Yield",
-                "type": "float",
-                "name": "Yield today for yesterday on tracker 1 (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/2/Yield",
-                "type": "float",
-                "name": "Yield today for yesterday on tracker 2 (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/3/Yield",
-                "type": "float",
-                "name": "Yield today for yesterday on tracker 3 (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/0/MaxPower",
-                "type": "float",
-                "name": "Maximum power for today on tracker 0 (W)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/1/MaxPower",
-                "type": "float",
-                "name": "Maximum power for today on tracker 1 (W)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/2/MaxPower",
-                "type": "float",
-                "name": "Maximum power for today on tracker 2 (W)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/3/MaxPower",
-                "type": "float",
-                "name": "Maximum power for today on tracker 3 (W)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/0/MaxPower",
-                "type": "float",
-                "name": "Maximum power for yesterday on tracker 0 (W)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/1/MaxPower",
-                "type": "float",
-                "name": "Maximum power for yesterday on tracker 1 (W)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/2/MaxPower",
-                "type": "float",
-                "name": "Maximum power for yesterday on tracker 2 (W)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/3/MaxPower",
-                "type": "float",
-                "name": "Maximum power for yesterday on tracker 3 (W)"
-            }
-        ]
-    },
-    "input-pvinverter": {
-        "help": "<p>This node is for obtaining information from the PV inverter.</p>",
-        "pvinverter": [
-            {
-                "path": "/Ac/L1/Voltage",
-                "type": "float",
-                "name": "L1 Voltage (V)"
-            },
-            {
-                "path": "/Ac/L1/Current",
-                "type": "float",
-                "name": "L1 Current (A)"
-            },
-            {
-                "path": "/Ac/L1/Power",
-                "type": "float",
-                "name": "L1 Power (W)"
-            },
-            {
-                "path": "/Ac/L1/Energy/Forward",
-                "type": "float",
-                "name": "L1 Energy (kWh)"
-            },
-            {
-                "path": "/Ac/L2/Voltage",
-                "type": "float",
-                "name": "L2 Voltage (V)"
-            },
-            {
-                "path": "/Ac/L2/Current",
-                "type": "float",
-                "name": "L2 Current (A)"
-            },
-            {
-                "path": "/Ac/L2/Power",
-                "type": "float",
-                "name": "L2 Power (W)"
-            },
-            {
-                "path": "/Ac/L2/Energy/Forward",
-                "type": "float",
-                "name": "L2 Energy (kWh)"
-            },
-            {
-                "path": "/Ac/L3/Voltage",
-                "type": "float",
-                "name": "L3 Voltage (V)"
-            },
-            {
-                "path": "/Ac/L3/Current",
-                "type": "float",
-                "name": "L3 Current (A)"
-            },
-            {
-                "path": "/Ac/L3/Power",
-                "type": "float",
-                "name": "L3 Power (W)"
-            },
-            {
-                "path": "/Ac/L3/Energy/Forward",
-                "type": "float",
-                "name": "L3 Energy (kWh)"
-            },
-            {
-                "path": "/StatusCode",
-                "type": "enum",
-                "name": "Status",
-                "enum": {
-                    "0": "Startup 0",
-                    "1": "Startup 1",
-                    "2": "Startup 2",
-                    "3": "Startup 3",
-                    "4": "Startup 4",
-                    "5": "Startup 5",
-                    "6": "Startup 6",
-                    "7": "Running",
-                    "8": "Standby",
-                    "9": "Boot loading",
-                    "10": "Error",
-                    "11": "Running (MPPT)",
-                    "12": "Running (Throttled)"
-                }
-            },
-            {
-                "path": "/ErrorCode",
-                "type": "enum",
-                "name": "Error",
-                "enum": {
-                    "0": "No Error"
-                }
-            },
-            {
-                "path": "/Ac/Energy/Forward",
-                "type": "float",
-                "name": "Total energy (kWh)"
-            },
-            {
-                "path": "/Ac/Power",
-                "type": "float",
-                "name": "Total Power (W)"
-            },
-            {
-                "path": "/Ac/MaxPower",
-                "type": "float",
-                "name": "Maximum Power Capacity (kW)"
-            },
-            {
-                "path": "/Serial",
-                "type": "string",
-                "name": "Serial"
-            },
-            {
-                "path": "/Position",
-                "type": "enum",
-                "name": "Position",
-                "enum": {
-                    "0": "AC input 1",
-                    "1": "AC output",
-                    "2": "AC input 2"
-                }
-            }
-        ]
-    },
-    "input-accharger": {
-        "help": "<p>The AC charger can be read with this node.</p>",
-        "charger": [
-            {
-                "path": "/Dc/0/Voltage",
-                "type": "float",
-                "name": "Output 1 - voltage (V)"
-            },
-            {
-                "path": "/Dc/0/Current",
-                "type": "float",
-                "name": "Output 1 - current (A)"
-            },
-            {
-                "path": "/Dc/0/Temperature",
-                "type": "float",
-                "name": "Output 1 - temperature (C)"
-            },
-            {
-                "path": "/Dc/1/Voltage",
-                "type": "float",
-                "name": "Output 2 - voltage (V)"
-            },
-            {
-                "path": "/Dc/1/Current",
-                "type": "float",
-                "name": "Output 2 - current (A)"
-            },
-            {
-                "path": "/Dc/1/Temperature",
-                "type": "float",
-                "name": "Battery 1 temperature (C)"
-            },
-            {
-                "path": "/Dc/2/Voltage",
-                "type": "float",
-                "name": "Output 3 - voltage (V)"
-            },
-            {
-                "path": "/Dc/2/Current",
-                "type": "float",
-                "name": "Output 3 - current (A)"
-            },
-            {
-                "path": "/Dc/2/Temperature",
-                "type": "float",
-                "name": "Battery 2 temperature (C)"
-            },
-            {
-                "path": "/Ac/In/L1/I",
-                "type": "float",
-                "name": "AC Current (A)"
-            },
-            {
-                "path": "/Ac/In/L1/P",
-                "type": "float",
-                "name": "AC Power (W)"
-            },
-            {
-                "path": "/Ac/In/CurrentLimit",
-                "type": "float",
-                "name": "AC Current limit (A)"
-            },
-            {
-                "path": "/Mode",
-                "type": "enum",
-                "name": "Charger on/off",
-                "enum": {
-                    "1": "On",
-                    "4": "Off"
-                }
-            },
-            {
-                "path": "/State",
-                "type": "enum",
-                "name": "Charge state",
-                "enum": {
-                    "0": "Off",
-                    "2": "Fault",
-                    "3": "Bulk",
-                    "4": "Absorption",
-                    "5": "Float",
-                    "6": "Storage",
-                    "7": "Equalize",
-                    "11": "Power supply mode",
-                    "246": "Repeated absorption",
-                    "247": "Equalize",
-                    "248": "Battery safe"
-                }
-            },
-            {
-                "path": "/ErrorCode",
-                "type": "enum",
-                "name": "Error",
-                "enum": {
-                    "0": "No error",
-                    "1": "Err 1: Battery temperature too high",
-                    "2": "Err 2: Battery voltage too high",
-                    "3": "Err 3: Battery temperature sensor miswired (+)",
-                    "4": "Err 3: Battery temperature sensor miswired (-)",
-                    "5": "Err 5: Battery temperature sensor disconnected",
-                    "6": "Err 6: Battery voltage sense miswired (+)",
-                    "7": "Err 7: Battery voltage sense miswired (-)",
-                    "8": "Err 8: Battery voltage sense disconnected",
-                    "9": "Err 9: Battery voltage wire losses too high",
-                    "17": "Err 17: Charger temperature too high",
-                    "18": "Err 18: Charger over-current",
-                    "19": "Err 19: Charger current polarity reversed",
-                    "20": "Err 20: Bulk time limit reached",
-                    "22": "Err 22: Charger temperature sensor miswired",
-                    "23": "Err 23: Charger temperature sensor disconnected",
-                    "34": "Err 34: Input current too high",
-                    "67": "Err 67: No BMS"
-                }
-            },
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay on the charger",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            },
-            {
-                "path": "/Alarms/LowVoltage",
-                "type": "enum",
-                "name": "Low voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighVoltage",
-                "type": "enum",
-                "name": "High voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/NrOfOutputs",
-                "type": "float",
-                "name": "Number of charger outputs"
-            }
-        ]
-    },
-    "input-solarcharger": {
-        "help": "<p>Information from the Solar charger can be read with this node.</p>",
-        "solarcharger": [
-            {
-                "path": "/Dc/0/Voltage",
-                "type": "float",
-                "name": "Voltage (V)"
-            },
-            {
-                "path": "/Dc/0/Current",
-                "type": "float",
-                "name": "Current (A)"
-            },
-            {
-                "path": "/Dc/0/Temperature",
-                "type": "float",
-                "name": "Battery temperature (C)"
-            },
-            {
-                "path": "/Mode",
-                "type": "enum",
-                "name": "Charger on/off",
-                "enum": {
-                    "1": "On",
-                    "4": "Off"
-                }
-            },
-            {
-                "path": "/State",
-                "type": "enum",
-                "name": "Charge state",
-                "enum": {
-                    "0": "Off",
-                    "2": "Fault",
-                    "3": "Bulk",
-                    "4": "Absorption",
-                    "5": "Float",
-                    "6": "Storage",
-                    "7": "Equalize",
-                    "245": "Off",
-                    "247": "Equalize",
-                    "252": "Ext. Control"
-                }
-            },
-            {
-                "path": "/Position",
-                "type": "enum",
-                "name": "Position",
-                "enum": {
-                    "0": "AC input 1",
-                    "1": "AC output",
-                    "2": "AC input 2"
-                }
-            },
-            {
-                "path": "/Pv/V",
-                "type": "float",
-                "name": "PV voltage"
-            },
-            {
-                "path": "/Pv/0/P",
-                "type": "float",
-                "name": "Tracker 1 power"
-            },
-            {
-                "path": "/Pv/0/V",
-                "type": "float",
-                "name": "Tracker 1 voltage"
-            },
-            {
-                "path": "/Pv/1/P",
-                "type": "float",
-                "name": "Tracker 2 power"
-            },
-            {
-                "path": "/Pv/1/V",
-                "type": "float",
-                "name": "Tracker 2 voltage"
-            },
-            {
-                "path": "/Pv/2/P",
-                "type": "float",
-                "name": "Tracker 3 power"
-            },
-            {
-                "path": "/Pv/2/V",
-                "type": "float",
-                "name": "Tracker 3 voltage"
-            },
-            {
-                "path": "/Pv/3/P",
-                "type": "float",
-                "name": "Tracker 4 power"
-            },
-            {
-                "path": "/Pv/3/V",
-                "type": "float",
-                "name": "Tracker 4 voltage"
-            },
-            {
-                "path": "/Yield/Power",
-                "type": "float",
-                "name": "PV Power (W)"
-            },
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay on the charger",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            },
-            {
-                "path": "/Alarms/Alarm",
-                "type": "enum",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowVoltage",
-                "type": "enum",
-                "name": "Low batt. voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighVoltage",
-                "type": "enum",
-                "name": "High batt. voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Alarm"
-                }
-            },
-            {
-                "path": "/ErrorCode",
-                "type": "enum",
-                "name": "Error code",
-                "enum": {
-                    "0": "No error",
-                    "1": "#1 - Battery temperature too high",
-                    "2": "#2 - Battery voltage too high",
-                    "3": "#3 - Battery temperature sensor miswired (+)",
-                    "4": "#4 - Battery temperature sensor miswired (-)",
-                    "5": "#5 - Battery temperature sensor disconnected",
-                    "6": "#6 - Battery voltage sense miswired (+)",
-                    "7": "#7 - Battery voltage sense miswired (-)",
-                    "8": "#8 - Battery voltage sense disconnected",
-                    "9": "#9 - Battery voltage wire losses too high",
-                    "10": "#10 - Battery voltage too low",
-                    "11": "#11 - Battery ripple voltage on terminals too high",
-                    "12": "#12 - Battery low state of charge",
-                    "13": "#13 - Battery mid-point voltage issue",
-                    "14": "#14 - Battery temperature too low",
-                    "17": "#17 - Charger temperature too high",
-                    "18": "#18 - Charger over-current",
-                    "19": "#19 - Charger current polarity reversed",
-                    "20": "#20 - Max Bulk-time exceeded",
-                    "21": "#21 - Charger current sensor issue",
-                    "22": "#22 - Temperature sensor miswired",
-                    "23": "#23 - Charger temperature sensor disconnected",
-                    "24": "#24 - Charger internal fan not detected",
-                    "25": "#25 - Charger internal fan over-current",
-                    "26": "#26 - Charger terminal overheated",
-                    "27": "#27 - Charger short circuit",
-                    "28": "#28 - Charger issue with power stage",
-                    "29": "#29 - Over-charge protection",
-                    "31": "#31 - Input voltage out of range",
-                    "32": "#32 - Input voltage too low",
-                    "33": "#33 - Input voltage too high",
-                    "34": "#34 - PV over current",
-                    "35": "#35 - Input excessive power",
-                    "36": "#36 - Input polarity issue",
-                    "37": "#37 - Input voltage absent (mains removed, fuse blown?)",
-                    "38": "#38 - Input shutdown due to battery over-voltage",
-                    "39": "#39 - Input shutdown due to battery over-voltage",
-                    "40": "#40 - Internal failure (PV Input failed to shutdown)",
-                    "41": "#41 - Inverter shutdown (panel isolation resistance too low)",
-                    "42": "#42 - Inverter shutdown (ground current too high: >30mA)",
-                    "43": "#43 - Inverter shutdown (voltage over ground relay too high)",
-                    "50": "#50 - Inverter overload (iit protection)",
-                    "51": "#51 - Inverter temperature too high",
-                    "52": "#52 - Inverter excessive current",
-                    "53": "#53 - Inverter dc level (internal dc rail voltage)",
-                    "54": "#54 - Inverter ac level (output voltage not ok)",
-                    "55": "#55 - Inverter dc fail (dc on output)",
-                    "56": "#56 - Inverter ac fail (shape wrong)*/",
-                    "57": "#57 - Inverter ac on output (inverter only)",
-                    "58": "#58 - Inverter bridge fault (hardware signal)",
-                    "59": "#59 - ACIN1 relay test fault",
-                    "60": "#60 - ACIN2 relay test fault",
-                    "65": "#65 - Device disappeared during parallel operation (broken cable?)",
-                    "66": "#66 - Incompatible device encountered for parallel operation (e.g. old firmware/different settings)",
-                    "67": "#67 - No BMS",
-                    "68": "#68 - Network misconfigured",
-                    "113": "#113 - Non-volatile storage write error",
-                    "114": "#114 - CPU temperature to high",
-                    "115": "#115 - CAN/SCI communication lost (when critical)",
-                    "116": "#116 - Calibration data lost",
-                    "117": "#117 - Incompatible firmware encountered",
-                    "118": "#118 - Incompatible hardware encountered",
-                    "119": "#119 - Settings data lost",
-                    "120": "#120 - Reference voltage failure",
-                    "121": "#121 - Tester fail",
-                    "122": "#122 - Non-volatile history data invalid/corrupted",
-                    "200": "#200 - Internal error",
-                    "201": "#201 - Internal error",
-                    "203": "#203 - Internal error",
-                    "205": "#205 - Internal error",
-                    "212": "#212 - Internal error",
-                    "215": "#215 - Internal error"
-                }
-            },
-            {
-                "path": "/Equalization/TimeRemaining",
-                "type": "float",
-                "name": "Equalization time remaining (seconds)"
-            },
-            {
-                "path": "/Equalization/Pending",
-                "type": "enum",
-                "name": "Equalization pending",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes",
-                    "2": "Error",
-                    "3": "Unavailable- Unknown"
-                }
-            },
-            {
-                "path": "/Load/State",
-                "type": "enum",
-                "name": "Load state",
-                "enum": {
-                    "0": "Off",
-                    "1": "On"
-                }
-            },
-            {
-                "path": "/Yield/User",
-                "type": "string",
-                "name": "Yield since reset (kWh)"
-            },
-            {
-                "path": "/Yield/System",
-                "type": "string",
-                "name": "Yield since last update (kWh)"
-            },
-            {
-                "path": "/MppOperationMode",
-                "type": "enum",
-                "name": "MPP operation mode",
-                "enum": {
-                    "0": "Off",
-                    "1": "Voltage or current limited",
-                    "2": "MPPT Tracker active",
-                    "255": "Not available"
-                }
-            },
-            {
-                "path": "/History/Daily/0/Yield",
-                "type": "float",
-                "name": "Yield today (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power today (W)"
-            },
-            {
-                "path": "/History/Daily/1/Yield",
-                "type": "float",
-                "name": "Yield yesterday (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power yesterday (W)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/0/Yield",
-                "type": "float",
-                "name": "Yield today for tracker 0 (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/1/Yield",
-                "type": "float",
-                "name": "Yield today for tracker 1 (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/2/Yield",
-                "type": "float",
-                "name": "Yield today for tracker 2 (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/3/Yield",
-                "type": "float",
-                "name": "Yield today for tracker 3 (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/0/Yield",
-                "type": "float",
-                "name": "Yield yesterday for tracker 0 (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/1/Yield",
-                "type": "float",
-                "name": "Yield yesterday for tracker 1 (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/2/Yield",
-                "type": "float",
-                "name": "Yield yesterday for tracker 2 (kWh)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/3/Yield",
-                "type": "float",
-                "name": "Yield yesterday for tracker 3 (kWh)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/0/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power today for tracker 0 (W)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/1/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power today for tracker 1 (W)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/2/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power today for tracker 2 (W)"
-            },
-            {
-                "path": "/History/Daily/0/Pv/3/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power today for tracker 3 (W)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/0/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power yesterday tracker 0 (W)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/1/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power yesterday tracker 1 (W)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/2/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power yesterday tracker 2 (W)"
-            },
-            {
-                "path": "/History/Daily/1/Pv/3/MaxPower",
-                "type": "float",
-                "name": "Maximum charge power yesterday tracker 3 (W)"
-            }
-            
-        ]
-    },
-    "input-battery": {
-        "help": "<p>This node allows for monitoring the state of the battery.</p>",
-        "battery": [
-            {
-                "path": "/Dc/0/Voltage",
-                "type": "float",
-                "name": "Voltage (V)"
-            },
-            {
-                "path": "/Dc/1/Voltage",
-                "type": "float",
-                "name": "Starter battery voltage (V)"
-            },
-            {
-                "path": "/Dc/0/Current",
-                "type": "float",
-                "name": "Current (A)"
-            },
-            {
-                "path": "/ConsumedAmphours",
-                "type": "float",
-                "name": "Consumed Amphours (Ah)"
-            },
-            {
-                "path": "/Soc",
-                "type": "float",
-                "name": "State of charge (%)"
-            },
-            {
-                "path": "/TimeToGo",
-                "type": "float",
-                "name": "Time to go (h)"
-            },
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay status",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            },
-            {
-                "path": "/Dc/0/Temperature",
-                "type": "float",
-                "name": "Battery temperature (C)"
-            },
-            {
-                "path": "/Dc/0/MidVoltage",
-                "type": "float",
-                "name": "Mid-point voltage of the battery bank (V)"
-            },
-            {
-                "path": "/Dc/0/MidVoltageDeviation",
-                "type": "float",
-                "name": "Mid-point deviation of the battery bank (%)"
-            },
-            {
-                "path": "/Alarms/LowVoltage",
-                "type": "enum",
-                "name": "Low voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighVoltage",
-                "type": "enum",
-                "name": "High voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowStarterVoltage",
-                "type": "enum",
-                "name": "Low starter-voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighStarterVoltage",
-                "type": "enum",
-                "name": "High starter-voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowSoc",
-                "type": "enum",
-                "name": "Low state-of-charge alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowTemperature",
-                "type": "enum",
-                "name": "Low battery temperature alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighTemperature",
-                "type": "enum",
-                "name": "High battery temperature alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/MidVoltage",
-                "type": "enum",
-                "name": "Mid-voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/FuseBlown",
-                "type": "enum",
-                "name": "Fuse blown alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighInternalTemperature",
-                "type": "enum",
-                "name": "High internal-temperature alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/Alarm",
-                "type": "enum",
-                "name": "Alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowFusedVoltage",
-                "type": "enum",
-                "name": "Low fused-voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighFusedVoltage",
-                "type": "enum",
-                "name": "High fused-voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Soh",
-                "type": "float",
-                "name": "State of health (%)"
-            },
-            {
-                "path": "/Capacity",
-                "type": "float",
-                "name": "Capacity (Ah)"
-            },
-            {
-                "path": "/Info/MaxChargeVoltage",
-                "type": "float",
-                "name": "CVL - Charge Voltage Limit (V)"
-            },
-            {
-                "path": "/Info/MaxChargeCurrent",
-                "type": "float",
-                "name": "CCL - Charge Current Limit (A)"
-            },
-            {
-                "path": "/Info/MaxDischargeCurrent",
-                "type": "float",
-                "name": "DCL - Discharge Current Limit (A)"
-            },
-            {
-                "path": "/Info/BatteryLowVoltage",
-                "type": "float",
-                "name": "Min discharge voltage (V DC)"
-            },
-            {
-                "path": "/State",
-                "type": "enum",
-                "name": "State",
-                "enum": {
-                    "0": "Initializing (Wait start)",
-                    "1": "Initializing (before boot)",
-                    "2": "Initializing (Before boot delay)",
-                    "3": "Initializing (Wait boot)",
-                    "4": "Initializing",
-                    "5": "Initializing (Measure battery voltage)",
-                    "6": "Initializing (Calculate battery voltage)",
-                    "7": "Initializing (Wait bus voltage)",
-                    "8": "Initializing (Wait for lynx shunt)",
-                    "9": "Running",
-                    "10": "Error (10)",
-                    "11": "Unused (11)",
-                    "12": "Shutdown",
-                    "13": "Slave updating",
-                    "14": "Standby",
-                    "15": "Going to run",
-                    "16": "Pre-charging"
-                }
-            },
-            {
-                "path": "/ErrorCode",
-                "type": "enum",
-                "name": "Error",
-                "enum": {
-                    "0": "No error",
-                    "1": "Battery initialization error",
-                    "2": "No batteries connected",
-                    "3": "Unknown battery connected",
-                    "4": "Different battery type",
-                    "5": "Number of batteries incorrect",
-                    "6": "Lynx Shunt not found",
-                    "7": "Battery measure error",
-                    "8": "Internal calculation error",
-                    "9": "Batteries in series not ok",
-                    "10": "Number of batteries incorrect",
-                    "11": "Hardware error",
-                    "12": "Watchdog error",
-                    "13": "Over voltage",
-                    "14": "Under voltage",
-                    "15": "Over temperature",
-                    "16": "Under temperature",
-                    "17": "Hardware fault",
-                    "18": "Standby shutdown",
-                    "19": "Pre-charge charge error",
-                    "20": "Safety contactor check error",
-                    "21": "Pre-charge discharge error",
-                    "22": "ADC error",
-                    "23": "Slave error",
-                    "24": "Slave warning",
-                    "25": "Pre-charge error",
-                    "26": "Safety contactor error",
-                    "27": "Over current",
-                    "28": "Slave update failed",
-                    "29": "Slave update unavailable",
-                    "30": "Calibration data lost",
-                    "31": "Settings invalid",
-                    "32": "BMS cable",
-                    "33": "Reference failure",
-                    "34": "Wrong system voltage",
-                    "35": "Pre-charge timeout"
-                }
-            },
-            {
-                "path": "/SystemSwitch",
-                "type": "enum",
-                "name": "System-switch",
-                "enum": {
-                    "0": "Disabled",
-                    "1": "Enabled"
-                }
-            },
-            {
-                "path": "/Balancing",
-                "type": "enum",
-                "name": "Balancing",
-                "enum": {
-                    "0": "Inactive",
-                    "1": "Active"
-                }
-            },
-            {
-                "path": "/System/NrOfBatteries",
-                "type": "float",
-                "name": "System; number of batteries (count)"
-            },
-            {
-                "path": "/System/BatteriesParallel",
-                "type": "float",
-                "name": "System; batteries parallel (count)"
-            },
-            {
-                "path": "/System/BatteriesSeries",
-                "type": "float",
-                "name": "System; batteries series (count)"
-            },
-            {
-                "path": "/System/NrOfCellsPerBattery",
-                "type": "float",
-                "name": "System; number of cells per battery (count)"
-            },
-            {
-                "path": "/System/MinCellVoltage",
-                "type": "float",
-                "name": "System; minimum cell voltage (V DC)"
-            },
-            {
-                "path": "/System/MaxCellVoltage",
-                "type": "float",
-                "name": "System; maximum cell voltage (V DC)"
-            },
-            {
-                "path": "/Alarms/CellImbalance",
-                "type": "enum",
-                "name": "Cell Imbalance alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighChargeCurrent",
-                "type": "enum",
-                "name": "High charge current alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighDischargeCurrent",
-                "type": "enum",
-                "name": "High discharge current alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/InternalFailure",
-                "type": "enum",
-                "name": "Internal error alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighChargeTemperature",
-                "type": "enum",
-                "name": "High charge temperature alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowChargeTemperature",
-                "type": "enum",
-                "name": "Low charge temperature alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowCellVoltage",
-                "type": "enum",
-                "name": "Low cell voltage alarm",
-                "enum": {
-                    "0": "No alarm",
-                    "1": "Almost discharged",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Diagnostics/ShutDownsDueError",
-                "type": "float",
-                "name": "Diagnostics; shutdowns due to error (count)"
-            },
-            {
-                "path": "/Diagnostics/LastErrors/1/Error",
-                "type": "enum",
-                "name": "Diagnostics; 1st last error",
-                "enum": {
-                    "0": "No error",
-                    "1": "Battery initialization error",
-                    "2": "No batteries connected",
-                    "3": "Unknown battery connected",
-                    "4": "Different battery type",
-                    "5": "Number of batteries incorrect",
-                    "6": "Lynx Shunt not found",
-                    "7": "Battery measure error",
-                    "8": "Internal calculation error",
-                    "9": "Batteries in series not ok",
-                    "10": "Number of batteries incorrect",
-                    "11": "Hardware error",
-                    "12": "Watchdog error",
-                    "13": "Over voltage",
-                    "14": "Under voltage",
-                    "15": "Over temperature",
-                    "16": "Under temperature",
-                    "17": "Hardware fault",
-                    "18": "Standby shutdown",
-                    "19": "Pre-charge charge error",
-                    "20": "Safety contactor check error",
-                    "21": "Pre-charge discharge error",
-                    "22": "ADC error",
-                    "23": "Slave error",
-                    "24": "Slave warning",
-                    "25": "Pre-charge error",
-                    "26": "Safety contactor error",
-                    "27": "Over current",
-                    "28": "Slave update failed",
-                    "29": "Slave update unavailable",
-                    "30": "Calibration data lost",
-                    "31": "Settings invalid",
-                    "32": "BMS cable",
-                    "33": "Reference failure",
-                    "34": "Wrong system voltage",
-                    "35": "Pre-charge timeout"
-                }
-            },
-			{
-				"path": "/Io/AllowToCharge",
-				"type": "enum",
-				"name": "ATC (Allow to Charge)",
-				"enum": {
-					"0": "No",
-					"1": "Yes"
-				}
-			},
-			{
-				"path": "/Io/AllowToDischarge",
-				"type": "enum",
-				"name": "ATD (Allow to Discharge)",
-				"enum": {
-					"0": "No",
-					"1": "Yes"
-				}
-			},
-            {
-                "path": "/Io/ExternalRelay",
-                "type": "enum",
-                "name": "IO; external relay",
-                "enum": {
-                    "0": "Inactive",
-                    "1": "Active"
-                }
-            },
-            {
-                "path": "/History/DeepestDischarge",
-                "type": "float",
-                "name": "Deepest discharge (Ah)"
-            },
-            {
-                "path": "/History/LastDischarge",
-                "type": "float",
-                "name": "Last discharge (Ah)"
-            },
-            {
-                "path": "/History/AverageDischarge",
-                "type": "float",
-                "name": "Average discharge (Ah)"
-            },
-            {
-                "path": "/History/ChargeCycles",
-                "type": "float",
-                "name": "Charge cycles (count)"
-            },
-            {
-                "path": "/History/FullDischarges",
-                "type": "float",
-                "name": "Full discharges (count)"
-            },
-            {
-                "path": "/History/TotalAhDrawn",
-                "type": "float",
-                "name": "Total Ah drawn (Ah)"
-            },
-            {
-                "path": "/History/MinimumVoltage",
-                "type": "float",
-                "name": "Minimum voltage (V DC)"
-            },
-            {
-                "path": "/History/MaximumVoltage",
-                "type": "float",
-                "name": "Maximum voltage (V DC)"
-            },
-            {
-                "path": "/History/TimeSinceLastFullCharge",
-                "type": "float",
-                "name": "Time since last full charge (seconds)"
-            },
-            {
-                "path": "/History/AutomaticSyncs",
-                "type": "float",
-                "name": "Automatic syncs (count)"
-            },
-            {
-                "path": "/History/LowVoltageAlarms",
-                "type": "float",
-                "name": "Low voltage alarms (count)"
-            },
-            {
-                "path": "/History/HighVoltageAlarms",
-                "type": "float",
-                "name": "High voltage alarms (count)"
-            },
-            {
-                "path": "/History/LowStarterVoltageAlarms",
-                "type": "float",
-                "name": "Low starter voltage alarms (count)"
-            },
-            {
-                "path": "/History/HighStarterVoltageAlarms",
-                "type": "float",
-                "name": "High starter voltage alarms (count)"
-            },
-            {
-                "path": "/History/MinimumStarterVoltage",
-                "type": "float",
-                "name": "Minimum starter voltage (V DC)"
-            },
-            {
-                "path": "/History/MaximumStarterVoltage",
-                "type": "float",
-                "name": "Maximum starter voltage (V DC)"
-            },
-            {
-                "path": "/History/LowFusedVoltageAlarms",
-                "type": "float",
-                "name": "Low fused-voltage alarms (count)"
-            },
-            {
-                "path": "/History/HighFusedVoltageAlarms",
-                "type": "float",
-                "name": "High fused-voltage alarms (count)"
-            },
-            {
-                "path": "/History/MinimumFusedVoltage",
-                "type": "float",
-                "name": "Minimum fused voltage (V DC)"
-            },
-            {
-                "path": "/History/MaximumFusedVoltage",
-                "type": "float",
-                "name": "Maximum fused voltage (V DC)"
-            },
-            {
-                "path": "/History/DischargedEnergy",
-                "type": "float",
-                "name": "Discharged Energy (kWh)"
-            },
-            {
-                "path": "/History/ChargedEnergy",
-                "type": "float",
-                "name": "Charged Energy (kWh)"
-            },
-            {
-                "path": "/History/MinimumCellVoltage",
-                "type": "float",
-                "name": "History; Min cell-voltage (V DC)"
-            },
-            {
-                "path": "/History/MaximumCellVoltage",
-                "type": "float",
-                "name": "History; Max cell-voltage (V DC)"
-            },
-            {
-                "path": "/Diagnostics/LastErrors/1/Time",
-                "type": "float",
-                "name": "Diagnostics; 1st last error timestamp"
-            },
-            {
-                "path": "/Diagnostics/LastErrors/2/Time",
-                "type": "float",
-                "name": "Diagnostics; 2nd last error timestamp"
-            },
-            {
-                "path": "/Diagnostics/LastErrors/3/Time",
-                "type": "float",
-                "name": "Diagnostics; 3rd last error timestamp"
-            },
-            {
-                "path": "/Diagnostics/LastErrors/4/Time",
-                "type": "float",
-                "name": "Diagnostics; 4th last error timestamp"
-            },
-            {
-                "path": "/System/MinCellTemperature",
-                "type": "float",
-                "name": "Minimum cell temperature (Degrees celsius)"
-            },
-            {
-                "path": "/System/MaxCellTemperature",
-                "type": "float",
-                "name": "Maximum cell temperature (Degrees celsius)"
-            }
-            
-        ]
-    },
-    "input-gridmeter": {
-        "help": "<p>This node gives allows for monitoring the grid. See also <a href=\"https://www.victronenergy.com/accessories/energy-meter\">energy meters</a> accessoires.</p>",
-        "grid": [
-            {
-                "path": "/Ac/Energy/Forward",
-                "type": "float",
-                "name": "Total Forward Energy (bought) (kWh)"
-            },
-            {
-                "path": "/Ac/Energy/Reverse",
-                "type": "float",
-                "name": "Total Reverse Energy (sold) (kWh)"
-            },
-            {
-                "path": "/Ac/Power",
-                "type": "float",
-                "name": "Power (W)"
-            },
-            {
-                "path": "/Ac/L1/Current",
-                "type": "float",
-                "name": "L1 Current (A)"
-            },
-            {
-                "path": "/Ac/L1/Energy/Forward",
-                "type": "float",
-                "name": "L1 Forward energy (bought) (kWh)"
-            },
-            {
-                "path": "/Ac/L1/Energy/Reverse",
-                "type": "float",
-                "name": "L1 Reverse energy (sold) (kWh)"
-            },
-            {
-                "path": "/Ac/L1/Power",
-                "type": "float",
-                "name": "L1 Power (W)"
-            },
-            {
-                "path": "/Ac/L1/Voltage",
-                "type": "float",
-                "name": "L1 Voltage (V)"
-            },
-            {
-                "path": "/Ac/L2/Current",
-                "type": "float",
-                "name": "L2 Current (A)"
-            },
-            {
-                "path": "/Ac/L2/Energy/Forward",
-                "type": "float",
-                "name": "L2 Forward energy (bought) (kWh)"
-            },
-            {
-                "path": "/Ac/L2/Energy/Reverse",
-                "type": "float",
-                "name": "L2 Reverse energy (sold) (kWh)"
-            },
-            {
-                "path": "/Ac/L2/Power",
-                "type": "float",
-                "name": "L2 Power (W)"
-            },
-            {
-                "path": "/Ac/L2/Voltage",
-                "type": "float",
-                "name": "L2 Voltage (V)"
-            },
-            {
-                "path": "/Ac/L3/Current",
-                "type": "float",
-                "name": "L2 Current (A)"
-            },
-            {
-                "path": "/Ac/L3/Energy/Forward",
-                "type": "float",
-                "name": "L3 Forward energy (bought) (kWh)"
-            },
-            {
-                "path": "/Ac/L3/Energy/Reverse",
-                "type": "float",
-                "name": "L3 Reverse energy (sold) (kWh)"
-            },
-            {
-                "path": "/Ac/L3/Power",
-                "type": "float",
-                "name": "L3 Power (W)"
-            },
-            {
-                "path": "/Ac/L3/Voltage",
-                "type": "float",
-                "name": "L3 Voltage (V)"
-            },
-            {
-                "path": "/Serial",
-                "type": "string",
-                "name": "Serial"
-            }            
-        ]
-    },
-    "input-vebus": {
-        "help": "<p>Information from VE.Bus connected devices can be obtained with this node.</p>",
-        "vebus": [
-            {
-                "path": "/Ac/ActiveIn/L1/V",
-                "type": "float",
-                "name": "Input voltage phase 1 (VAC)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L2/V",
-                "type": "float",
-                "name": "Input voltage phase 2 (VAC)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L3/V",
-                "type": "float",
-                "name": "Input voltage phase 3 (VAC)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L1/I",
-                "type": "float",
-                "name": "Input current phase 1 (A)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L2/I",
-                "type": "float",
-                "name": "Input current phase 2 (A)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L3/I",
-                "type": "float",
-                "name": "Input current phase 3 (A)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L1/F",
-                "type": "float",
-                "name": "Input frequency 1 (Hz)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L2/F",
-                "type": "float",
-                "name": "Input frequency 2 (Hz)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L3/F",
-                "type": "float",
-                "name": "Input frequency 3 (Hz)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L1/P",
-                "type": "float",
-                "name": "Input power 1 (W)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L2/P",
-                "type": "float",
-                "name": "Input power 2 (W)"
-            },
-            {
-                "path": "/Ac/ActiveIn/L3/P",
-                "type": "float",
-                "name": "Input power 3 (W)"
-            },
-            {
-                "path": "/Ac/In/1/CurrentLimit",
-                "type": "float",
-                "name": "Input 1 current limit (A)"
-            },
-            {
-                "path": "/Ac/In/1/CurrentLimitIsAdjustable",
-                "type": "enum",
-                "name": "Input 1 current limit is adjustable",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Ac/In/2/CurrentLimit",
-                "type": "float",
-                "name": "Input 2 current limit (A)"
-            },
-            {
-                "path": "/Ac/In/2/CurrentLimitIsAdjustable",
-                "type": "enum",
-                "name": "Input 2 current limit is adjustable",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Ac/Out/L1/V",
-                "type": "float",
-                "name": "Output voltage phase 1 (VAC)"
-            },
-            {
-                "path": "/Ac/Out/L2/V",
-                "type": "float",
-                "name": "Output voltage phase 2 (VAC)"
-            },
-            {
-                "path": "/Ac/Out/L3/V",
-                "type": "float",
-                "name": "Output voltage phase 3 (VAC)"
-            },
-            {
-                "path": "/Ac/Out/L1/I",
-                "type": "float",
-                "name": "Output current phase 1 (A)"
-            },
-            {
-                "path": "/Ac/Out/L2/I",
-                "type": "float",
-                "name": "Output current phase 2 (A)"
-            },
-            {
-                "path": "/Ac/Out/L3/I",
-                "type": "float",
-                "name": "Output current phase 3 (A)"
-            },
-            {
-                "path": "/Ac/Out/L1/F",
-                "type": "float",
-                "name": "Output frequency (Hz)"
-            },
-            {
-                "path": "/Ac/Out/L1/P",
-                "type": "float",
-                "name": "Output power 1 (W)"
-            },
-            {
-                "path": "/Ac/Out/L2/P",
-                "type": "float",
-                "name": "Output power 2 (W)"
-            },
-            {
-                "path": "/Ac/Out/L3/P",
-                "type": "float",
-                "name": "Output power 3 (W)"
-            },
-            {
-                "path": "/Dc/0/Voltage",
-                "type": "float",
-                "name": "Voltage (V)"
-            },
-            {
-                "path": "/Dc/0/Current",
-                "type": "float",
-                "name": "Current (A)"
-            },
-            {
-                "path": "/Dc/0/Temperature",
-                "type": "float",
-                "name": "Temperature (C)"
-            },
-            {
-                "path": "/Ac/NumberOfPhases",
-                "type": "float",
-                "name": "Phase count"
-            },
-            {
-                "path": "/Ac/ActiveIn/ActiveInput",
-                "type": "enum",
-                "name": "Active input",
-                "enum": {
-                    "0": "AC Input 1",
-                    "1": "AC Input 2",
-                    "240": "Disconnected"
-                }
-            },
-            {
-                "path": "/Ac/State/IgnoreAcIn1",
-                "type": "enum",
-                "name": "AC input 1 ignored",
-                "enum": {
-                    "0": "AC input not ignored",
-                    "1": "AC input ignored"
-                }
-            },
-            {
-                "path": "/Ac/State/IgnoreAcIn2",
-                "type": "enum",
-                "name": "AC input 2 ignored",
-                "enum": {
-                    "0": "AC input not ignored",
-                    "1": "AC input ignored"
-                }
-            },
-            {
-                "path": "/Soc",
-                "type": "float",
-                "name": "VE.Bus state of charge (%)"
-            },
-            {
-                "path": "/State",
-                "type": "enum",
-                "name": "VE.Bus state",
-                "enum": {
-                    "0": "Off",
-                    "1": "Low Power",
-                    "2": "Fault",
-                    "3": "Bulk",
-                    "4": "Absorption",
-                    "5": "Float",
-                    "6": "Storage",
-                    "7": "Equalize",
-                    "8": "Passthru",
-                    "9": "Inverting",
-                    "10": "Power assist",
-                    "11": "Power supply",
-                    "252": "Bulk protect"
-                }
-            },
-            {
-                "path": "/VebusError",
-                "type": "enum",
-                "name": "VE.Bus Error",
-                "enum": {
-                    "0": "No error",
-                    "1": "VE.Bus Error 1: Device is switched off because one of the other phases in the system has switched off",
-                    "2": "VE.Bus Error 2: New and old types MK2 are mixed in the system",
-                    "3": "VE.Bus Error 3: Not all, or more than, the expected devices were found in the system",
-                    "4": "VE.Bus Error 4: No other device whatsoever detected",
-                    "5": "VE.Bus Error 5: Overvoltage on AC-out",
-                    "6": "VE.Bus Error 6: Error in DDC Program",
-                    "7": "VE.Bus Error 7:  BMS connected, which requires an Assistant, but no assistant found",
-                    "8": "VE.Bus Error 8: Ground relay test failed",
-                    "9": "VE.Bus Error 9",
-                    "10": "VE.Bus Error 10: System time synchronisation problem occurred",
-                    "11": "VE.Bus Error 11: Relay test fault",
-                    "12": "VE.Bus Error 12",
-                    "13": "VE.Bus Error 13",
-                    "14": "VE.Bus Error 14: Device cannot transmit data",
-                    "15": "VE.Bus Error 15",
-                    "16": "VE.Bus Error 16: Awaiting configuration or dongle missing",
-                    "17": "VE.Bus Error 17: Phase master missing",
-                    "18": "VE.Bus Error 18: AC Overvoltage on the output of a slave has occurred while already switched off",
-                    "19": "VE.Bus Error 19",
-                    "20": "VE.Bus Error 20",
-                    "21": "VE.Bus Error 21",
-                    "22": "VE.Bus Error 22: This device cannot function as slave",
-                    "23": "VE.Bus Error 23",
-                    "24": "VE.Bus Error 24: Switch-over system protection initiated",
-                    "25": "VE.Bus Error 25: Firmware incompatibility. The firmware of one of the connected device is not sufficiently up to date to operate in conjunction with this device",
-                    "26": "VE.Bus Error 26: Internal error",
-                    "27": "VE.Bus Error 27",
-                    "28": "VE.Bus Error 28",
-                    "29": "VE.Bus Error 29",
-                    "30": "VE.Bus Error 30",
-                    "31": "VE.Bus Error 31",
-                    "32": "VE.Bus Error 32"
-                }
-            },
-            {
-                "path": "/Alarms/GridLost",
-                "type": "enum",
-                "name": "Grid lost alarm",
-                "enum": {
-                    "0": "Ok",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/PhaseRotation",
-                "type": "enum",
-                "name": "Phase Rotation",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning"
-                }
-            },
-            {
-                "path": "/Alarms/HighTemperature",
-                "type": "enum",
-                "name": "Temperature",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowBattery",
-                "type": "enum",
-                "name": "Low battery",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/Overload",
-                "type": "enum",
-                "name": "Overload",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/TemperatureSensor",
-                "type": "enum",
-                "name": "Temperatur sensor alarm",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/VoltageSensor",
-                "type": "enum",
-                "name": "Voltage sensor alarm",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L1/HighTemperature",
-                "type": "enum",
-                "name": "Temperature alarm L1",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L1/LowBattery",
-                "type": "enum",
-                "name": "Low battery alarm L1",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L1/Overload",
-                "type": "enum",
-                "name": "Overload alarm L1",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L1/Ripple",
-                "type": "enum",
-                "name": "Ripple alarm L1",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L2/HighTemperature",
-                "type": "enum",
-                "name": "Temperature alarm L2",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L2/LowBattery",
-                "type": "enum",
-                "name": "Low battery alarm L2",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L2/Overload",
-                "type": "enum",
-                "name": "Overload alarm L2",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L2/Ripple",
-                "type": "enum",
-                "name": "Ripple alarm L2",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L3/HighTemperature",
-                "type": "enum",
-                "name": "Temperature alarm L3",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L3/LowBattery",
-                "type": "enum",
-                "name": "Low battery alarm L3",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L3/Overload",
-                "type": "enum",
-                "name": "Overload alarm L3",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/L3/Ripple",
-                "type": "enum",
-                "name": "Ripple alarm L3",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Mode",
-                "type": "enum",
-                "name": "Switch Position",
-                "enum": {
-                    "1": "Charger Only",
-                    "2": "Inverter Only",
-                    "3": "On",
-                    "4": "Off"
-                }
-            },
-            {
-                "path": "/ModeIsAdjustable",
-                "type": "enum",
-                "name": "Mode is adjustable",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Energy/AcIn1ToInverter",
-                "type": "float",
-                "name": "Energy AcIn1 to Inverter (kWh)"
-            },
-            {
-                "path": "/Energy/AcIn2ToInverter",
-                "type": "float",
-                "name": "Energy ACIn2 to Inverter (kWh)"
-            },
-            {
-                "path": "/Energy/AcIn1ToAcOut",
-                "type": "float",
-                "name": "Energy ACIn1 to AcOut (kWh)"
-            },
-            {
-                "path": "/Energy/AcIn2ToAcOut",
-                "type": "float",
-                "name": "Energy ACIn2 to AcOut (kWh)"
-            },
-            {
-                "path": "/Energy/InverterToAcIn1",
-                "type": "float",
-                "name": "Energy Inverter to AcIn1 (kWh)"
-            },
-            {
-                "path": "/Energy/InverterToAcIn2",
-                "type": "float",
-                "name": "Energy Inverter to AcIn2 (kWh)"
-            },
-            {
-                "path": "/Energy/AcOutToAcIn1",
-                "type": "float",
-                "name": "Energy AcOut to AcIn1 (kWh)"
-            },
-            {
-                "path": "/Energy/AcOutToAcIn2",
-                "type": "float",
-                "name": "Energy AcOut to AcIn2 (kWh)"
-            },
-            {
-                "path": "/Energy/InverterToAcOut",
-                "type": "float",
-                "name": "Inverter To AcOut (kWh)"
-            },
-            {
-                "path": "/Energy/OutToInverter",
-                "type": "float",
-                "name": "AcOut to Inverter (kWh)"
-            },
-            {
-                "path": "/Bms/AllowToCharge",
-                "type": "enum",
-                "name": "BMS allows battery to be charged",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Bms/AllowToDischarge",
-                "type": "enum",
-                "name": "BMS allows battery to be discharged",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Bms/BmsExpected",
-                "type": "enum",
-                "name": "VE.Bus BMS is expected",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Bms/Error",
-                "type": "enum",
-                "name": "VE.Bus BMS error",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            }
-        ]
-    },
-    "input-gps": {
-        "help": "<p>GPS information can be obtained with this node. For an example usage see the <a href=\"https://github.com/victronenergy/node-red-contrib-victron/wiki/Example-Flows#location-based-scheduling\">location based scheduling</a> example.</p>",
-        "gps": [
-            {
-                "path": "/Altitude",
-                "type": "float",
-                "name": "Altitude (m)"
-            },
-            {
-                "path": "/Course",
-                "type": "float",
-                "name": "Course (Deg)"
-            },
-            {
-                "path": "/Fix",
-                "type": "integer",
-                "name": "Fix"
-            },
-            {
-                "path": "/NrOfSatellites",
-                "type": "integer",
-                "name": "Number of satellites"
-            },
-            {
-                "path": "/Position/Latitude",
-                "type": "float",
-                "name": "Latitude (LAT)"
-            },
-            {
-                "path": "/Position/Longitude",
-                "type": "float",
-                "name": "Longitude (LNG)"
-            },
-            {
-                "path": "/Speed",
-                "type": "float",
-                "name": "Speed (m/s)"
-            }
-        ]
-    },
-    "input-ess": {
-        "help": "<p>This node gives information on the energy storage system (ESS).</p>",
-        "vebus": [
-            {
-                "path": "/Hub4/DisableFeedIn",
-                "type": "enum",
-                "name": "Disable feed-in",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Hub4/DisableCharge",
-                "type": "enum",
-                "name": "Disable charge",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Hub4/L1/AcPowerSetpoint",
-                "type": "integer",
-                "name": "AC Power L1 setpoint (W)"
-            },
-            {
-                "path": "/Hub4/L2/AcPowerSetpoint",
-                "type": "integer",
-                "name": "AC Power L2 setpoint (W)"
-            },
-            {
-                "path": "/Hub4/L3/AcPowerSetpoint",
-                "type": "integer",
-                "name": "AC Power L3 setpoint (W)"
-            }
-        ],
-        "settings": [
-            {
-                "path": "/Settings/CGwacs/Hub4Mode",
-                "type": "enum",
-                "name": "ESS mode",
-                "enum": {
-                    "1": "Optimized mode or 'keep batteries charged' and phase compensation enabled",
-                    "2": "Optimized mode or 'keep batteries charged' and phase compensation disabled",
-                    "3": "External control"
-                }
-            },
-            {
-                "path": "/Settings/CGwacs/AcPowerSetPoint",
-                "type": "integer",
-                "name": "Grid set-point (W)"
-            },
-            {
-                "path": "/Settings/CGwacs/BatteryLife/MinimumSocLimit",
-                "type": "integer",
-                "name": "Minimum Discharge SOC (%)"
-            },
-            {
-                "path": "/Settings/CGwacs/BatteryLife/SocLimit",
-                "type": "integer",
-                "name": "Active SOC limit (%)"
-	    },
-            {
-                "path": "/Settings/CGwacs/BatteryLife/State",
-                "type": "enum",
-                "name": "ESS state",
-                "enum": {
-                    "1": "BatteryLife enabled (GUI controlled)",
-                    "2": "Optimized Mode /w BatteryLife: self consumption",
-                    "3": "Optimized Mode /w BatteryLife: self consumption, SoC exceeds 85%",
-                    "4": "Optimized Mode /w BatteryLife: self consumption, SoC at 100%",
-                    "5": "Optimized Mode /w BatteryLife: SoC below dynamic SoC limit",
-                    "6": "Optimized Mode /w BatteryLife: SoC has been below SoC limit for more than 24 hours. Charging the battery (5A)",
-                    "7": "Optimized Mode /w BatteryLife: Inverter/Charger is in sustain mode",
-                    "8": "Optimized Mode /w BatteryLife: recharging, SoC dropped by 5% or more below the minimum SoC",
-                    "9": "'Keep batteries charged' mode is enabled",
-                    "10": "Optimized mode w/o BatteryLife: self consumption, SoC at or above minimum SoC",
-                    "11": "Optimized mode w/o BatteryLife: self consumption, SoC is below minimum SoC",
-                    "12": "Optimized mode w/o BatteryLife: recharging, SoC dropped by 5% or more below minimum SoC"
-                }
-            },
-            {
-                "path": "/Settings/CGwacs/Hub4Mode",
-                "type": "enum",
-                "name": "ESS mode",
-                "enum": {
-                    "1": "Optimized mode or 'keep batteries charged' and phase compensation enabled",
-                    "2": "Optimized mode or 'keep batteries charged' and phase compensation disabled",
-                    "3": "External control"
-                }
-            },
-            {
-                "path": "/Settings/CGwacs/MaxDischargePower",
-                "type": "integer",
-                "name": "Max inverter power (W)"
-            },
-            {
-                "path": "/Settings/CGwacs/OvervoltageFeedIn",
-                "type": "enum",
-                "name": "Feed-in excess solar charger power",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Settings/CGwacs/PreventFeedback",
-                "type": "enum",
-                "name": "PV Inverter zero feed-in (on/off)",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                }
-            },
-            {
-                "path": "/Settings/SystemSetup/MaxChargeCurrent",
-                "type": "float",
-                "name": "Charge current limit (A)"
-            }
-        ]
-    },
-    "input-meteo": {
-        "help": "<p>The <b>input-meteo</b> node allows for Solar Irradiance, Temperature and Wind Speed Sensors measuring.</p><p>More information and supported devices can be found in the <a href=\"https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-d4b7dfe9-4ee0-53bc-8959-c567ed63cebb\">manual</a>.</p>",
-        "meteo": [
-            {
-                "path": "/Irradiance",
-                "type": "float",
-                "name": "Solar Irradiance (W/m^2)"
-            },
-            {
-                "path": "/WindSpeed",
-                "type": "float",
-                "name": "Wind speed (m/s)"
-            },
-            {
-                "path": "/CellTemperature",
-                "type": "float",
-                "name": "Sensor cell temperature (C)"
-            },
-            {
-                "path": "/ExternalTemperature",
-                "type": "float",
-                "name": "External temperature (C)"
-            }
-        ]
-    },
-    "input-system": {
-        "help": "<p>This input node takes is for retrieving information from the <tt>com.victronenergy.system</tt> dbus path.</p>",
-        "system": [
-            {
-                "path": "/Ac/ActiveIn/Source",
-                "type": "enum",
-                "name": "AC-Input",
-                "enum": {
-                    "0": "Not available",
-                    "1": "Grid",
-                    "2": "Generator",
-                    "3": "Shore",
-                    "240": "Inverting"
-                }
-            },
-            {
-                "path": "/Ac/Consumption/L1/Power",
-                "type": "float",
-                "name": "AC Consumption L1 (W)"
-            },
-            {
-                "path": "/Ac/Consumption/L2/Power",
-                "type": "float",
-                "name": "AC Consumption L2 (W)"
-            },
-            {
-                "path": "/Ac/Consumption/L3/Power",
-                "type": "float",
-                "name": "AC Consumption L3 (W)"
-            },
-            {
-                "path": "/Ac/ConsumptionOnInput/NumberOfPhases",
-                "type": "integer",
-                "name": "AC Consumption on Input Number Of Phases"
-            },
-            {
-                "path": "/Ac/ConsumptionOnOutput/L1/Power",
-                "type": "float",
-                "name": "AC Consumption on Output L1"
-            },
-            {
-                "path": "/Ac/ConsumptionOnOutput/L2/Power",
-                "type": "float",
-                "name": "AC Consumption on Output L2"
-            },
-            {
-                "path": "/Ac/ConsumptionOnOutput/L3/Power",
-                "type": "float",
-                "name": "AC Consumption on Output L3"
-            },
-            {
-                "path": "/Ac/ConsumptionOnOutput/NumberOfPhases",
-                "type": "integer",
-                "name": "AC Consumption on Output Number Of Phases"
-            },
-            {
-                "path": "/Ac/Genset/L1/Power",
-                "type": "float",
-                "name": "Genset L1 (W)"
-            },
-            {
-                "path": "/Ac/Genset/L2/Power",
-                "type": "float",
-                "name": "Genset L2 (W)"
-            },
-            {
-                "path": "/Ac/Genset/L3/Power",
-                "type": "float",
-                "name": "Genset L3 (W)"
-            },
-            {
-                "path": "/Ac/Genset/NumberOfPhases",
-                "type": "integer",
-                "name": "Genset Number Of Phases"
-            },
-            {
-                "path": "/Ac/Genset/DeviceType",
-                "type": "float",
-                "name": "Genset Device Type",
-                "enum": {}
-            },
-            {
-                "path": "/Ac/Grid/L1/Power",
-                "type": "float",
-                "name": "Grid L1 (W)"
-            },
-            {
-                "path": "/Ac/Grid/L2/Power",
-                "type": "float",
-                "name": "Grid L2 (W)"
-            },
-            {
-                "path": "/Ac/Grid/L3/Power",
-                "type": "float",
-                "name": "Grid L3 (W)"
-            },
-            {
-                "path": "/Ac/Grid/NumberOfPhases",
-                "type": "integer",
-                "name": "Grid Number Of Phases"
-            },
-            {
-                "path": "/Ac/Grid/DeviceType",
-                "type": "float",
-                "name": "Grid Device Type"
-            },
-            {
-                "path": "/Ac/PvOnGenset/L1/Power",
-                "type": "float",
-                "name": "PV Power AC-tied on Generator L1"
-            },
-            {
-                "path": "/Ac/PvOnGenset/L2/Power",
-                "type": "float",
-                "name": "PV Power AC-tied on Generator L2"
-            },
-            {
-                "path": "/Ac/PvOnGenset/L3/Power",
-                "type": "float",
-                "name": "PV Power AC-tied on Generator L3"
-            },
-            {
-                "path": "/Ac/PvOnGenset/NumberOfPhases",
-                "type": "integer",
-                "name": "PV Power AC-tied on Generator Number Of Phases"
-            },
-            {
-                "path": "/Ac/PvOnGrid/L1/Power",
-                "type": "float",
-                "name": "PV - AC-coupled on input L1 (W)"
-            },
-            {
-                "path": "/Ac/PvOnGrid/L2/Power",
-                "type": "float",
-                "name": "PV - AC-coupled on input L2 (W)"
-            },
-            {
-                "path": "/Ac/PvOnGrid/L3/Power",
-                "type": "float",
-                "name": "PV - AC-coupled on input L3 (W)"
-            },
-            {
-                "path": "/Ac/PvOnGrid/NumberOfPhases",
-                "type": "integer",
-                "name": "PV - AC-coupled on input Number Of Phases"
-            },
-            {
-                "path": "/Ac/PvOnOutput/L1/Power",
-                "type": "float",
-                "name": "PV - AC-coupled on output L1 (W)"
-            },
-            {
-                "path": "/Ac/PvOnOutput/L2/Power",
-                "type": "float",
-                "name": "PV - AC-coupled on output L2 (W)"
-            },
-            {
-                "path": "/Ac/PvOnOutput/L3/Power",
-                "type": "float",
-                "name": "PV - AC-coupled on output L3 (W)"
-            },
-            {
-                "path": "/Ac/PvOnOutput/NumberOfPhases",
-                "type": "integer",
-                "name": "PV - AC-coupled on output Number Of Phases"
-            },
-            {
-                "path": "/Dc/Battery/ConsumedAmphours",
-                "type": "float",
-                "name": "Battery Consumed Amphours (Ah)"
-            },
-            {
-                "path": "/Dc/Battery/Current",
-                "type": "float",
-                "name": "Battery current (A)"
-            },
-            {
-                "path": "/Dc/Battery/Power",
-                "type": "float",
-                "name": "Battery Power (W)"
-            },
-            {
-                "path": "/Dc/Battery/Soc",
-                "type": "float",
-                "name": "Battery State of Charge (%)"
-            },
-            {
-                "path": "/Dc/Battery/State",
-                "type": "enum",
-                "name": "Battery state",
-                "enum": {
-                    "0": "idle",
-                    "1": "charging",
-                    "2": "discharging"
-                }
-            },
-            {
-                "path": "/Dc/Battery/TimeToGo",
-                "type": "float",
-                "name": "Battery Time to Go (h)"
-            },
-            {
-                "path": "/Dc/Battery/Voltage",
-                "type": "float",
-                "name": "Battery voltage (V)"
-            },
-            {
-                "path": "/Dc/Battery/Temperature",
-                "type": "float",
-                "name": "Battery temperature (C)"
-            },
-            {
-                "path": "/Dc/Charger/Power",
-                "type": "integer",
-                "name": "AC-Chargers - power (W)"
-            },
-            {
-                "path": "/Dc/Pv/Power",
-                "type": "float",
-                "name": "MPPTs - power (W)"
-            },
-            {
-                "path": "/Dc/Pv/Current",
-                "type": "float",
-                "name": "MPPTs - current (A)"
-            },
-            {
-                "path": "/Dc/System/Power",
-                "type": "float",
-                "name": "DC System (W)"
-            },
-            {
-                "path": "/Dc/Vebus/Current",
-                "type": "float",
-                "name": "VE.Bus charge current (A)"
-            },
-            {
-                "path": "/Dc/Vebus/Power",
-                "type": "float",
-                "name": "VE.Bus charge power (W)"
-            },
-            {
-                "path": "/Buzzer/State",
-                "type": "float",
-                "name": "Buzzer State",
-                "enum": {
-                    "0": "Off",
-                    "1": "On"
-                }
-            },
-            {
-                "path": "/Timers/TimeOnGrid",
-                "type": "float",
-                "name": "Time grid (s)"
-            },
-            {
-                "path": "/Timers/TimeOnGenerator",
-                "type": "float",
-                "name": "Time generator (s)"
-            },
-            {
-                "path": "/Timers/TimeOnInverter",
-                "type": "float",
-                "name": "Time inverting (s)"
-            },
-            {
-                "path": "/Timers/TimeOff",
-                "type": "float",
-                "name": "Time off (s)"
-            },
-            {
-                "path": "/SystemType",
-                "type": "string",
-                "name": "System type"
-            },
-            {
-                "path": "/Serial",
-                "type": "string",
-                "name": "Serial (System)"
-            }
-        ]
-    },
-	"input-dcsource": {
-		"help": "<p>This node allows for monitoring the state of Battery Monitor Victron devices (BMV's) configured in Monitor Mode and DC meter type is a source.</p>",
-		"dcsource": [
-			{
-				"path": "/Dc/0/Voltage",
-				"type": "float",
-				"name": "Voltage (V)"
-			},
-			{
-				"path": "/Dc/1/Voltage",
-				"type": "float",
-				"name": "Starter battery voltage (V)"
-			},
-			{
-				"path": "/Dc/0/Current",
-				"type": "float",
-				"name": "Current (A)"
-			},
-			{
-				"path": "/Dc/0/Power",
-				"type": "float",
-				"name": "Battery power (W)"
-			},
-			{
-				"path": "/Relay/0/State",
-				"type": "enum",
-				"name": "Relay status",
-				"enum": {
-					"0": "Open",
-					"1": "Closed"
-				}
-			},
-			{
-				"path": "/Dc/0/Temperature",
-				"type": "float",
-				"name": "Battery temperature (C)"
-			},
-			{
-				"path": "/Dc/0/MidVoltage",
-				"type": "float",
-				"name": "Mid-point voltage of the battery bank (V)"
-			},
-			{
-				"path": "/Dc/0/MidVoltageDeviation",
-				"type": "float",
-				"name": "Mid-point deviation of the battery bank (%)"
-			},
-            {
-                "path": "/History/EnergyOut",
-                "type": "float",
-                "name": "Total energy produced (kWh)"
-            },
-			{
-				"path": "/Alarms/LowVoltage",
-				"type": "enum",
-				"name": "Low voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/HighVoltage",
-				"type": "enum",
-				"name": "High voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/LowStarterVoltage",
-				"type": "enum",
-				"name": "Low starter-voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/HighStarterVoltage",
-				"type": "enum",
-				"name": "High starter-voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/LowTemperature",
-				"type": "enum",
-				"name": "Low battery temperature alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/HighTemperature",
-				"type": "enum",
-				"name": "High battery temperature alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/MidVoltage",
-				"type": "enum",
-				"name": "Mid-voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			}
-		]
-	},
-	"input-dcload": {
-		"help": "<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is a load.</p>",
-		"dcload": [
-			{
-				"path": "/Dc/0/Voltage",
-				"type": "float",
-				"name": "Voltage (V)"
-			},
-			{
-				"path": "/Dc/1/Voltage",
-				"type": "float",
-				"name": "Starter battery voltage (V)"
-			},
-			{
-				"path": "/Dc/0/Current",
-				"type": "float",
-				"name": "Current (A)"
-			},
-			{
-				"path": "/Dc/0/Power",
-				"type": "float",
-				"name": "Battery power (W)"
-			},
-			{
-				"path": "/Relay/0/State",
-				"type": "enum",
-				"name": "Relay status",
-				"enum": {
-					"0": "Open",
-					"1": "Closed"
-				}
-			},
-			{
-				"path": "/Dc/0/Temperature",
-				"type": "float",
-				"name": "Battery temperature (C)"
-			},
-			{
-				"path": "/Dc/0/MidVoltage",
-				"type": "float",
-				"name": "Mid-point voltage of the battery bank (V)"
-			},
-			{
-				"path": "/Dc/0/MidVoltageDeviation",
-				"type": "float",
-				"name": "Mid-point deviation of the battery bank (%)"
-			},
-            {
-                "path": "/History/EnergyIn",
-                "type": "float",
-                "name": "Total energy consumed (kWh)"
-            },
-			{
-				"path": "/Alarms/LowVoltage",
-				"type": "enum",
-				"name": "Low voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/HighVoltage",
-				"type": "enum",
-				"name": "High voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/LowStarterVoltage",
-				"type": "enum",
-				"name": "Low starter-voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/HighStarterVoltage",
-				"type": "enum",
-				"name": "High starter-voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/LowTemperature",
-				"type": "enum",
-				"name": "Low battery temperature alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/HighTemperature",
-				"type": "enum",
-				"name": "High battery temperature alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/MidVoltage",
-				"type": "enum",
-				"name": "Mid-voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			}
-		]
-	},
-	"input-alternator": {
-		"help": "<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is Alternator or an alternator controller which is interfaced to the Venus OS.</p>",
-		"alternator": [
-			{
-				"path": "/Dc/0/Voltage",
-				"type": "float",
-				"name": "Voltage (V)"
-			},
-			{
-				"path": "/Dc/0/Current",
-				"type": "float",
-				"name": "Current (A)"
-			},
-			{
-				"path": "/Dc/0/Power",
-				"type": "float",
-				"name": "Battery power (W)"
-			},
-			{
-				"path": "/Dc/0/Temperature",
-				"type": "float",
-				"name": "Battery temperature (C)"
-			},
-            {
-                "path": "/Dc/1/Voltage",
-                "type": "float",
-                "name": "Auxiliary voltage (V DC)"
-            },
-			{
-				"path": "/AlternatorRPM",
-				"type": "float",
-				"name": "Alternator RPM"
-			},
-			{
-				"path": "/EngineRPM",
-				"type": "float",
-				"name": "Engine RPM"
-			},
-			{
-				"path": "/FieldDrive",
-				"type": "float",
-				"name": "Alternator Field Drive %"
-			},
-			{
-				"path": "/AlternatorStatus",
-				"type": "enum",
-				"name": "Alterntor Charging Status",
-				"enum": {
-					"0": "Not Charging",
-					"1": "Charing",
-					"2": "Error",
-					"3": "Not Available"
-				}
-			},
-			{
-				"path": "/ChargeEnable",
-				"type": "enum",
-				"name": "Charger Status",
-				"enum": {
-					"0": "Off",
-					"1": "On"
-				}
-			},
-			{
-				"path": "/Mode",
-				"type": "enum",
-				"name": "Charger Mode",
-				"enum": {
-					"0": "Standalone",
-					"1": "Master",
-					"2": "Slave"
-				}
-			},
-			{
-				"path": "/State",
-				"type": "enum",
-				"name": "Charger State",
-				"enum": {
-					"0": "Off",
-					"1": "Bulk",
-					"2": "Absorbtion",
-					"5": "Float",
-					"7": "Ext. Control",
-					"8": "Disabled",
-					"9": "Fault"
-				}
-			},
-            {
-                "path": "/History/EnergyOut",
-                "type": "float",
-                "name": "Total energy produced (kWh)"
-            },
-			{
-				"path": "/Alarms/LowVoltage",
-				"type": "enum",
-				"name": "Low voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/ChargerError",
-				"type": "enum",
-				"name": "Charger Error",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/Overload",
-				"type": "enum",
-				"name": "Charger Overload",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/Temperature",
-				"type": "enum",
-				"name": "Charger high temperature",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/AlternatorError",
-				"type": "enum",
-				"name": "Alternator Error",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-            {
-                "path": "/Alarms/HighVoltage",
-                "type": "enum",
-                "name": "High voltage alarm",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowStarterVoltage",
-                "type": "enum",
-                "name": "Low auxiliary voltage alarm",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighStarterVoltage",
-                "type": "enum",
-                "name": "High auxiliary voltage alarm",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/LowTemperature",
-                "type": "enum",
-                "name": "Low temperature alarm",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            },
-            {
-                "path": "/Alarms/HighTemperature",
-                "type": "enum",
-                "name": "High temperature alarm",
-                "enum": {
-                    "0": "Ok",
-                    "1": "Warning",
-                    "2": "Alarm"
-                }
-            }
-		]
-	},
-	"input-dcdc": {
-		"help": "<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is DC/DC, or a DC/DC controller which is interfaced to the Venus OS.</p>",
-		"dcdc": [
-			{
-				"path": "/Dc/0/Voltage",
-				"type": "float",
-				"name": "Voltage (V)"
-			},
-			{
-				"path": "/Dc/0/Current",
-				"type": "float",
-				"name": "Current (A)"
-			},
-			{
-				"path": "/Dc/0/Power",
-				"type": "float",
-				"name": "Battery power (W)"
-			},
-			{
-				"path": "/Dc/0/Temperature",
-				"type": "float",
-				"name": "Battery temperature (C)"
-			},
-			{
-				"path": "/ChargeEnable",
-				"type": "enum",
-				"name": "Charger Status",
-				"enum": {
-					"0": "Off",
-					"1": "On"
-				}
-			},
-			{
-				"path": "/Mode",
-				"type": "enum",
-				"name": "Charger Mode",
-				"enum": {
-					"0": "Standalone",
-					"1": "Master",
-					"2": "Slave"
-				}
-			},
-			{
-				"path": "/State",
-				"type": "enum",
-				"name": "Charger State",
-				"enum": {
-					"0": "Off",
-					"1": "Bulk",
-					"2": "Absorbtion",
-					"5": "Float",
-					"7": "Ext. Control",
-					"8": "Disabled",
-					"9": "Fault"
-				}
-			},
-			{
-				"path": "/Alarms/LowVoltage",
-				"type": "enum",
-				"name": "Low voltage alarm",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/ChargerError",
-				"type": "enum",
-				"name": "Charger Error",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/Overload",
-				"type": "enum",
-				"name": "Charger Overload",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			},
-			{
-				"path": "/Alarms/Temperature",
-				"type": "enum",
-				"name": "Charger high temperature",
-				"enum": {
-					"0": "No alarm",
-					"2": "Alarm"
-				}
-			}
-		]
-	},
-    "input-relay": {
-        "help": "<p>The <b>input-relay</b> node reads the state of the relay(s) of the Venus device.</p>",
-        "system": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Venus relay 1 state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            },
-            {
-                "path": "/Relay/1/State",
-                "type": "enum",
-                "name": "Venus relay 2 state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            },
-            {
-                "path": "/Relay/2/State",
-                "type": "enum",
-                "name": "Venus relay 3 state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            },
-            {
-                "path": "/Relay/3/State",
-                "type": "enum",
-                "name": "Venus relay 4 state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            }
-        ],
-        "battery": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay status",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            }
-        ],
-        "charger": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay on the charger",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            }
-        ],
-        "solarcharger": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay on the charger",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            }
-        ],
-        "inverter": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                }
-            }
-        ]
-    },
-    "output-relay": {
-        "help": "<p>The relays of the Venus device can be controled with this node. Make sure to set the relay(s) to <b>Manual</b> via the Venus OS GUI first. </p>",
-        "system": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Venus relay 1 state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Relay/1/State",
-                "type": "enum",
-                "name": "Venus relay 2 state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Relay/2/State",
-                "type": "enum",
-                "name": "Venus relay 3 state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Relay/3/State",
-                "type": "enum",
-                "name": "Venus relay 4 state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            }
-        ],
-        "battery": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay status",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            }
-        ],
-        "charger": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay on the charger",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            }
-        ],
-        "solarcharger": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay on the charger",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            }
-        ],
-        "inverter": [
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay state",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            }
-        ]
-    },
-    "output-inverter": {
-        "help": "<p>This node can be used for controlling the inverter.</p>",
-        "inverter": [
-            {
-                "path": "/Mode",
-                "type": "enum",
-                "name": "Mode",
-                "enum": {
-                    "2": "Inverter on",
-                    "4": "Off",
-                    "5": "Low Power/ECO"
-                },
-                "writable": true
-            }
-        ]
-    },
-    "output-accharger": {
-        "help": "<p>This node is for controlling the AC charger.</p>",
-        "charger": [
-            {
-                "path": "/Ac/In/CurrentLimit",
-                "type": "float",
-                "name": "AC Current limit (A)",
-                "writable": true
-            },
-            {
-                "path": "/Mode",
-                "type": "enum",
-                "name": "Charger on/off",
-                "enum": {
-                    "1": "On",
-                    "4": "Off"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Relay/0/State",
-                "type": "enum",
-                "name": "Relay on the charger",
-                "enum": {
-                    "0": "Open",
-                    "1": "Closed"
-                },
-                "writable": true
-            }
-        ]
-    },
-    "output-solarcharger": {
-        "help": "<p>With this node the solar charger can be switched on and off.</p>",
-        "solarcharger": [
-            {
-                "path": "/Mode",
-                "type": "enum",
-                "name": "Charger on/off",
-                "enum": {
-                    "1": "On",
-                    "4": "Off"
-                },
-                "writable": true
-            }
-        ]
-    },
-    "output-ess": {
-        "help": "<p>This node allows for controlling the Energy Storage System (ESS).</p>",
-        "vebus": [
-            {
-                "path": "/Hub4/DisableFeedIn",
-                "type": "enum",
-                "name": "Disable feed-in",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Hub4/DisableCharge",
-                "type": "enum",
-                "name": "Disable charge",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                },
-                "writable": true
-            },
-            {
-                "path": "/PvInverter/Disable",
-                "type": "enum",
-                "name": "Disable PV inverter",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L1/AcPowerSetpoint",
-                "type": "integer",
-                "name": "AC Power L1 setpoint (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L1/MaxFeedInPower",
-                "type": "integer",
-                "name": "Maximum overvoltage feed-in power L1 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L2/AcPowerSetpoint",
-                "type": "integer",
-                "name": "AC Power L2 setpoint (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L2/MaxFeedInPower",
-                "type": "integer",
-                "name": "Maximum overvoltage feed-in power L2 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L3/AcPowerSetpoint",
-                "type": "integer",
-                "name": "AC Power L3 setpoint (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/L3/MaxFeedInPower",
-                "type": "integer",
-                "name": "Maximum overvoltage feed-in power L3 (W)",
-                "writable": true
-            },
-            {
-                "path": "/Hub4/DoNotFeedInOvervoltage",
-                "type": "enum",
-                "name": "Feed in overvoltage",
-                "enum": {
-                    "1": "No",
-                    "0": "Yes"
-                },
-                "writable": true
-            },
-            {
-                "path": "/SystemReset",
-                "type": "enum",
-                "name": "VE.Bus Reset",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                },
-                "writable": true
-            }
-        ],
-        "settings": [
-            {
-                "path": "/Settings/CGwacs/AcPowerSetPoint",
-                "type": "integer",
-                "name": "Grid set-point (W)",
-                "writable": true
-            },
-            {
-                "path": "/Settings/CGwacs/BatteryLife/MinimumSocLimit",
-                "type": "integer",
-                "name": "Minimum Discharge SOC (%)",
-                "writable": true
-            },
-            {
-                "path": "/Settings/CGwacs/BatteryLife/State",
-                "type": "enum",
-                "name": "ESS state",
-                "enum": {
-                    "1": "BatteryLife enabled (GUI controlled)",
-                    "2": "Optimized Mode /w BatteryLife: self consumption",
-                    "3": "Optimized Mode /w BatteryLife: self consumption, SoC exceeds 85%",
-                    "4": "Optimized Mode /w BatteryLife: self consumption, SoC at 100%",
-                    "5": "Optimized Mode /w BatteryLife: SoC below dynamic SoC limit",
-                    "6": "Optimized Mode /w BatteryLife: SoC has been below SoC limit for more than 24 hours. Charging the battery (5A)",
-                    "7": "Optimized Mode /w BatteryLife: Inverter/Charger is in sustain mode",
-                    "8": "Optimized Mode /w BatteryLife: recharging, SoC dropped by 5% or more below the minimum SoC",
-                    "9": "'Keep batteries charged' mode is enabled",
-                    "10": "Optimized mode w/o BatteryLife: self consumption, SoC at or above minimum SoC",
-                    "11": "Optimized mode w/o BatteryLife: self consumption, SoC is below minimum SoC",
-                    "12": "Optimized mode w/o BatteryLife: recharging, SoC dropped by 5% or more below minimum SoC"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Settings/CGwacs/Hub4Mode",
-                "type": "enum",
-                "name": "ESS mode",
-                "enum": {
-                    "1": "Optimized mode or 'keep batteries charged' and phase compensation enabled",
-                    "2": "Optimized mode or 'keep batteries charged' and phase compensation disabled",
-                    "3": "External control"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Settings/CGwacs/MaxDischargePower",
-                "type": "integer",
-                "name": "Max inverter power (W)",
-                "writable": true
-            },
-            {
-                "path": "/Settings/CGwacs/OvervoltageFeedIn",
-                "type": "enum",
-                "name": "Feed-in excess solar charger power",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Settings/CGwacs/PreventFeedback",
-                "type": "enum",
-                "name": "PV Inverter zero feed-in (on/off)",
-                "enum": {
-                    "0": "No",
-                    "1": "Yes"
-                },
-                "writable": true
-            },
-            {
-                "path": "/Settings/SystemSetup/MaxChargeCurrent",
-                "type": "float",
-                "name": "Charge current limit (A)",
-                "writable": true
-            }
-        ]
-    },
-    "output-multi": {
-        "help": "<p>Multi RS output node.</p>",
-        "multi": [
-            {
-                "path" : "/Ac/In/1/CurrentLimit",
-                "type" : "float",
-                "name" : "Ac input 1 current limit (A)",
-                "writable": true
-            },
-            {
-                "path" : "/Ac/In/2/CurrentLimit",
-                "type" : "float",
-                "name" : "Ac input 2 current limit (A)",
-                "writable": true
-            },
-            {
-                "path" : "/Mode",
-                "type" : "enum",
-                "name" : "Switch position",
-                "enum" : {
-                    "1" : "Charger Only",
-                    "2" : "Inverter Only",
-                    "3" : "On",
-                    "4" : "Off"
-                },
-                "writable": true
-            }
-        ]
-    },
-    "output-evcharger": {
-        "help": "<p>With this node the ev charger can be controlled.</p>",
-        "evcharger": [
-          {
-              "path": "/MaxCurrent",
-              "type": "float",
-              "name": "Maximum charge current (A)",
-              "writable": true
-          },
-          {
-              "path": "/Mode",
-              "type": "enum",
-              "name": "Mode",
-              "enum": {
-                  "0": "Manual",
-                  "1": "Auto"
-              },
-              "writable": true
-          },
-          {
-              "path": "/SetCurrent",
-              "type": "float",
-              "name": "Set charge current (manual mode) (A)",
-              "writable": true
-          },
-          {
-              "path": "/StartStop",
-              "type": "enum",
-              "name": "Start/stop charging (manual mode)",
-              "enum": {
-                  "0": "Stop",
-                  "1": "Start"
-              },
-              "writable": true
-          }
-        ]
-    }
- 
+  "input-accharger": {
+    "help": "<p>The AC charger can be read with this node.</p>",
+    "charger": [
+      {
+        "path": "/Ac/In/CurrentLimit",
+        "type": "float",
+        "name": "AC Current limit (A)"
+      },
+      {
+        "path": "/Ac/In/L1/I",
+        "type": "float",
+        "name": "AC Current (A)"
+      },
+      {
+        "path": "/Ac/In/L1/P",
+        "type": "float",
+        "name": "AC Power (W)"
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Output 1 - current (A)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Output 1 - temperature (C)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Output 1 - voltage (V)"
+      },
+      {
+        "path": "/Dc/1/Current",
+        "type": "float",
+        "name": "Output 2 - current (A)"
+      },
+      {
+        "path": "/Dc/1/Temperature",
+        "type": "float",
+        "name": "Battery 1 temperature (C)"
+      },
+      {
+        "path": "/Dc/1/Voltage",
+        "type": "float",
+        "name": "Output 2 - voltage (V)"
+      },
+      {
+        "path": "/Dc/2/Current",
+        "type": "float",
+        "name": "Output 3 - current (A)"
+      },
+      {
+        "path": "/Dc/2/Temperature",
+        "type": "float",
+        "name": "Battery 2 temperature (C)"
+      },
+      {
+        "path": "/Dc/2/Voltage",
+        "type": "float",
+        "name": "Output 3 - voltage (V)"
+      },
+      {
+        "path": "/ErrorCode",
+        "type": "enum",
+        "name": "Error",
+        "enum": {
+          "0": "No error",
+          "1": "Err 1: Battery temperature too high",
+          "2": "Err 2: Battery voltage too high",
+          "3": "Err 3: Battery temperature sensor miswired (+)",
+          "4": "Err 3: Battery temperature sensor miswired (-)",
+          "5": "Err 5: Battery temperature sensor disconnected",
+          "6": "Err 6: Battery voltage sense miswired (+)",
+          "7": "Err 7: Battery voltage sense miswired (-)",
+          "8": "Err 8: Battery voltage sense disconnected",
+          "9": "Err 9: Battery voltage wire losses too high",
+          "17": "Err 17: Charger temperature too high",
+          "18": "Err 18: Charger over-current",
+          "19": "Err 19: Charger current polarity reversed",
+          "20": "Err 20: Bulk time limit reached",
+          "22": "Err 22: Charger temperature sensor miswired",
+          "23": "Err 23: Charger temperature sensor disconnected",
+          "34": "Err 34: Input current too high",
+          "67": "Err 67: No BMS"
+        }
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Charger on/off",
+        "enum": {
+          "1": "On",
+          "4": "Off"
+        }
+      },
+      {
+        "path": "/NrOfOutputs",
+        "type": "float",
+        "name": "Number of charger outputs"
+      },
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay on the charger",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "Charge state",
+        "enum": {
+          "0": "Off",
+          "2": "Fault",
+          "3": "Bulk",
+          "4": "Absorption",
+          "5": "Float",
+          "6": "Storage",
+          "7": "Equalize",
+          "11": "Power supply mode",
+          "246": "Repeated absorption",
+          "247": "Equalize",
+          "248": "Battery safe"
+        }
+      }
+    ]
+  },
+  "input-acload": {
+    "help": "<p>This node allows for AC load monitoring. Measuring can be done by using an energy meter and assigning it the 'ac load' role.</p>",
+    "acload": [
+      {
+        "path": "/Ac/L1/Current",
+        "type": "float",
+        "name": "L1 Current (A)"
+      },
+      {
+        "path": "/Ac/L1/Energy/Forward",
+        "type": "float",
+        "name": "L1 Energy (kWh)"
+      },
+      {
+        "path": "/Ac/L1/Power",
+        "type": "float",
+        "name": "L1 Power (W)"
+      },
+      {
+        "path": "/Ac/L1/Voltage",
+        "type": "float",
+        "name": "L1 Voltage (V AC)"
+      },
+      {
+        "path": "/Ac/L2/Current",
+        "type": "float",
+        "name": "L2 Current (A)"
+      },
+      {
+        "path": "/Ac/L2/Energy/Forward",
+        "type": "float",
+        "name": "L2 Energy (kWh)"
+      },
+      {
+        "path": "/Ac/L2/Power",
+        "type": "float",
+        "name": "L2 Power (W)"
+      },
+      {
+        "path": "/Ac/L2/Voltage",
+        "type": "float",
+        "name": "L2 Voltage (V AC)"
+      },
+      {
+        "path": "/Ac/L3/Current",
+        "type": "float",
+        "name": "L3 Current (A)"
+      },
+      {
+        "path": "/Ac/L3/Energy/Forward",
+        "type": "float",
+        "name": "L3 Energy (kWh)"
+      },
+      {
+        "path": "/Ac/L3/Power",
+        "type": "float",
+        "name": "L3 Power (W)"
+      },
+      {
+        "path": "/Ac/L3/Voltage",
+        "type": "float",
+        "name": "L3 Voltage (V AC)"
+      },
+      {
+        "path": "/Serial",
+        "type": "string",
+        "name": "Serial number"
+      }
+    ]
+  },
+  "input-alternator": {
+    "help": "<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is Alternator or an alternator controller which is interfaced to the Venus OS.</p>",
+    "alternator": [
+      {
+        "path": "/Alarms/AlternatorError",
+        "type": "enum",
+        "name": "Alternator Error",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/ChargerError",
+        "type": "enum",
+        "name": "Charger Error",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighStarterVoltage",
+        "type": "enum",
+        "name": "High auxiliary voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighTemperature",
+        "type": "enum",
+        "name": "High temperature alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowStarterVoltage",
+        "type": "enum",
+        "name": "Low auxiliary voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowTemperature",
+        "type": "enum",
+        "name": "Low temperature alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Overload",
+        "type": "enum",
+        "name": "Charger Overload",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Temperature",
+        "type": "enum",
+        "name": "Charger high temperature",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/AlternatorRPM",
+        "type": "float",
+        "name": "Alternator RPM"
+      },
+      {
+        "path": "/AlternatorStatus",
+        "type": "enum",
+        "name": "Alterntor Charging Status",
+        "enum": {
+          "0": "Not Charging",
+          "1": "Charing",
+          "2": "Error",
+          "3": "Not Available"
+        }
+      },
+      {
+        "path": "/ChargeEnable",
+        "type": "enum",
+        "name": "Charger Status",
+        "enum": {
+          "0": "Off",
+          "1": "On"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Current (A)"
+      },
+      {
+        "path": "/Dc/0/Power",
+        "type": "float",
+        "name": "Battery power (W)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Battery temperature (C)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Voltage (V)"
+      },
+      {
+        "path": "/Dc/1/Voltage",
+        "type": "float",
+        "name": "Auxiliary voltage (V DC)"
+      },
+      {
+        "path": "/EngineRPM",
+        "type": "float",
+        "name": "Engine RPM"
+      },
+      {
+        "path": "/FieldDrive",
+        "type": "float",
+        "name": "Alternator Field Drive %"
+      },
+      {
+        "path": "/History/EnergyOut",
+        "type": "float",
+        "name": "Total energy produced (kWh)"
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Charger Mode",
+        "enum": {
+          "0": "Standalone",
+          "1": "Master",
+          "2": "Slave"
+        }
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "Charger State",
+        "enum": {
+          "0": "Off",
+          "1": "Bulk",
+          "2": "Absorbtion",
+          "5": "Float",
+          "7": "Ext. Control",
+          "8": "Disabled",
+          "9": "Fault"
+        }
+      }
+    ]
+  },
+  "input-battery": {
+    "help": "<p>This node allows for monitoring the state of the battery.</p>",
+    "battery": [
+      {
+        "path": "/Alarms/Alarm",
+        "type": "enum",
+        "name": "Alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/CellImbalance",
+        "type": "enum",
+        "name": "Cell Imbalance alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/FuseBlown",
+        "type": "enum",
+        "name": "Fuse blown alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighChargeCurrent",
+        "type": "enum",
+        "name": "High charge current alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighChargeTemperature",
+        "type": "enum",
+        "name": "High charge temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighDischargeCurrent",
+        "type": "enum",
+        "name": "High discharge current alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighFusedVoltage",
+        "type": "enum",
+        "name": "High fused-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighInternalTemperature",
+        "type": "enum",
+        "name": "High internal-temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighStarterVoltage",
+        "type": "enum",
+        "name": "High starter-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighTemperature",
+        "type": "enum",
+        "name": "High battery temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/InternalFailure",
+        "type": "enum",
+        "name": "Internal error alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowCellVoltage",
+        "type": "enum",
+        "name": "Low cell voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Almost discharged",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowChargeTemperature",
+        "type": "enum",
+        "name": "Low charge temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowFusedVoltage",
+        "type": "enum",
+        "name": "Low fused-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowSoc",
+        "type": "enum",
+        "name": "Low state-of-charge alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowStarterVoltage",
+        "type": "enum",
+        "name": "Low starter-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowTemperature",
+        "type": "enum",
+        "name": "Low battery temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/MidVoltage",
+        "type": "enum",
+        "name": "Mid-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Balancing",
+        "type": "enum",
+        "name": "Balancing",
+        "enum": {
+          "0": "Inactive",
+          "1": "Active"
+        }
+      },
+      {
+        "path": "/Capacity",
+        "type": "float",
+        "name": "Capacity (Ah)"
+      },
+      {
+        "path": "/ConsumedAmphours",
+        "type": "float",
+        "name": "Consumed Amphours (Ah)"
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Current (A)"
+      },
+      {
+        "path": "/Dc/0/MidVoltage",
+        "type": "float",
+        "name": "Mid-point voltage of the battery bank (V)"
+      },
+      {
+        "path": "/Dc/0/MidVoltageDeviation",
+        "type": "float",
+        "name": "Mid-point deviation of the battery bank (%)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Battery temperature (C)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Voltage (V)"
+      },
+      {
+        "path": "/Dc/1/Voltage",
+        "type": "float",
+        "name": "Starter battery voltage (V)"
+      },
+      {
+        "path": "/Diagnostics/LastErrors/1/Error",
+        "type": "enum",
+        "name": "Diagnostics; 1st last error",
+        "enum": {
+          "0": "No error",
+          "1": "Battery initialization error",
+          "2": "No batteries connected",
+          "3": "Unknown battery connected",
+          "4": "Different battery type",
+          "5": "Number of batteries incorrect",
+          "6": "Lynx Shunt not found",
+          "7": "Battery measure error",
+          "8": "Internal calculation error",
+          "9": "Batteries in series not ok",
+          "10": "Number of batteries incorrect",
+          "11": "Hardware error",
+          "12": "Watchdog error",
+          "13": "Over voltage",
+          "14": "Under voltage",
+          "15": "Over temperature",
+          "16": "Under temperature",
+          "17": "Hardware fault",
+          "18": "Standby shutdown",
+          "19": "Pre-charge charge error",
+          "20": "Safety contactor check error",
+          "21": "Pre-charge discharge error",
+          "22": "ADC error",
+          "23": "Slave error",
+          "24": "Slave warning",
+          "25": "Pre-charge error",
+          "26": "Safety contactor error",
+          "27": "Over current",
+          "28": "Slave update failed",
+          "29": "Slave update unavailable",
+          "30": "Calibration data lost",
+          "31": "Settings invalid",
+          "32": "BMS cable",
+          "33": "Reference failure",
+          "34": "Wrong system voltage",
+          "35": "Pre-charge timeout"
+        }
+      },
+      {
+        "path": "/Diagnostics/LastErrors/1/Time",
+        "type": "float",
+        "name": "Diagnostics; 1st last error timestamp"
+      },
+      {
+        "path": "/Diagnostics/LastErrors/2/Time",
+        "type": "float",
+        "name": "Diagnostics; 2nd last error timestamp"
+      },
+      {
+        "path": "/Diagnostics/LastErrors/3/Time",
+        "type": "float",
+        "name": "Diagnostics; 3rd last error timestamp"
+      },
+      {
+        "path": "/Diagnostics/LastErrors/4/Time",
+        "type": "float",
+        "name": "Diagnostics; 4th last error timestamp"
+      },
+      {
+        "path": "/Diagnostics/ShutDownsDueError",
+        "type": "float",
+        "name": "Diagnostics; shutdowns due to error (count)"
+      },
+      {
+        "path": "/ErrorCode",
+        "type": "enum",
+        "name": "Error",
+        "enum": {
+          "0": "No error",
+          "1": "Battery initialization error",
+          "2": "No batteries connected",
+          "3": "Unknown battery connected",
+          "4": "Different battery type",
+          "5": "Number of batteries incorrect",
+          "6": "Lynx Shunt not found",
+          "7": "Battery measure error",
+          "8": "Internal calculation error",
+          "9": "Batteries in series not ok",
+          "10": "Number of batteries incorrect",
+          "11": "Hardware error",
+          "12": "Watchdog error",
+          "13": "Over voltage",
+          "14": "Under voltage",
+          "15": "Over temperature",
+          "16": "Under temperature",
+          "17": "Hardware fault",
+          "18": "Standby shutdown",
+          "19": "Pre-charge charge error",
+          "20": "Safety contactor check error",
+          "21": "Pre-charge discharge error",
+          "22": "ADC error",
+          "23": "Slave error",
+          "24": "Slave warning",
+          "25": "Pre-charge error",
+          "26": "Safety contactor error",
+          "27": "Over current",
+          "28": "Slave update failed",
+          "29": "Slave update unavailable",
+          "30": "Calibration data lost",
+          "31": "Settings invalid",
+          "32": "BMS cable",
+          "33": "Reference failure",
+          "34": "Wrong system voltage",
+          "35": "Pre-charge timeout"
+        }
+      },
+      {
+        "path": "/History/AutomaticSyncs",
+        "type": "float",
+        "name": "Automatic syncs (count)"
+      },
+      {
+        "path": "/History/AverageDischarge",
+        "type": "float",
+        "name": "Average discharge (Ah)"
+      },
+      {
+        "path": "/History/ChargeCycles",
+        "type": "float",
+        "name": "Charge cycles (count)"
+      },
+      {
+        "path": "/History/ChargedEnergy",
+        "type": "float",
+        "name": "Charged Energy (kWh)"
+      },
+      {
+        "path": "/History/DeepestDischarge",
+        "type": "float",
+        "name": "Deepest discharge (Ah)"
+      },
+      {
+        "path": "/History/DischargedEnergy",
+        "type": "float",
+        "name": "Discharged Energy (kWh)"
+      },
+      {
+        "path": "/History/FullDischarges",
+        "type": "float",
+        "name": "Full discharges (count)"
+      },
+      {
+        "path": "/History/HighFusedVoltageAlarms",
+        "type": "float",
+        "name": "High fused-voltage alarms (count)"
+      },
+      {
+        "path": "/History/HighStarterVoltageAlarms",
+        "type": "float",
+        "name": "High starter voltage alarms (count)"
+      },
+      {
+        "path": "/History/HighVoltageAlarms",
+        "type": "float",
+        "name": "High voltage alarms (count)"
+      },
+      {
+        "path": "/History/LastDischarge",
+        "type": "float",
+        "name": "Last discharge (Ah)"
+      },
+      {
+        "path": "/History/LowFusedVoltageAlarms",
+        "type": "float",
+        "name": "Low fused-voltage alarms (count)"
+      },
+      {
+        "path": "/History/LowStarterVoltageAlarms",
+        "type": "float",
+        "name": "Low starter voltage alarms (count)"
+      },
+      {
+        "path": "/History/LowVoltageAlarms",
+        "type": "float",
+        "name": "Low voltage alarms (count)"
+      },
+      {
+        "path": "/History/MaximumCellVoltage",
+        "type": "float",
+        "name": "History; Max cell-voltage (V DC)"
+      },
+      {
+        "path": "/History/MaximumFusedVoltage",
+        "type": "float",
+        "name": "Maximum fused voltage (V DC)"
+      },
+      {
+        "path": "/History/MaximumStarterVoltage",
+        "type": "float",
+        "name": "Maximum starter voltage (V DC)"
+      },
+      {
+        "path": "/History/MaximumVoltage",
+        "type": "float",
+        "name": "Maximum voltage (V DC)"
+      },
+      {
+        "path": "/History/MinimumCellVoltage",
+        "type": "float",
+        "name": "History; Min cell-voltage (V DC)"
+      },
+      {
+        "path": "/History/MinimumFusedVoltage",
+        "type": "float",
+        "name": "Minimum fused voltage (V DC)"
+      },
+      {
+        "path": "/History/MinimumStarterVoltage",
+        "type": "float",
+        "name": "Minimum starter voltage (V DC)"
+      },
+      {
+        "path": "/History/MinimumVoltage",
+        "type": "float",
+        "name": "Minimum voltage (V DC)"
+      },
+      {
+        "path": "/History/TimeSinceLastFullCharge",
+        "type": "float",
+        "name": "Time since last full charge (seconds)"
+      },
+      {
+        "path": "/History/TotalAhDrawn",
+        "type": "float",
+        "name": "Total Ah drawn (Ah)"
+      },
+      {
+        "path": "/Info/BatteryLowVoltage",
+        "type": "float",
+        "name": "Min discharge voltage (V DC)"
+      },
+      {
+        "path": "/Info/MaxChargeCurrent",
+        "type": "float",
+        "name": "CCL - Charge Current Limit (A)"
+      },
+      {
+        "path": "/Info/MaxChargeVoltage",
+        "type": "float",
+        "name": "CVL - Charge Voltage Limit (V)"
+      },
+      {
+        "path": "/Info/MaxDischargeCurrent",
+        "type": "float",
+        "name": "DCL - Discharge Current Limit (A)"
+      },
+      {
+        "path": "/Io/AllowToCharge",
+        "type": "enum",
+        "name": "ATC (Allow to Charge)",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Io/AllowToDischarge",
+        "type": "enum",
+        "name": "ATD (Allow to Discharge)",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Io/ExternalRelay",
+        "type": "enum",
+        "name": "IO; external relay",
+        "enum": {
+          "0": "Inactive",
+          "1": "Active"
+        }
+      },
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay status",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      },
+      {
+        "path": "/Soc",
+        "type": "float",
+        "name": "State of charge (%)"
+      },
+      {
+        "path": "/Soh",
+        "type": "float",
+        "name": "State of health (%)"
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "State",
+        "enum": {
+          "0": "Initializing (Wait start)",
+          "1": "Initializing (before boot)",
+          "2": "Initializing (Before boot delay)",
+          "3": "Initializing (Wait boot)",
+          "4": "Initializing",
+          "5": "Initializing (Measure battery voltage)",
+          "6": "Initializing (Calculate battery voltage)",
+          "7": "Initializing (Wait bus voltage)",
+          "8": "Initializing (Wait for lynx shunt)",
+          "9": "Running",
+          "10": "Error (10)",
+          "11": "Unused (11)",
+          "12": "Shutdown",
+          "13": "Slave updating",
+          "14": "Standby",
+          "15": "Going to run",
+          "16": "Pre-charging"
+        }
+      },
+      {
+        "path": "/System/BatteriesParallel",
+        "type": "float",
+        "name": "System; batteries parallel (count)"
+      },
+      {
+        "path": "/System/BatteriesSeries",
+        "type": "float",
+        "name": "System; batteries series (count)"
+      },
+      {
+        "path": "/System/MaxCellTemperature",
+        "type": "float",
+        "name": "Maximum cell temperature (Degrees celsius)"
+      },
+      {
+        "path": "/System/MaxCellVoltage",
+        "type": "float",
+        "name": "System; maximum cell voltage (V DC)"
+      },
+      {
+        "path": "/System/MinCellTemperature",
+        "type": "float",
+        "name": "Minimum cell temperature (Degrees celsius)"
+      },
+      {
+        "path": "/System/MinCellVoltage",
+        "type": "float",
+        "name": "System; minimum cell voltage (V DC)"
+      },
+      {
+        "path": "/System/NrOfBatteries",
+        "type": "float",
+        "name": "System; number of batteries (count)"
+      },
+      {
+        "path": "/System/NrOfCellsPerBattery",
+        "type": "float",
+        "name": "System; number of cells per battery (count)"
+      },
+      {
+        "path": "/SystemSwitch",
+        "type": "enum",
+        "name": "System-switch",
+        "enum": {
+          "0": "Disabled",
+          "1": "Enabled"
+        }
+      },
+      {
+        "path": "/TimeToGo",
+        "type": "float",
+        "name": "Time to go (h)"
+      }
+    ]
+  },
+  "input-dcdc": {
+    "help": "<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is DC/DC, or a DC/DC controller which is interfaced to the Venus OS.</p>",
+    "dcdc": [
+      {
+        "path": "/Alarms/ChargerError",
+        "type": "enum",
+        "name": "Charger Error",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Overload",
+        "type": "enum",
+        "name": "Charger Overload",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Temperature",
+        "type": "enum",
+        "name": "Charger high temperature",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/ChargeEnable",
+        "type": "enum",
+        "name": "Charger Status",
+        "enum": {
+          "0": "Off",
+          "1": "On"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Current (A)"
+      },
+      {
+        "path": "/Dc/0/Power",
+        "type": "float",
+        "name": "Battery power (W)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Battery temperature (C)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Voltage (V)"
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Charger Mode",
+        "enum": {
+          "0": "Standalone",
+          "1": "Master",
+          "2": "Slave"
+        }
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "Charger State",
+        "enum": {
+          "0": "Off",
+          "1": "Bulk",
+          "2": "Absorbtion",
+          "5": "Float",
+          "7": "Ext. Control",
+          "8": "Disabled",
+          "9": "Fault"
+        }
+      }
+    ]
+  },
+  "input-dcload": {
+    "help": "<p>This node allows for monitoring the state BMVs configured in Monitor Mode and DC meter type is a load.</p>",
+    "dcload": [
+      {
+        "path": "/Alarms/HighStarterVoltage",
+        "type": "enum",
+        "name": "High starter-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighTemperature",
+        "type": "enum",
+        "name": "High battery temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowStarterVoltage",
+        "type": "enum",
+        "name": "Low starter-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowTemperature",
+        "type": "enum",
+        "name": "Low battery temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/MidVoltage",
+        "type": "enum",
+        "name": "Mid-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Current (A)"
+      },
+      {
+        "path": "/Dc/0/MidVoltage",
+        "type": "float",
+        "name": "Mid-point voltage of the battery bank (V)"
+      },
+      {
+        "path": "/Dc/0/MidVoltageDeviation",
+        "type": "float",
+        "name": "Mid-point deviation of the battery bank (%)"
+      },
+      {
+        "path": "/Dc/0/Power",
+        "type": "float",
+        "name": "Battery power (W)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Battery temperature (C)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Voltage (V)"
+      },
+      {
+        "path": "/Dc/1/Voltage",
+        "type": "float",
+        "name": "Starter battery voltage (V)"
+      },
+      {
+        "path": "/History/EnergyIn",
+        "type": "float",
+        "name": "Total energy consumed (kWh)"
+      },
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay status",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      }
+    ]
+  },
+  "input-dcsource": {
+    "help": "<p>This node allows for monitoring the state of Battery Monitor Victron devices (BMV's) configured in Monitor Mode and DC meter type is a source.</p>",
+    "dcsource": [
+      {
+        "path": "/Alarms/HighStarterVoltage",
+        "type": "enum",
+        "name": "High starter-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighTemperature",
+        "type": "enum",
+        "name": "High battery temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowStarterVoltage",
+        "type": "enum",
+        "name": "Low starter-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowTemperature",
+        "type": "enum",
+        "name": "Low battery temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/MidVoltage",
+        "type": "enum",
+        "name": "Mid-voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Current (A)"
+      },
+      {
+        "path": "/Dc/0/MidVoltage",
+        "type": "float",
+        "name": "Mid-point voltage of the battery bank (V)"
+      },
+      {
+        "path": "/Dc/0/MidVoltageDeviation",
+        "type": "float",
+        "name": "Mid-point deviation of the battery bank (%)"
+      },
+      {
+        "path": "/Dc/0/Power",
+        "type": "float",
+        "name": "Battery power (W)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Battery temperature (C)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Voltage (V)"
+      },
+      {
+        "path": "/Dc/1/Voltage",
+        "type": "float",
+        "name": "Starter battery voltage (V)"
+      },
+      {
+        "path": "/History/EnergyOut",
+        "type": "float",
+        "name": "Total energy produced (kWh)"
+      },
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay status",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      }
+    ]
+  },
+  "input-dcsystem": {
+    "help": "<p>DC system input node is a DC measurement for loads in your system.</p>",
+    "dcsystem": [
+      {
+        "path": "/Alarms/HighStarterVoltage",
+        "type": "enum",
+        "name": "High auxiliary voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighTemperature",
+        "type": "enum",
+        "name": "High temperature alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowStarterVoltage",
+        "type": "enum",
+        "name": "Low auxiliary voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowTemperature",
+        "type": "enum",
+        "name": "Low temperature alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Battery current (A)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Temperature (Degrees celsius)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Battery voltage (V DC)"
+      },
+      {
+        "path": "/Dc/1/Voltage",
+        "type": "float",
+        "name": "Auxiliary voltage (V DC)"
+      },
+      {
+        "path": "/History/EnergyIn",
+        "type": "float",
+        "name": "Total energy consumed (kWh)"
+      },
+      {
+        "path": "/History/EnergyOut",
+        "type": "float",
+        "name": "Total energy produced (kWh)"
+      }
+    ]
+  },
+  "input-digitalinput": {
+    "help": "<p>With this node it is possible to read the digital inputs from the Venus device. The node only shows the enabled digital inputs, so first make sure to enable the input from the Venus OS GUI (<i>Settings -> I/O -> digital inputs</i>) for the desired readout.</p><p>Depending on the selected type of input, different measurements become available.</p><p>Also see the section on <a href=\"https://www.victronenergy.com/media/pg/Cerbo_GX/en/digital-inputs.html\">digital inputs</a> in the Cerbo GX manual.</p>",
+    "pulsemeter": [
+      {
+        "path": "/Aggregate",
+        "type": "float",
+        "name": "Pulse meter aggregate"
+      },
+      {
+        "path": "/Count",
+        "type": "float",
+        "name": "Pulse meter count"
+      }
+    ],
+    "digitalinput": [
+      {
+        "path": "/Alarm",
+        "type": "enum",
+        "name": "Digital input alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Count",
+        "type": "float",
+        "name": "Digital input count"
+      },
+      {
+        "path": "/ProductId",
+        "type": "string",
+        "name": "Digital input product id"
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "Digital input state",
+        "enum": {
+          "0": "low",
+          "1": "high",
+          "2": "off",
+          "3": "on",
+          "4": "no",
+          "5": "yes",
+          "6": "open",
+          "7": "closed",
+          "8": "ok",
+          "9": "alarm",
+          "10": "running",
+          "11": "stopped"
+        }
+      },
+      {
+        "path": "/Type",
+        "type": "enum",
+        "name": "Digital input type",
+        "enum": {
+          "0": "Disabled",
+          "1": "Pulse meter",
+          "2": "Door sensor",
+          "3": "Bilge pump",
+          "4": "Bilge alarm",
+          "5": "Burglar alarm",
+          "6": "Smoke alarm",
+          "7": "Fire alarm",
+          "8": "CO2 alarm",
+          "9": "Generic input"
+        }
+      }
+    ]
+  },
+  "input-ess": {
+    "help": "<p>This node gives information on the energy storage system (ESS).</p>",
+    "vebus": [
+      {
+        "path": "/Hub4/DisableCharge",
+        "type": "enum",
+        "name": "Disable charge",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Hub4/DisableFeedIn",
+        "type": "enum",
+        "name": "Disable feed-in",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Hub4/DoNotFeedInOvervoltage",
+        "type": "enum",
+        "name": "Feed in overvoltage",
+        "enum": {
+          "0": "Yes",
+          "1": "No"
+        }
+      },
+      {
+        "path": "/Hub4/L1/AcPowerSetpoint",
+        "type": "integer",
+        "name": "AC Power L1 setpoint (W)"
+      },
+      {
+        "path": "/Hub4/L1/MaxFeedInPower",
+        "type": "integer",
+        "name": "Maximum overvoltage feed-in power L1 (W)"
+      },
+      {
+        "path": "/Hub4/L2/AcPowerSetpoint",
+        "type": "integer",
+        "name": "AC Power L2 setpoint (W)"
+      },
+      {
+        "path": "/Hub4/L2/MaxFeedInPower",
+        "type": "integer",
+        "name": "Maximum overvoltage feed-in power L2 (W)"
+      },
+      {
+        "path": "/Hub4/L3/MaxFeedInPower",
+        "type": "integer",
+        "name": "Maximum overvoltage feed-in power L3 (W)"
+      },
+      {
+        "path": "/Hub4/L3/AcPowerSetpoint",
+        "type": "integer",
+        "name": "AC Power L3 setpoint (W)"
+      },
+      {
+        "path": "/PvInverter/Disable",
+        "type": "enum",
+        "name": "Disable PV inverter",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/SystemReset",
+        "type": "enum",
+        "name": "VE.Bus Reset",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      }
+    ],
+    "settings": [
+      {
+        "path": "/Settings/CGwacs/AcPowerSetPoint",
+        "type": "integer",
+        "name": "Grid set-point (W)"
+      },
+      {
+        "path": "/Settings/CGwacs/BatteryLife/MinimumSocLimit",
+        "type": "integer",
+        "name": "Minimum Discharge SOC (%)"
+      },
+      {
+        "path": "/Settings/CGwacs/BatteryLife/SocLimit",
+        "type": "integer",
+        "name": "Active SOC limit (%)"
+      },
+      {
+        "path": "/Settings/CGwacs/BatteryLife/State",
+        "type": "enum",
+        "name": "ESS state",
+        "enum": {
+          "1": "BatteryLife enabled (GUI controlled)",
+          "2": "Optimized Mode /w BatteryLife: self consumption",
+          "3": "Optimized Mode /w BatteryLife: self consumption, SoC exceeds 85%",
+          "4": "Optimized Mode /w BatteryLife: self consumption, SoC at 100%",
+          "5": "Optimized Mode /w BatteryLife: SoC below dynamic SoC limit",
+          "6": "Optimized Mode /w BatteryLife: SoC has been below SoC limit for more than 24 hours. Charging the battery (5A)",
+          "7": "Optimized Mode /w BatteryLife: Inverter/Charger is in sustain mode",
+          "8": "Optimized Mode /w BatteryLife: recharging, SoC dropped by 5% or more below the minimum SoC",
+          "9": "'Keep batteries charged' mode is enabled",
+          "10": "Optimized mode w/o BatteryLife: self consumption, SoC at or above minimum SoC",
+          "11": "Optimized mode w/o BatteryLife: self consumption, SoC is below minimum SoC",
+          "12": "Optimized mode w/o BatteryLife: recharging, SoC dropped by 5% or more below minimum SoC"
+        }
+      },
+      {
+        "path": "/Settings/CGwacs/Hub4Mode",
+        "type": "enum",
+        "name": "ESS mode",
+        "enum": {
+          "1": "Optimized mode or 'keep batteries charged' and phase compensation enabled",
+          "2": "Optimized mode or 'keep batteries charged' and phase compensation disabled",
+          "3": "External control"
+        }
+      },
+      {
+        "path": "/Settings/CGwacs/MaxDischargePower",
+        "type": "integer",
+        "name": "Max inverter power (W)"
+      },
+      {
+        "path": "/Settings/CGwacs/OvervoltageFeedIn",
+        "type": "enum",
+        "name": "Feed-in excess solar charger power",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Settings/CGwacs/PreventFeedback",
+        "type": "enum",
+        "name": "PV Inverter zero feed-in (on/off)",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Settings/SystemSetup/MaxChargeCurrent",
+        "type": "float",
+        "name": "Charge current limit (A)"
+      }
+    ]
+  },
+  "input-evcharger": {
+    "help": "<p>EV charger input node</p>",
+    "evcharger": [
+      {
+        "path": "/Ac/Energy/Forward",
+        "type": "float",
+        "name": "Energy consumed by charger (kWh)"
+      },
+      {
+        "path": "/Ac/L1/Power",
+        "type": "float",
+        "name": "L1 Power (W)"
+      },
+      {
+        "path": "/Ac/L2/Power",
+        "type": "float",
+        "name": "L2 Power (W)"
+      },
+      {
+        "path": "/Ac/L3/Power",
+        "type": "float",
+        "name": "L3 Power (W)"
+      },
+      {
+        "path": "/Ac/Power",
+        "type": "float",
+        "name": "Total power (W)"
+      },
+      {
+        "path": "/ChargingTime",
+        "type": "float",
+        "name": "Charging time (seconds)"
+      },
+      {
+        "path": "/Current",
+        "type": "float",
+        "name": "Charge current (A)"
+      },
+      {
+        "path": "/FirmwareVersion",
+        "type": "float",
+        "name": "Firmware version"
+      },
+      {
+        "path": "/MaxCurrent",
+        "type": "float",
+        "name": "Maximum charge current (A)"
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Mode",
+        "enum": {
+          "0": "Manual",
+          "1": "Auto"
+        }
+      },
+      {
+        "path": "/Model",
+        "type": "float",
+        "name": "Model"
+      },
+      {
+        "path": "/ProductId",
+        "type": "float",
+        "name": "Product ID"
+      },
+      {
+        "path": "/Serial",
+        "type": "string",
+        "name": "Serial"
+      },
+      {
+        "path": "/SetCurrent",
+        "type": "float",
+        "name": "Set charge current (manual mode) (A)"
+      },
+      {
+        "path": "/StartStop",
+        "type": "enum",
+        "name": "Start/stop charging (manual mode)",
+        "enum": {
+          "0": "Stop",
+          "1": "Start"
+        }
+      },
+      {
+        "path": "/Status",
+        "type": "enum",
+        "name": "Status",
+        "enum": {
+          "0": "Disconnected",
+          "1": "Connected",
+          "2": "Charging",
+          "3": "Charged",
+          "4": "Waiting for sun",
+          "5": "Waiting for RFID",
+          "6": "Waiting for start",
+          "7": "Low SOC",
+          "8": "Ground fault",
+          "9": "Welded contacts",
+          "10": "CP Input shorted",
+          "11": "Residual current detected",
+          "12": "Under voltage detected",
+          "13": "Overvoltage detected",
+          "14": "Overheating detected"
+        }
+      }
+    ]
+  },
+  "input-generator": {
+    "help": "<p>Generator input node for Fischer Panda generators. Also see <a href=\"https://github.com/victronenergy/venus/wiki/dbus#generator\">here</a> for more information.</p>",
+    "generator": [
+      {
+        "path": "/Generator0/Alarms/NoGeneratorAtAcIn",
+        "type": "enum",
+        "name": "Generator not detected at AC input alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Generator0/Error",
+        "type": "enum",
+        "name": "Generator remote error",
+        "enum": {
+          "0": "No Error",
+          "1": "Remote disabled",
+          "2": "Remote fault"
+        }
+      },
+      {
+        "path": "/Generator0/RunningByConditionCode",
+        "type": "enum",
+        "name": "Condition that started the generator",
+        "enum": {
+          "0": "Stopped",
+          "1": "Manual",
+          "2": "TestRun",
+          "3": "LossOfComms",
+          "4": "Soc",
+          "5": "AcLoad",
+          "6": "BatteryCurrent",
+          "7": "BatteryVoltage",
+          "8": "InverterTemperatur",
+          "9": "InverterOverload",
+          "10": "StopOnAc1"
+        }
+      },
+      {
+        "path": "/Generator0/Runtime",
+        "type": "float",
+        "name": "Runtime in seconds (seconds)"
+      },
+      {
+        "path": "/Generator0/State",
+        "type": "enum",
+        "name": "Generator start/stop state",
+        "enum": {
+          "0": "Stopped",
+          "1": "Running",
+          "10": "Error"
+        }
+      }
+    ]
+  },
+  "input-genset": {
+    "help": "<p>This node is essentially an energy meter showing volts, amps, power, energy etc. It is comparable with the input-gridmeter.</p>",
+    "genset": [
+      {
+        "path": "/Ac/L1/Current",
+        "type": "float",
+        "name": "Phase 1 current (A AC)"
+      },
+      {
+        "path": "/Ac/L1/Frequency",
+        "type": "float",
+        "name": "Phase 1 frequency (Hz)"
+      },
+      {
+        "path": "/Ac/L1/Power",
+        "type": "float",
+        "name": "Phase 1 power (W)"
+      },
+      {
+        "path": "/Ac/L1/Voltage",
+        "type": "float",
+        "name": "Phase 1 voltage (V AC)"
+      },
+      {
+        "path": "/Ac/L2/Current",
+        "type": "float",
+        "name": "Phase 2 current (A AC)"
+      },
+      {
+        "path": "/Ac/L2/Frequency",
+        "type": "float",
+        "name": "Phase 2 frequency (Hz)"
+      },
+      {
+        "path": "/Ac/L2/Power",
+        "type": "float",
+        "name": "Phase 2 power (W)"
+      },
+      {
+        "path": "/Ac/L2/Voltage",
+        "type": "float",
+        "name": "Phase 2 voltage (V AC)"
+      },
+      {
+        "path": "/Ac/L3/Current",
+        "type": "float",
+        "name": "Phase 3 current (A AC)"
+      },
+      {
+        "path": "/Ac/L3/Frequency",
+        "type": "float",
+        "name": "Phase 3 frequency (Hz)"
+      },
+      {
+        "path": "/Ac/L3/Power",
+        "type": "float",
+        "name": "Phase 3 power (W)"
+      },
+      {
+        "path": "/Ac/L3/Voltage",
+        "type": "float",
+        "name": "Phase 3 voltage (V AC)"
+      },
+      {
+        "path": "/AutoStart",
+        "type": "enum",
+        "name": "Auto start",
+        "enum": {
+          "0": "Disabled",
+          "1": "Enabled"
+        }
+      },
+      {
+        "path": "/Engine/CoolantTemperature",
+        "type": "float",
+        "name": "Engine coolant temperature (Degrees celsius)"
+      },
+      {
+        "path": "/Engine/ExaustTemperature",
+        "type": "float",
+        "name": "Engine exhaust temperature (Degrees celsius)"
+      },
+      {
+        "path": "/Engine/Load",
+        "type": "float",
+        "name": "Engine load (%)"
+      },
+      {
+        "path": "/Engine/OperatingHours",
+        "type": "float",
+        "name": "Engine operating hours (s)"
+      },
+      {
+        "path": "/Engine/Speed",
+        "type": "float",
+        "name": "Engine speed (RPM)"
+      },
+      {
+        "path": "/Engine/WindingTemperature",
+        "type": "float",
+        "name": "Engine winding temperature (Degrees celsius)"
+      },
+      {
+        "path": "/ErrorCode",
+        "type": "enum",
+        "name": "Error",
+        "enum": {
+          "0": "No error",
+          "1": "AC voltage L1 too low",
+          "2": "AC frequency L1 too low",
+          "3": "AC current too low",
+          "4": "AC power too low",
+          "5": "Emergency stop",
+          "6": "Servo current too low",
+          "7": "Oil pressure too low",
+          "8": "Engine temperature too low",
+          "9": "Winding temperature too low",
+          "10": "Exhaust temperature too low",
+          "13": "Starter current too low",
+          "14": "Glow current too low",
+          "15": "Glow current too low",
+          "16": "Fuel holding magnet current too low",
+          "17": "Stop solenoid hold coil current too low",
+          "18": "Stop solenoid pull coil current too low",
+          "19": "Optional DC out current too low",
+          "20": "5V output voltage too low",
+          "21": "Boost output current too low",
+          "22": "Panel supply current too high",
+          "25": "Starter battery voltage too low",
+          "26": "Startup aborted (rotation too low)",
+          "28": "Rotation too low",
+          "29": "Power contactor current too low",
+          "30": "AC voltage L2 too low",
+          "31": "AC frequency L2 too low",
+          "32": "AC current L2 too low",
+          "33": "AC power L2 too low",
+          "34": "AC voltage L3 too low",
+          "35": "AC frequency L3 too low",
+          "36": "AC current L3 too low",
+          "37": "AC power L3 too low",
+          "62": "Fuel temperature too low",
+          "63": "Fuel level too low",
+          "65": "AC voltage L1 too high",
+          "66": "AC frequency too high",
+          "67": "AC current too high",
+          "68": "AC power too high",
+          "70": "Servo current too high",
+          "71": "Oil pressure too high",
+          "72": "Engine temperature too high",
+          "73": "Winding temperature too high",
+          "74": "Exhaust temperature too low",
+          "77": "Starter current too low",
+          "78": "Glow current too high",
+          "79": "Glow current too high",
+          "80": "Fuel holding magnet current too high",
+          "81": "Stop solenoid hold coil current too high",
+          "82": "Stop solenoid pull coil current too high",
+          "83": "Optional DC out current too high",
+          "84": "5V output voltage too high",
+          "85": "Boost output current too high",
+          "89": "Starter battery voltage too high",
+          "90": "Startup aborted (rotation too high)",
+          "92": "Rotation too high",
+          "93": "Power contactor current too high",
+          "94": "AC voltage L2 too high",
+          "95": "AC frequency L2 too high",
+          "96": "AC current L2 too high",
+          "97": "AC power L2 too high",
+          "98": "AC voltage L3 too high",
+          "99": "AC frequency L3 too high",
+          "100": "AC current L3 too high",
+          "101": "AC power L3 too high",
+          "126": "Fuel temperature too high",
+          "127": "Fuel level too high",
+          "130": "Lost control unit",
+          "131": "Lost panel",
+          "132": "Service needed",
+          "133": "Lost 3-phase module",
+          "134": "Lost AGT module",
+          "135": "Synchronization failure",
+          "137": "Intake airfilter",
+          "139": "Lost sync. module",
+          "140": "Load-balance failed",
+          "141": "Sync-mode deactivated",
+          "142": "Engine controller",
+          "148": "Rotating field wrong",
+          "149": "Fuel level sensor lost",
+          "150": "Init failed",
+          "151": "Watchdog",
+          "152": "Out: winding",
+          "153": "Out: exhaust",
+          "154": "Out: Cyl. head",
+          "155": "Inverter over temperature",
+          "156": "Inverter overload",
+          "157": "Inverter communication lost",
+          "158": "Inverter sync failed",
+          "159": "CAN communication lost",
+          "160": "L1 overload",
+          "161": "L2 overload",
+          "162": "L3 overload",
+          "163": "DC overload",
+          "164": "DC overvoltage",
+          "165": "Emergency stop",
+          "166": "No connection"
+        }
+      },
+      {
+        "path": "/ProductId",
+        "type": "float",
+        "name": "Generator model"
+      },
+      {
+        "path": "/StarterVoltage",
+        "type": "float",
+        "name": "Starter voltage (V DC)"
+      },
+      {
+        "path": "/StatusCode",
+        "type": "enum",
+        "name": "Status",
+        "enum": {
+          "0": "Standby",
+          "1": "Startup 1",
+          "2": "Startup 2",
+          "3": "Startup 3",
+          "4": "Startup 4",
+          "5": "Startup 5",
+          "6": "Startup 6",
+          "7": "Startup 7",
+          "8": "Running",
+          "9": "Stopping",
+          "10": "Error"
+        }
+      }
+    ]
+  },
+  "input-gps": {
+    "help": "<p>GPS information can be obtained with this node. For an example usage see the <a href=\"https://github.com/victronenergy/node-red-contrib-victron/wiki/Example-Flows#location-based-scheduling\">location based scheduling</a> example.</p>",
+    "gps": [
+      {
+        "path": "/Altitude",
+        "type": "float",
+        "name": "Altitude (m)"
+      },
+      {
+        "path": "/Course",
+        "type": "float",
+        "name": "Course (Deg)"
+      },
+      {
+        "path": "/Fix",
+        "type": "integer",
+        "name": "Fix"
+      },
+      {
+        "path": "/NrOfSatellites",
+        "type": "integer",
+        "name": "Number of satellites"
+      },
+      {
+        "path": "/Position/Latitude",
+        "type": "float",
+        "name": "Latitude (LAT)"
+      },
+      {
+        "path": "/Position/Longitude",
+        "type": "float",
+        "name": "Longitude (LNG)"
+      },
+      {
+        "path": "/Speed",
+        "type": "float",
+        "name": "Speed (m/s)"
+      }
+    ]
+  },
+  "input-gridmeter": {
+    "help": "<p>This node gives allows for monitoring the grid. See also <a href=\"https://www.victronenergy.com/accessories/energy-meter\">energy meters</a> accessoires.</p>",
+    "grid": [
+      {
+        "path": "/Ac/Energy/Forward",
+        "type": "float",
+        "name": "Total Forward Energy (bought) (kWh)"
+      },
+      {
+        "path": "/Ac/Energy/Reverse",
+        "type": "float",
+        "name": "Total Reverse Energy (sold) (kWh)"
+      },
+      {
+        "path": "/Ac/L1/Current",
+        "type": "float",
+        "name": "L1 Current (A)"
+      },
+      {
+        "path": "/Ac/L1/Energy/Forward",
+        "type": "float",
+        "name": "L1 Forward energy (bought) (kWh)"
+      },
+      {
+        "path": "/Ac/L1/Energy/Reverse",
+        "type": "float",
+        "name": "L1 Reverse energy (sold) (kWh)"
+      },
+      {
+        "path": "/Ac/L1/Power",
+        "type": "float",
+        "name": "L1 Power (W)"
+      },
+      {
+        "path": "/Ac/L1/Voltage",
+        "type": "float",
+        "name": "L1 Voltage (V)"
+      },
+      {
+        "path": "/Ac/L2/Current",
+        "type": "float",
+        "name": "L2 Current (A)"
+      },
+      {
+        "path": "/Ac/L2/Energy/Forward",
+        "type": "float",
+        "name": "L2 Forward energy (bought) (kWh)"
+      },
+      {
+        "path": "/Ac/L2/Energy/Reverse",
+        "type": "float",
+        "name": "L2 Reverse energy (sold) (kWh)"
+      },
+      {
+        "path": "/Ac/L2/Power",
+        "type": "float",
+        "name": "L2 Power (W)"
+      },
+      {
+        "path": "/Ac/L2/Voltage",
+        "type": "float",
+        "name": "L2 Voltage (V)"
+      },
+      {
+        "path": "/Ac/L3/Current",
+        "type": "float",
+        "name": "L2 Current (A)"
+      },
+      {
+        "path": "/Ac/L3/Energy/Forward",
+        "type": "float",
+        "name": "L3 Forward energy (bought) (kWh)"
+      },
+      {
+        "path": "/Ac/L3/Energy/Reverse",
+        "type": "float",
+        "name": "L3 Reverse energy (sold) (kWh)"
+      },
+      {
+        "path": "/Ac/L3/Power",
+        "type": "float",
+        "name": "L3 Power (W)"
+      },
+      {
+        "path": "/Ac/L3/Voltage",
+        "type": "float",
+        "name": "L3 Voltage (V)"
+      },
+      {
+        "path": "/Ac/Power",
+        "type": "float",
+        "name": "Power (W)"
+      },
+      {
+        "path": "/Serial",
+        "type": "string",
+        "name": "Serial"
+      }
+    ]
+  },
+  "input-inverter": {
+    "help": "<p>This node is for reading from an inverter.</p>",
+    "inverter": [
+      {
+        "path": "/Ac/Out/L1/I",
+        "type": "float",
+        "name": "Output current (A)"
+      },
+      {
+        "path": "/Ac/Out/L1/P",
+        "type": "float",
+        "name": "Output power (W AC)"
+      },
+      {
+        "path": "/Ac/Out/L1/V",
+        "type": "float",
+        "name": "Output voltage (V)"
+      },
+      {
+        "path": "/Alarms/HighTemperature",
+        "type": "enum",
+        "name": "High temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High battery voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltageAcOut",
+        "type": "enum",
+        "name": "High AC-Out voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowTemperature",
+        "type": "enum",
+        "name": "Low temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low battery voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltageAcOut",
+        "type": "enum",
+        "name": "Low AC-Out voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Overload",
+        "type": "enum",
+        "name": "Overload alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Ripple",
+        "type": "enum",
+        "name": "Ripple alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Battery current (A DC)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Input voltage (V)"
+      },
+      {
+        "path": "/Energy/InverterToAcOut",
+        "type": "float",
+        "name": "Energy from battery to AC-out (kWh)"
+      },
+      {
+        "path": "/Energy/OutToInverter",
+        "type": "float",
+        "name": "Energy from AC-out to battery (kWh)"
+      },
+      {
+        "path": "/Energy/SolarToAcOut",
+        "type": "float",
+        "name": "Energy from solar to AC-out (kWh)"
+      },
+      {
+        "path": "/Energy/SolarToBattery",
+        "type": "float",
+        "name": "Energy from solar to battery (kWh)"
+      },
+      {
+        "path": "/FirmwareVersion",
+        "type": "float",
+        "name": "Firmware version"
+      },
+      {
+        "path": "/History/Daily/0/Pv/0/MaxPower",
+        "type": "float",
+        "name": "Maximum power for today on tracker 0 (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/0/Yield",
+        "type": "float",
+        "name": "Yield today for today on tracker 0 (kWh)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/1/MaxPower",
+        "type": "float",
+        "name": "Maximum power for today on tracker 1 (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/1/Yield",
+        "type": "float",
+        "name": "Yield today for today on tracker 1 (kWh)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/2/MaxPower",
+        "type": "float",
+        "name": "Maximum power for today on tracker 2 (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/2/Yield",
+        "type": "float",
+        "name": "Yield today for today on tracker 2 (kWh)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/3/MaxPower",
+        "type": "float",
+        "name": "Maximum power for today on tracker 3 (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/3/Yield",
+        "type": "float",
+        "name": "Yield today for today on tracker 3 (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/0/MaxPower",
+        "type": "float",
+        "name": "Maximum power for yesterday on tracker 0 (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/0/Yield",
+        "type": "float",
+        "name": "Yield today for yesterday on tracker 0 (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/1/MaxPower",
+        "type": "float",
+        "name": "Maximum power for yesterday on tracker 1 (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/1/Yield",
+        "type": "float",
+        "name": "Yield today for yesterday on tracker 1 (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/2/MaxPower",
+        "type": "float",
+        "name": "Maximum power for yesterday on tracker 2 (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/2/Yield",
+        "type": "float",
+        "name": "Yield today for yesterday on tracker 2 (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/3/MaxPower",
+        "type": "float",
+        "name": "Maximum power for yesterday on tracker 3 (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/3/Yield",
+        "type": "float",
+        "name": "Yield today for yesterday on tracker 3 (kWh)"
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Mode",
+        "enum": {
+          "2": "Inverter on",
+          "4": "Off",
+          "5": "Low Power/ECO"
+        }
+      },
+      {
+        "path": "/ProductId",
+        "type": "float",
+        "name": "Inverter model"
+      },
+      {
+        "path": "/Pv/0/P",
+        "type": "float",
+        "name": "PV power for tracker 0 (W)"
+      },
+      {
+        "path": "/Pv/0/V",
+        "type": "float",
+        "name": "PV voltage for tracker 0 (V DC)"
+      },
+      {
+        "path": "/Pv/1/P",
+        "type": "float",
+        "name": "PV power for tracker 1 (W)"
+      },
+      {
+        "path": "/Pv/1/V",
+        "type": "float",
+        "name": "PV voltage for tracker 1 (V DC)"
+      },
+      {
+        "path": "/Pv/2/P",
+        "type": "float",
+        "name": "PV power for tracker 2 (W)"
+      },
+      {
+        "path": "/Pv/2/V",
+        "type": "float",
+        "name": "PV voltage for tracker 2 (V DC)"
+      },
+      {
+        "path": "/Pv/3/P",
+        "type": "float",
+        "name": "PV power for tracker 3 (W)"
+      },
+      {
+        "path": "/Pv/3/V",
+        "type": "float",
+        "name": "PV voltage for tracker 3 (V DC)"
+      },
+      {
+        "path": "/Pv/V",
+        "type": "float",
+        "name": "PV voltage (for single tracker units) (V DC)"
+      },
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "State",
+        "enum": {
+          "0": "Off",
+          "1": "Low Power",
+          "2": "Fault",
+          "9": "Inverting"
+        }
+      }
+    ]
+  },
+  "input-meteo": {
+    "help": "<p>The <b>input-meteo</b> node allows for Solar Irradiance, Temperature and Wind Speed Sensors measuring.</p><p>More information and supported devices can be found in the <a href=\"https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-d4b7dfe9-4ee0-53bc-8959-c567ed63cebb\">manual</a>.</p>",
+    "meteo": [
+      {
+        "path": "/CellTemperature",
+        "type": "float",
+        "name": "Sensor cell temperature (C)"
+      },
+      {
+        "path": "/ExternalTemperature",
+        "type": "float",
+        "name": "External temperature (C)"
+      },
+      {
+        "path": "/Irradiance",
+        "type": "float",
+        "name": "Solar Irradiance (W/m^2)"
+      },
+      {
+        "path": "/WindSpeed",
+        "type": "float",
+        "name": "Wind speed (m/s)"
+      }
+    ]
+  },
+  "input-multi": {
+    "help": "<p>This is the Multi RS input node.</p>",
+    "multi": [
+      {
+        "path": "/Ac/ActiveIn/ActiveInput",
+        "type": "enum",
+        "name": "Active AC input",
+        "enum": {
+          "0": "AC Input 1",
+          "1": "AC Input 2",
+          "240": "Disconnected"
+        }
+      },
+      {
+        "path": "/Ac/In/1/CurrentLimit",
+        "type": "float",
+        "name": "Ac input 1 current limit (A)"
+      },
+      {
+        "path": "/Ac/In/1/L1/F",
+        "type": "float",
+        "name": "Input frequency (Hz)"
+      },
+      {
+        "path": "/Ac/In/1/L1/I",
+        "type": "float",
+        "name": "Input current phase 1 (A AC)"
+      },
+      {
+        "path": "/Ac/In/1/L1/P",
+        "type": "float",
+        "name": "Input power phase 1 (W)"
+      },
+      {
+        "path": "/Ac/In/1/L1/V",
+        "type": "float",
+        "name": "Input voltage phase 1 (V AC)"
+      },
+      {
+        "path": "/Ac/In/1/L2/I",
+        "type": "float",
+        "name": "Input current phase 2 (A AC)"
+      },
+      {
+        "path": "/Ac/In/1/L2/P",
+        "type": "float",
+        "name": "Input power phase 2 (W)"
+      },
+      {
+        "path": "/Ac/In/1/L2/V",
+        "type": "float",
+        "name": "Input voltage phase 2 (V AC)"
+      },
+      {
+        "path": "/Ac/In/1/L3/I",
+        "type": "float",
+        "name": "Input current phase 3 (A AC)"
+      },
+      {
+        "path": "/Ac/In/1/L3/P",
+        "type": "float",
+        "name": "Input power phase 3 (W)"
+      },
+      {
+        "path": "/Ac/In/1/L3/V",
+        "type": "float",
+        "name": "Input voltage phase 3 (V AC)"
+      },
+      {
+        "path": "/Ac/In/1/Type",
+        "type": "enum",
+        "name": "AC input 1 source type",
+        "enum": {
+          "0": "Unused",
+          "1": "Grid",
+          "2": "Genset",
+          "3": "Shore"
+        }
+      },
+      {
+        "path": "/Ac/In/2/CurrentLimit",
+        "type": "float",
+        "name": "Ac input 2 current limit (A)"
+      },
+      {
+        "path": "/Ac/In/2/Type",
+        "type": "enum",
+        "name": "AC input 2 source type",
+        "enum": {
+          "0": "Unused",
+          "1": "Grid",
+          "2": "Genset",
+          "3": "Shore"
+        }
+      },
+      {
+        "path": "/Ac/NumberOfPhases",
+        "type": "float",
+        "name": "Phase count (count)"
+      },
+      {
+        "path": "/Ac/Out/L1/F",
+        "type": "float",
+        "name": "Output frequency (Hz)"
+      },
+      {
+        "path": "/Ac/Out/L1/I",
+        "type": "float",
+        "name": "Output current phase 1 (A AC)"
+      },
+      {
+        "path": "/Ac/Out/L1/P",
+        "type": "float",
+        "name": "Output power phase 1 (W)"
+      },
+      {
+        "path": "/Ac/Out/L1/V",
+        "type": "float",
+        "name": "Output voltage phase 1 (V AC)"
+      },
+      {
+        "path": "/Ac/Out/L2/I",
+        "type": "float",
+        "name": "Output current phase 2 (A AC)"
+      },
+      {
+        "path": "/Ac/Out/L2/P",
+        "type": "float",
+        "name": "Output power phase 2 (W)"
+      },
+      {
+        "path": "/Ac/Out/L2/V",
+        "type": "float",
+        "name": "Output voltage phase 2 (V AC)"
+      },
+      {
+        "path": "/Ac/Out/L3/I",
+        "type": "float",
+        "name": "Output current phase 3 (A AC)"
+      },
+      {
+        "path": "/Ac/Out/L3/P",
+        "type": "float",
+        "name": "Output power phase 3 (W)"
+      },
+      {
+        "path": "/Ac/Out/L3/V",
+        "type": "float",
+        "name": "Output voltage phase 3 (V AC)"
+      },
+      {
+        "path": "/Alarms/HighTemperature",
+        "type": "enum",
+        "name": "Temperature alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltageAcOut",
+        "type": "enum",
+        "name": "High AC-Out voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowTemperature",
+        "type": "enum",
+        "name": "Low battery temperature alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltageAcOut",
+        "type": "enum",
+        "name": "Low AC-Out voltage alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Overload",
+        "type": "enum",
+        "name": "Overload alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Ripple",
+        "type": "enum",
+        "name": "High DC ripple alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Battery current (A DC)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Battery temperature (Degrees celsius)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Battery voltage (V DC)"
+      },
+      {
+        "path": "/Energy/AcIn1ToAcOut",
+        "type": "float",
+        "name": "Energy from AC-in-1 to AC-out (kWh)"
+      },
+      {
+        "path": "/Energy/AcIn1ToInverter",
+        "type": "float",
+        "name": "Energy from AC-in-1 to battery (kWh)"
+      },
+      {
+        "path": "/Energy/AcIn2ToAcOut",
+        "type": "float",
+        "name": "Energy from AC-in-2 to AC-out (kWh)"
+      },
+      {
+        "path": "/Energy/AcIn2ToInverter",
+        "type": "float",
+        "name": "Energy from AC-in-2 to battery (kWh)"
+      },
+      {
+        "path": "/Energy/AcOutToAcIn1",
+        "type": "float",
+        "name": "Energy from AC-out to AC-in-1 (kWh)"
+      },
+      {
+        "path": "/Energy/AcOutToAcIn2",
+        "type": "float",
+        "name": "Energy from AC-out to AC-in-2 (kWh)"
+      },
+      {
+        "path": "/Energy/InverterToAcIn1",
+        "type": "float",
+        "name": "Energy from battery to AC-in-1 (kWh)"
+      },
+      {
+        "path": "/Energy/InverterToAcIn2",
+        "type": "float",
+        "name": "Energy from battery to AC-in-2 (kWh)"
+      },
+      {
+        "path": "/Energy/InverterToAcOut",
+        "type": "float",
+        "name": "Energy from battery to AC-out (kWh)"
+      },
+      {
+        "path": "/Energy/OutToInverter",
+        "type": "float",
+        "name": "Energy from AC-out to battery (kWh)"
+      },
+      {
+        "path": "/Energy/SolarToAcIn1",
+        "type": "float",
+        "name": "Energy from solar to AC-in-1 (kWh)"
+      },
+      {
+        "path": "/Energy/SolarToAcIn2",
+        "type": "float",
+        "name": "Energy from solar to AC-in-2 (kWh)"
+      },
+      {
+        "path": "/Energy/SolarToAcOut",
+        "type": "float",
+        "name": "Energy from solar to AC-out (kWh)"
+      },
+      {
+        "path": "/Energy/SolarToBattery",
+        "type": "float",
+        "name": "Energy from solar to battery (kWh)"
+      },
+      {
+        "path": "/ErrorCode",
+        "type": "enum",
+        "name": "Error code",
+        "enum": {
+          "0": "No error",
+          "1": "Battery temperature too high",
+          "2": "Battery voltage too high",
+          "3": "Battery temperature sensor miswired (+)",
+          "4": "Battery temperature sensor miswired (-)",
+          "5": "Battery temperature sensor disconnected",
+          "6": "Battery voltage sense miswired (+)",
+          "7": "Battery voltage sense miswired (-)",
+          "8": "Battery voltage sense disconnected",
+          "9": "Battery voltage wire losses too high",
+          "17": "Charger temperature too high",
+          "18": "Charger over-current",
+          "19": "Charger current polarity reversed",
+          "20": "Bulk time limit reached",
+          "22": "Charger temperature sensor miswired",
+          "23": "Charger temperature sensor disconnected",
+          "34": "Input current too high"
+        }
+      },
+      {
+        "path": "/MppOperationMode",
+        "type": "enum",
+        "name": "MPP operation mode",
+        "enum": {
+          "0": "Off",
+          "1": "Voltage/current limited",
+          "2": "MPPT active",
+          "255": "Not available"
+        }
+      },
+      {
+        "path": "/Pv/V",
+        "type": "float",
+        "name": "PV voltage (V DC)"
+      },
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay on the Multi RS",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      },
+      {
+        "path": "/Soc",
+        "type": "float",
+        "name": "Battery State of Charge (%)"
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "Inverter/Charger state",
+        "enum": {
+          "0": "Off",
+          "1": "Low Power",
+          "2": "Fault",
+          "3": "Bulk",
+          "4": "Absorption",
+          "5": "Float",
+          "6": "Storage",
+          "7": "Equalize",
+          "8": "Passthru",
+          "9": "Inverting",
+          "10": "Power assist",
+          "11": "Power supply",
+          "252": "Bulk protection"
+        }
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Switch position",
+        "enum": {
+          "1": "Charger Only",
+          "2": "Inverter Only",
+          "3": "On",
+          "4": "Off"
+        }
+      },
+      {
+        "path": "/Yield/Power",
+        "type": "float",
+        "name": "PV power (W)"
+      },
+      {
+        "path": "/Yield/User",
+        "type": "float",
+        "name": "User yield (kWh)"
+      }
+    ]
+  },
+  "input-pvinverter": {
+    "help": "<p>This node is for obtaining information from the PV inverter.</p>",
+    "pvinverter": [
+      {
+        "path": "/Ac/Energy/Forward",
+        "type": "float",
+        "name": "Total energy (kWh)"
+      },
+      {
+        "path": "/Ac/L1/Current",
+        "type": "float",
+        "name": "L1 Current (A)"
+      },
+      {
+        "path": "/Ac/L1/Energy/Forward",
+        "type": "float",
+        "name": "L1 Energy (kWh)"
+      },
+      {
+        "path": "/Ac/L1/Power",
+        "type": "float",
+        "name": "L1 Power (W)"
+      },
+      {
+        "path": "/Ac/L1/Voltage",
+        "type": "float",
+        "name": "L1 Voltage (V)"
+      },
+      {
+        "path": "/Ac/L2/Current",
+        "type": "float",
+        "name": "L2 Current (A)"
+      },
+      {
+        "path": "/Ac/L2/Energy/Forward",
+        "type": "float",
+        "name": "L2 Energy (kWh)"
+      },
+      {
+        "path": "/Ac/L2/Power",
+        "type": "float",
+        "name": "L2 Power (W)"
+      },
+      {
+        "path": "/Ac/L2/Voltage",
+        "type": "float",
+        "name": "L2 Voltage (V)"
+      },
+      {
+        "path": "/Ac/L3/Current",
+        "type": "float",
+        "name": "L3 Current (A)"
+      },
+      {
+        "path": "/Ac/L3/Energy/Forward",
+        "type": "float",
+        "name": "L3 Energy (kWh)"
+      },
+      {
+        "path": "/Ac/L3/Power",
+        "type": "float",
+        "name": "L3 Power (W)"
+      },
+      {
+        "path": "/Ac/L3/Voltage",
+        "type": "float",
+        "name": "L3 Voltage (V)"
+      },
+      {
+        "path": "/Ac/MaxPower",
+        "type": "float",
+        "name": "Maximum Power Capacity (kW)"
+      },
+      {
+        "path": "/Ac/Power",
+        "type": "float",
+        "name": "Total Power (W)"
+      },
+      {
+        "path": "/ErrorCode",
+        "type": "enum",
+        "name": "Error",
+        "enum": {
+          "0": "No Error"
+        }
+      },
+      {
+        "path": "/Position",
+        "type": "enum",
+        "name": "Position",
+        "enum": {
+          "0": "AC input 1",
+          "1": "AC output",
+          "2": "AC input 2"
+        }
+      },
+      {
+        "path": "/Serial",
+        "type": "string",
+        "name": "Serial"
+      },
+      {
+        "path": "/StatusCode",
+        "type": "enum",
+        "name": "Status",
+        "enum": {
+          "0": "Startup 0",
+          "1": "Startup 1",
+          "2": "Startup 2",
+          "3": "Startup 3",
+          "4": "Startup 4",
+          "5": "Startup 5",
+          "6": "Startup 6",
+          "7": "Running",
+          "8": "Standby",
+          "9": "Boot loading",
+          "10": "Error",
+          "11": "Running (MPPT)",
+          "12": "Running (Throttled)"
+        }
+      }
+    ]
+  },
+  "input-relay": {
+    "help": "<p>The <b>input-relay</b> node reads the state of the relay(s) of the Venus device.</p>",
+    "system": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Venus relay 1 state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      },
+      {
+        "path": "/Relay/1/State",
+        "type": "enum",
+        "name": "Venus relay 2 state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      },
+      {
+        "path": "/Relay/2/State",
+        "type": "enum",
+        "name": "Venus relay 3 state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      },
+      {
+        "path": "/Relay/3/State",
+        "type": "enum",
+        "name": "Venus relay 4 state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      }
+    ],
+    "battery": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay status",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      }
+    ],
+    "charger": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay on the charger",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      }
+    ],
+    "solarcharger": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay on the charger",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      }
+    ],
+    "inverter": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      }
+    ]
+  },
+  "input-solarcharger": {
+    "help": "<p>Information from the Solar charger can be read with this node.</p>",
+    "solarcharger": [
+      {
+        "path": "/Alarms/Alarm",
+        "type": "enum",
+        "name": "Alarm",
+        "enum": {
+          "0": "No alarm",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighVoltage",
+        "type": "enum",
+        "name": "High batt. voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowVoltage",
+        "type": "enum",
+        "name": "Low batt. voltage alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Alarm"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Current (A)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Battery temperature (C)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Voltage (V)"
+      },
+      {
+        "path": "/Equalization/Pending",
+        "type": "enum",
+        "name": "Equalization pending",
+        "enum": {
+          "0": "No",
+          "1": "Yes",
+          "2": "Error",
+          "3": "Unavailable- Unknown"
+        }
+      },
+      {
+        "path": "/Equalization/TimeRemaining",
+        "type": "float",
+        "name": "Equalization time remaining (seconds)"
+      },
+      {
+        "path": "/ErrorCode",
+        "type": "enum",
+        "name": "Error code",
+        "enum": {
+          "0": "No error",
+          "1": "#1 - Battery temperature too high",
+          "2": "#2 - Battery voltage too high",
+          "3": "#3 - Battery temperature sensor miswired (+)",
+          "4": "#4 - Battery temperature sensor miswired (-)",
+          "5": "#5 - Battery temperature sensor disconnected",
+          "6": "#6 - Battery voltage sense miswired (+)",
+          "7": "#7 - Battery voltage sense miswired (-)",
+          "8": "#8 - Battery voltage sense disconnected",
+          "9": "#9 - Battery voltage wire losses too high",
+          "10": "#10 - Battery voltage too low",
+          "11": "#11 - Battery ripple voltage on terminals too high",
+          "12": "#12 - Battery low state of charge",
+          "13": "#13 - Battery mid-point voltage issue",
+          "14": "#14 - Battery temperature too low",
+          "17": "#17 - Charger temperature too high",
+          "18": "#18 - Charger over-current",
+          "19": "#19 - Charger current polarity reversed",
+          "20": "#20 - Max Bulk-time exceeded",
+          "21": "#21 - Charger current sensor issue",
+          "22": "#22 - Temperature sensor miswired",
+          "23": "#23 - Charger temperature sensor disconnected",
+          "24": "#24 - Charger internal fan not detected",
+          "25": "#25 - Charger internal fan over-current",
+          "26": "#26 - Charger terminal overheated",
+          "27": "#27 - Charger short circuit",
+          "28": "#28 - Charger issue with power stage",
+          "29": "#29 - Over-charge protection",
+          "31": "#31 - Input voltage out of range",
+          "32": "#32 - Input voltage too low",
+          "33": "#33 - Input voltage too high",
+          "34": "#34 - PV over current",
+          "35": "#35 - Input excessive power",
+          "36": "#36 - Input polarity issue",
+          "37": "#37 - Input voltage absent (mains removed, fuse blown?)",
+          "38": "#38 - Input shutdown due to battery over-voltage",
+          "39": "#39 - Input shutdown due to battery over-voltage",
+          "40": "#40 - Internal failure (PV Input failed to shutdown)",
+          "41": "#41 - Inverter shutdown (panel isolation resistance too low)",
+          "42": "#42 - Inverter shutdown (ground current too high: >30mA)",
+          "43": "#43 - Inverter shutdown (voltage over ground relay too high)",
+          "50": "#50 - Inverter overload (iit protection)",
+          "51": "#51 - Inverter temperature too high",
+          "52": "#52 - Inverter excessive current",
+          "53": "#53 - Inverter dc level (internal dc rail voltage)",
+          "54": "#54 - Inverter ac level (output voltage not ok)",
+          "55": "#55 - Inverter dc fail (dc on output)",
+          "56": "#56 - Inverter ac fail (shape wrong)*/",
+          "57": "#57 - Inverter ac on output (inverter only)",
+          "58": "#58 - Inverter bridge fault (hardware signal)",
+          "59": "#59 - ACIN1 relay test fault",
+          "60": "#60 - ACIN2 relay test fault",
+          "65": "#65 - Device disappeared during parallel operation (broken cable?)",
+          "66": "#66 - Incompatible device encountered for parallel operation (e.g. old firmware/different settings)",
+          "67": "#67 - No BMS",
+          "68": "#68 - Network misconfigured",
+          "113": "#113 - Non-volatile storage write error",
+          "114": "#114 - CPU temperature to high",
+          "115": "#115 - CAN/SCI communication lost (when critical)",
+          "116": "#116 - Calibration data lost",
+          "117": "#117 - Incompatible firmware encountered",
+          "118": "#118 - Incompatible hardware encountered",
+          "119": "#119 - Settings data lost",
+          "120": "#120 - Reference voltage failure",
+          "121": "#121 - Tester fail",
+          "122": "#122 - Non-volatile history data invalid/corrupted",
+          "200": "#200 - Internal error",
+          "201": "#201 - Internal error",
+          "203": "#203 - Internal error",
+          "205": "#205 - Internal error",
+          "212": "#212 - Internal error",
+          "215": "#215 - Internal error"
+        }
+      },
+      {
+        "path": "/History/Daily/0/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power today (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/0/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power today for tracker 0 (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/0/Yield",
+        "type": "float",
+        "name": "Yield today for tracker 0 (kWh)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/1/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power today for tracker 1 (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/1/Yield",
+        "type": "float",
+        "name": "Yield today for tracker 1 (kWh)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/2/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power today for tracker 2 (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/2/Yield",
+        "type": "float",
+        "name": "Yield today for tracker 2 (kWh)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/3/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power today for tracker 3 (W)"
+      },
+      {
+        "path": "/History/Daily/0/Pv/3/Yield",
+        "type": "float",
+        "name": "Yield today for tracker 3 (kWh)"
+      },
+      {
+        "path": "/History/Daily/0/Yield",
+        "type": "float",
+        "name": "Yield today (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power yesterday (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/0/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power yesterday tracker 0 (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/0/Yield",
+        "type": "float",
+        "name": "Yield yesterday for tracker 0 (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/1/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power yesterday tracker 1 (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/1/Yield",
+        "type": "float",
+        "name": "Yield yesterday for tracker 1 (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/2/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power yesterday tracker 2 (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/2/Yield",
+        "type": "float",
+        "name": "Yield yesterday for tracker 2 (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/3/MaxPower",
+        "type": "float",
+        "name": "Maximum charge power yesterday tracker 3 (W)"
+      },
+      {
+        "path": "/History/Daily/1/Pv/3/Yield",
+        "type": "float",
+        "name": "Yield yesterday for tracker 3 (kWh)"
+      },
+      {
+        "path": "/History/Daily/1/Yield",
+        "type": "float",
+        "name": "Yield yesterday (kWh)"
+      },
+      {
+        "path": "/Load/State",
+        "type": "enum",
+        "name": "Load state",
+        "enum": {
+          "0": "Off",
+          "1": "On"
+        }
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Charger on/off",
+        "enum": {
+          "1": "On",
+          "4": "Off"
+        }
+      },
+      {
+        "path": "/MppOperationMode",
+        "type": "enum",
+        "name": "MPP operation mode",
+        "enum": {
+          "0": "Off",
+          "1": "Voltage or current limited",
+          "2": "MPPT Tracker active",
+          "255": "Not available"
+        }
+      },
+      {
+        "path": "/Position",
+        "type": "enum",
+        "name": "Position",
+        "enum": {
+          "0": "AC input 1",
+          "1": "AC output",
+          "2": "AC input 2"
+        }
+      },
+      {
+        "path": "/Pv/0/P",
+        "type": "float",
+        "name": "Tracker 1 power"
+      },
+      {
+        "path": "/Pv/0/V",
+        "type": "float",
+        "name": "Tracker 1 voltage"
+      },
+      {
+        "path": "/Pv/1/P",
+        "type": "float",
+        "name": "Tracker 2 power"
+      },
+      {
+        "path": "/Pv/1/V",
+        "type": "float",
+        "name": "Tracker 2 voltage"
+      },
+      {
+        "path": "/Pv/2/P",
+        "type": "float",
+        "name": "Tracker 3 power"
+      },
+      {
+        "path": "/Pv/2/V",
+        "type": "float",
+        "name": "Tracker 3 voltage"
+      },
+      {
+        "path": "/Pv/3/P",
+        "type": "float",
+        "name": "Tracker 4 power"
+      },
+      {
+        "path": "/Pv/3/V",
+        "type": "float",
+        "name": "Tracker 4 voltage"
+      },
+      {
+        "path": "/Pv/V",
+        "type": "float",
+        "name": "PV voltage"
+      },
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay on the charger",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        }
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "Charge state",
+        "enum": {
+          "0": "Off",
+          "2": "Fault",
+          "3": "Bulk",
+          "4": "Absorption",
+          "5": "Float",
+          "6": "Storage",
+          "7": "Equalize",
+          "245": "Off",
+          "247": "Equalize",
+          "252": "Ext. Control"
+        }
+      },
+      {
+        "path": "/Yield/Power",
+        "type": "float",
+        "name": "PV Power (W)"
+      },
+      {
+        "path": "/Yield/System",
+        "type": "string",
+        "name": "Yield since last update (kWh)"
+      },
+      {
+        "path": "/Yield/User",
+        "type": "string",
+        "name": "Yield since reset (kWh)"
+      }
+    ]
+  },
+  "input-system": {
+    "help": "<p>This input node takes is for retrieving information from the <tt>com.victronenergy.system</tt> dbus path.</p>",
+    "system": [
+      {
+        "path": "/Ac/ActiveIn/Source",
+        "type": "enum",
+        "name": "AC-Input",
+        "enum": {
+          "0": "Not available",
+          "1": "Grid",
+          "2": "Generator",
+          "3": "Shore",
+          "240": "Inverting"
+        }
+      },
+      {
+        "path": "/Ac/Consumption/L1/Power",
+        "type": "float",
+        "name": "AC Consumption L1 (W)"
+      },
+      {
+        "path": "/Ac/Consumption/L2/Power",
+        "type": "float",
+        "name": "AC Consumption L2 (W)"
+      },
+      {
+        "path": "/Ac/Consumption/L3/Power",
+        "type": "float",
+        "name": "AC Consumption L3 (W)"
+      },
+      {
+        "path": "/Ac/ConsumptionOnInput/NumberOfPhases",
+        "type": "integer",
+        "name": "AC Consumption on Input Number Of Phases"
+      },
+      {
+        "path": "/Ac/ConsumptionOnOutput/L1/Power",
+        "type": "float",
+        "name": "AC Consumption on Output L1"
+      },
+      {
+        "path": "/Ac/ConsumptionOnOutput/L2/Power",
+        "type": "float",
+        "name": "AC Consumption on Output L2"
+      },
+      {
+        "path": "/Ac/ConsumptionOnOutput/L3/Power",
+        "type": "float",
+        "name": "AC Consumption on Output L3"
+      },
+      {
+        "path": "/Ac/ConsumptionOnOutput/NumberOfPhases",
+        "type": "integer",
+        "name": "AC Consumption on Output Number Of Phases"
+      },
+      {
+        "path": "/Ac/Genset/DeviceType",
+        "type": "float",
+        "name": "Genset Device Type",
+        "enum": {}
+      },
+      {
+        "path": "/Ac/Genset/L1/Power",
+        "type": "float",
+        "name": "Genset L1 (W)"
+      },
+      {
+        "path": "/Ac/Genset/L2/Power",
+        "type": "float",
+        "name": "Genset L2 (W)"
+      },
+      {
+        "path": "/Ac/Genset/L3/Power",
+        "type": "float",
+        "name": "Genset L3 (W)"
+      },
+      {
+        "path": "/Ac/Genset/NumberOfPhases",
+        "type": "integer",
+        "name": "Genset Number Of Phases"
+      },
+      {
+        "path": "/Ac/Grid/DeviceType",
+        "type": "float",
+        "name": "Grid Device Type"
+      },
+      {
+        "path": "/Ac/Grid/L1/Power",
+        "type": "float",
+        "name": "Grid L1 (W)"
+      },
+      {
+        "path": "/Ac/Grid/L2/Power",
+        "type": "float",
+        "name": "Grid L2 (W)"
+      },
+      {
+        "path": "/Ac/Grid/L3/Power",
+        "type": "float",
+        "name": "Grid L3 (W)"
+      },
+      {
+        "path": "/Ac/Grid/NumberOfPhases",
+        "type": "integer",
+        "name": "Grid Number Of Phases"
+      },
+      {
+        "path": "/Ac/PvOnGenset/L1/Power",
+        "type": "float",
+        "name": "PV Power AC-tied on Generator L1"
+      },
+      {
+        "path": "/Ac/PvOnGenset/L2/Power",
+        "type": "float",
+        "name": "PV Power AC-tied on Generator L2"
+      },
+      {
+        "path": "/Ac/PvOnGenset/L3/Power",
+        "type": "float",
+        "name": "PV Power AC-tied on Generator L3"
+      },
+      {
+        "path": "/Ac/PvOnGenset/NumberOfPhases",
+        "type": "integer",
+        "name": "PV Power AC-tied on Generator Number Of Phases"
+      },
+      {
+        "path": "/Ac/PvOnGrid/L1/Power",
+        "type": "float",
+        "name": "PV - AC-coupled on input L1 (W)"
+      },
+      {
+        "path": "/Ac/PvOnGrid/L2/Power",
+        "type": "float",
+        "name": "PV - AC-coupled on input L2 (W)"
+      },
+      {
+        "path": "/Ac/PvOnGrid/L3/Power",
+        "type": "float",
+        "name": "PV - AC-coupled on input L3 (W)"
+      },
+      {
+        "path": "/Ac/PvOnGrid/NumberOfPhases",
+        "type": "integer",
+        "name": "PV - AC-coupled on input Number Of Phases"
+      },
+      {
+        "path": "/Ac/PvOnOutput/L1/Power",
+        "type": "float",
+        "name": "PV - AC-coupled on output L1 (W)"
+      },
+      {
+        "path": "/Ac/PvOnOutput/L2/Power",
+        "type": "float",
+        "name": "PV - AC-coupled on output L2 (W)"
+      },
+      {
+        "path": "/Ac/PvOnOutput/L3/Power",
+        "type": "float",
+        "name": "PV - AC-coupled on output L3 (W)"
+      },
+      {
+        "path": "/Ac/PvOnOutput/NumberOfPhases",
+        "type": "integer",
+        "name": "PV - AC-coupled on output Number Of Phases"
+      },
+      {
+        "path": "/Buzzer/State",
+        "type": "float",
+        "name": "Buzzer State",
+        "enum": {
+          "0": "Off",
+          "1": "On"
+        }
+      },
+      {
+        "path": "/Dc/Battery/ConsumedAmphours",
+        "type": "float",
+        "name": "Battery Consumed Amphours (Ah)"
+      },
+      {
+        "path": "/Dc/Battery/Current",
+        "type": "float",
+        "name": "Battery current (A)"
+      },
+      {
+        "path": "/Dc/Battery/Power",
+        "type": "float",
+        "name": "Battery Power (W)"
+      },
+      {
+        "path": "/Dc/Battery/Soc",
+        "type": "float",
+        "name": "Battery State of Charge (%)"
+      },
+      {
+        "path": "/Dc/Battery/State",
+        "type": "enum",
+        "name": "Battery state",
+        "enum": {
+          "0": "idle",
+          "1": "charging",
+          "2": "discharging"
+        }
+      },
+      {
+        "path": "/Dc/Battery/Temperature",
+        "type": "float",
+        "name": "Battery temperature (C)"
+      },
+      {
+        "path": "/Dc/Battery/TimeToGo",
+        "type": "float",
+        "name": "Battery Time to Go (h)"
+      },
+      {
+        "path": "/Dc/Battery/Voltage",
+        "type": "float",
+        "name": "Battery voltage (V)"
+      },
+      {
+        "path": "/Dc/Charger/Power",
+        "type": "integer",
+        "name": "AC-Chargers - power (W)"
+      },
+      {
+        "path": "/Dc/Pv/Current",
+        "type": "float",
+        "name": "MPPTs - current (A)"
+      },
+      {
+        "path": "/Dc/Pv/Power",
+        "type": "float",
+        "name": "MPPTs - power (W)"
+      },
+      {
+        "path": "/Dc/System/Power",
+        "type": "float",
+        "name": "DC System (W)"
+      },
+      {
+        "path": "/Dc/Vebus/Current",
+        "type": "float",
+        "name": "VE.Bus charge current (A)"
+      },
+      {
+        "path": "/Dc/Vebus/Power",
+        "type": "float",
+        "name": "VE.Bus charge power (W)"
+      },
+      {
+        "path": "/Serial",
+        "type": "string",
+        "name": "Serial (System)"
+      },
+      {
+        "path": "/SystemType",
+        "type": "string",
+        "name": "System type"
+      },
+      {
+        "path": "/Timers/TimeOff",
+        "type": "float",
+        "name": "Time off (s)"
+      },
+      {
+        "path": "/Timers/TimeOnGenerator",
+        "type": "float",
+        "name": "Time generator (s)"
+      },
+      {
+        "path": "/Timers/TimeOnGrid",
+        "type": "float",
+        "name": "Time grid (s)"
+      },
+      {
+        "path": "/Timers/TimeOnInverter",
+        "type": "float",
+        "name": "Time inverting (s)"
+      }
+    ]
+  },
+  "input-tank": {
+    "help": "<p>The input-tank node is for retrieving tank level sensor information.</p><p>Also see the <a href=\"https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-e4027d37-78e0-4433-1be4-3252d3b79152\">manual</a> for more information.</p>",
+    "tank": [
+      {
+        "path": "/Capacity",
+        "type": "float",
+        "name": "Tank capacity (m3)"
+      },
+      {
+        "path": "/FluidType",
+        "type": "enum",
+        "name": "Fluid type",
+        "enum": {
+          "0": "Fuel",
+          "1": "Fresh water",
+          "2": "Waste water",
+          "3": "Live well",
+          "4": "Oil",
+          "5": "Black water (sewage)"
+        }
+      },
+      {
+        "path": "/Level",
+        "type": "float",
+        "name": "Tank level (%)"
+      },
+      {
+        "path": "/ProductId",
+        "type": "float",
+        "name": "Product ID"
+      },
+      {
+        "path": "/Remaining",
+        "type": "float",
+        "name": "Fluid remaining (m3)"
+      },
+      {
+        "path": "/Standard",
+        "type": "enum",
+        "name": "Standard",
+        "enum": {
+          "0": "European",
+          "1": "USA"
+        }
+      },
+      {
+        "path": "/Status",
+        "type": "enum",
+        "name": "Tank sensor status",
+        "enum": {
+          "0": "Ok",
+          "1": "Disconnected",
+          "2": "Short circuited",
+          "3": "Unknown"
+        }
+      }
+    ]
+  },
+  "input-temperature": {
+    "help": "<p>Like the other nodes, the <b>input-temperature</b> node reads the temperate information from the dbus. This means that source of the temperature sensor can obtain its information from different sources (e.g. directly connected probe or Bluetooth connected Ruuvi tag).</p><p>See the <a href=\"https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-4d5df29c-761e-cfcc-9e2c-8230f126e7bb\">manual</a> for information on connecting a temperature sensor.</p>",
+    "temperature": [
+      {
+        "path": "/AccelX",
+        "type": "float",
+        "name": "Acceleration X (g)"
+      },
+      {
+        "path": "/AccelY",
+        "type": "float",
+        "name": "Acceleration Y (g)"
+      },
+      {
+        "path": "/AccelZ",
+        "type": "float",
+        "name": "Acceleration Z (g)"
+      },
+      {
+        "path": "/BatteryVoltage",
+        "type": "float",
+        "name": "Sensor battery voltage (V)"
+      },
+      {
+        "path": "/Humidity",
+        "type": "float",
+        "name": "Humidity (%)"
+      },
+      {
+        "path": "/Offset",
+        "type": "float",
+        "name": "Temperature offset"
+      },
+      {
+        "path": "/Pressure",
+        "type": "float",
+        "name": "Pressure (kPa)"
+      },
+      {
+        "path": "/ProductId",
+        "type": "float",
+        "name": "Product ID"
+      },
+      {
+        "path": "/Scale",
+        "type": "float",
+        "name": "Temperature scale factor"
+      },
+      {
+        "path": "/Status",
+        "type": "enum",
+        "name": "Sensor status",
+        "enum": {
+          "0": "Ok",
+          "1": "Disconnected",
+          "2": "Short circuited",
+          "3": "Reverse polarity",
+          "4": "Unknown"
+        }
+      },
+      {
+        "path": "/Temperature",
+        "type": "float",
+        "name": "Temperature (C)"
+      },
+      {
+        "path": "/TemperatureType",
+        "type": "enum",
+        "name": "Sensor type",
+        "enum": {
+          "0": "Battery",
+          "1": "Fridge",
+          "2": "Generic"
+        }
+      }
+    ]
+  },
+  "input-vebus": {
+    "help": "<p>Information from VE.Bus connected devices can be obtained with this node.</p>",
+    "vebus": [
+      {
+        "path": "/Ac/ActiveIn/ActiveInput",
+        "type": "enum",
+        "name": "Active input",
+        "enum": {
+          "0": "AC Input 1",
+          "1": "AC Input 2",
+          "240": "Disconnected"
+        }
+      },
+      {
+        "path": "/Ac/ActiveIn/L1/F",
+        "type": "float",
+        "name": "Input frequency 1 (Hz)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L1/I",
+        "type": "float",
+        "name": "Input current phase 1 (A)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L1/P",
+        "type": "float",
+        "name": "Input power 1 (W)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L1/V",
+        "type": "float",
+        "name": "Input voltage phase 1 (VAC)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L2/F",
+        "type": "float",
+        "name": "Input frequency 2 (Hz)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L2/I",
+        "type": "float",
+        "name": "Input current phase 2 (A)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L2/P",
+        "type": "float",
+        "name": "Input power 2 (W)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L2/V",
+        "type": "float",
+        "name": "Input voltage phase 2 (VAC)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L3/F",
+        "type": "float",
+        "name": "Input frequency 3 (Hz)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L3/I",
+        "type": "float",
+        "name": "Input current phase 3 (A)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L3/P",
+        "type": "float",
+        "name": "Input power 3 (W)"
+      },
+      {
+        "path": "/Ac/ActiveIn/L3/V",
+        "type": "float",
+        "name": "Input voltage phase 3 (VAC)"
+      },
+      {
+        "path": "/Ac/In/1/CurrentLimit",
+        "type": "float",
+        "name": "Input 1 current limit (A)"
+      },
+      {
+        "path": "/Ac/In/1/CurrentLimitIsAdjustable",
+        "type": "enum",
+        "name": "Input 1 current limit is adjustable",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Ac/In/2/CurrentLimit",
+        "type": "float",
+        "name": "Input 2 current limit (A)"
+      },
+      {
+        "path": "/Ac/In/2/CurrentLimitIsAdjustable",
+        "type": "enum",
+        "name": "Input 2 current limit is adjustable",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Ac/NumberOfPhases",
+        "type": "float",
+        "name": "Phase count"
+      },
+      {
+        "path": "/Ac/Out/L1/F",
+        "type": "float",
+        "name": "Output frequency (Hz)"
+      },
+      {
+        "path": "/Ac/Out/L1/I",
+        "type": "float",
+        "name": "Output current phase 1 (A)"
+      },
+      {
+        "path": "/Ac/Out/L1/P",
+        "type": "float",
+        "name": "Output power 1 (W)"
+      },
+      {
+        "path": "/Ac/Out/L1/V",
+        "type": "float",
+        "name": "Output voltage phase 1 (VAC)"
+      },
+      {
+        "path": "/Ac/Out/L2/I",
+        "type": "float",
+        "name": "Output current phase 2 (A)"
+      },
+      {
+        "path": "/Ac/Out/L2/P",
+        "type": "float",
+        "name": "Output power 2 (W)"
+      },
+      {
+        "path": "/Ac/Out/L2/V",
+        "type": "float",
+        "name": "Output voltage phase 2 (VAC)"
+      },
+      {
+        "path": "/Ac/Out/L3/I",
+        "type": "float",
+        "name": "Output current phase 3 (A)"
+      },
+      {
+        "path": "/Ac/Out/L3/P",
+        "type": "float",
+        "name": "Output power 3 (W)"
+      },
+      {
+        "path": "/Ac/Out/L3/V",
+        "type": "float",
+        "name": "Output voltage phase 3 (VAC)"
+      },
+      {
+        "path": "/Ac/State/IgnoreAcIn1",
+        "type": "enum",
+        "name": "AC input 1 ignored",
+        "enum": {
+          "0": "AC input not ignored",
+          "1": "AC input ignored"
+        }
+      },
+      {
+        "path": "/Ac/State/IgnoreAcIn2",
+        "type": "enum",
+        "name": "AC input 2 ignored",
+        "enum": {
+          "0": "AC input not ignored",
+          "1": "AC input ignored"
+        }
+      },
+      {
+        "path": "/Alarms/GridLost",
+        "type": "enum",
+        "name": "Grid lost alarm",
+        "enum": {
+          "0": "Ok",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighTemperature",
+        "type": "enum",
+        "name": "Temperature",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L1/HighTemperature",
+        "type": "enum",
+        "name": "Temperature alarm L1",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L1/LowBattery",
+        "type": "enum",
+        "name": "Low battery alarm L1",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L1/Overload",
+        "type": "enum",
+        "name": "Overload alarm L1",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L1/Ripple",
+        "type": "enum",
+        "name": "Ripple alarm L1",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L2/HighTemperature",
+        "type": "enum",
+        "name": "Temperature alarm L2",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L2/LowBattery",
+        "type": "enum",
+        "name": "Low battery alarm L2",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L2/Overload",
+        "type": "enum",
+        "name": "Overload alarm L2",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L2/Ripple",
+        "type": "enum",
+        "name": "Ripple alarm L2",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L3/HighTemperature",
+        "type": "enum",
+        "name": "Temperature alarm L3",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L3/LowBattery",
+        "type": "enum",
+        "name": "Low battery alarm L3",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L3/Overload",
+        "type": "enum",
+        "name": "Overload alarm L3",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/L3/Ripple",
+        "type": "enum",
+        "name": "Ripple alarm L3",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/LowBattery",
+        "type": "enum",
+        "name": "Low battery",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Overload",
+        "type": "enum",
+        "name": "Overload",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/PhaseRotation",
+        "type": "enum",
+        "name": "Phase Rotation",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning"
+        }
+      },
+      {
+        "path": "/Alarms/TemperatureSensor",
+        "type": "enum",
+        "name": "Temperatur sensor alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/VoltageSensor",
+        "type": "enum",
+        "name": "Voltage sensor alarm",
+        "enum": {
+          "0": "Ok",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Bms/AllowToCharge",
+        "type": "enum",
+        "name": "BMS allows battery to be charged",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Bms/AllowToDischarge",
+        "type": "enum",
+        "name": "BMS allows battery to be discharged",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Bms/BmsExpected",
+        "type": "enum",
+        "name": "VE.Bus BMS is expected",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Bms/Error",
+        "type": "enum",
+        "name": "VE.Bus BMS error",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Dc/0/Current",
+        "type": "float",
+        "name": "Current (A)"
+      },
+      {
+        "path": "/Dc/0/Temperature",
+        "type": "float",
+        "name": "Temperature (C)"
+      },
+      {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "Voltage (V)"
+      },
+      {
+        "path": "/Energy/AcIn1ToAcOut",
+        "type": "float",
+        "name": "Energy ACIn1 to AcOut (kWh)"
+      },
+      {
+        "path": "/Energy/AcIn1ToInverter",
+        "type": "float",
+        "name": "Energy AcIn1 to Inverter (kWh)"
+      },
+      {
+        "path": "/Energy/AcIn2ToAcOut",
+        "type": "float",
+        "name": "Energy ACIn2 to AcOut (kWh)"
+      },
+      {
+        "path": "/Energy/AcIn2ToInverter",
+        "type": "float",
+        "name": "Energy ACIn2 to Inverter (kWh)"
+      },
+      {
+        "path": "/Energy/AcOutToAcIn1",
+        "type": "float",
+        "name": "Energy AcOut to AcIn1 (kWh)"
+      },
+      {
+        "path": "/Energy/AcOutToAcIn2",
+        "type": "float",
+        "name": "Energy AcOut to AcIn2 (kWh)"
+      },
+      {
+        "path": "/Energy/InverterToAcIn1",
+        "type": "float",
+        "name": "Energy Inverter to AcIn1 (kWh)"
+      },
+      {
+        "path": "/Energy/InverterToAcIn2",
+        "type": "float",
+        "name": "Energy Inverter to AcIn2 (kWh)"
+      },
+      {
+        "path": "/Energy/InverterToAcOut",
+        "type": "float",
+        "name": "Inverter To AcOut (kWh)"
+      },
+      {
+        "path": "/Energy/OutToInverter",
+        "type": "float",
+        "name": "AcOut to Inverter (kWh)"
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Switch Position",
+        "enum": {
+          "1": "Charger Only",
+          "2": "Inverter Only",
+          "3": "On",
+          "4": "Off"
+        }
+      },
+      {
+        "path": "/ModeIsAdjustable",
+        "type": "enum",
+        "name": "Mode is adjustable",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/Soc",
+        "type": "float",
+        "name": "VE.Bus state of charge (%)"
+      },
+      {
+        "path": "/State",
+        "type": "enum",
+        "name": "VE.Bus state",
+        "enum": {
+          "0": "Off",
+          "1": "Low Power",
+          "2": "Fault",
+          "3": "Bulk",
+          "4": "Absorption",
+          "5": "Float",
+          "6": "Storage",
+          "7": "Equalize",
+          "8": "Passthru",
+          "9": "Inverting",
+          "10": "Power assist",
+          "11": "Power supply",
+          "252": "Bulk protect"
+        }
+      },
+      {
+        "path": "/VebusError",
+        "type": "enum",
+        "name": "VE.Bus Error",
+        "enum": {
+          "0": "No error",
+          "1": "VE.Bus Error 1: Device is switched off because one of the other phases in the system has switched off",
+          "2": "VE.Bus Error 2: New and old types MK2 are mixed in the system",
+          "3": "VE.Bus Error 3: Not all, or more than, the expected devices were found in the system",
+          "4": "VE.Bus Error 4: No other device whatsoever detected",
+          "5": "VE.Bus Error 5: Overvoltage on AC-out",
+          "6": "VE.Bus Error 6: Error in DDC Program",
+          "7": "VE.Bus Error 7:  BMS connected, which requires an Assistant, but no assistant found",
+          "8": "VE.Bus Error 8: Ground relay test failed",
+          "9": "VE.Bus Error 9",
+          "10": "VE.Bus Error 10: System time synchronisation problem occurred",
+          "11": "VE.Bus Error 11: Relay test fault",
+          "12": "VE.Bus Error 12",
+          "13": "VE.Bus Error 13",
+          "14": "VE.Bus Error 14: Device cannot transmit data",
+          "15": "VE.Bus Error 15",
+          "16": "VE.Bus Error 16: Awaiting configuration or dongle missing",
+          "17": "VE.Bus Error 17: Phase master missing",
+          "18": "VE.Bus Error 18: AC Overvoltage on the output of a slave has occurred while already switched off",
+          "19": "VE.Bus Error 19",
+          "20": "VE.Bus Error 20",
+          "21": "VE.Bus Error 21",
+          "22": "VE.Bus Error 22: This device cannot function as slave",
+          "23": "VE.Bus Error 23",
+          "24": "VE.Bus Error 24: Switch-over system protection initiated",
+          "25": "VE.Bus Error 25: Firmware incompatibility. The firmware of one of the connected device is not sufficiently up to date to operate in conjunction with this device",
+          "26": "VE.Bus Error 26: Internal error",
+          "27": "VE.Bus Error 27",
+          "28": "VE.Bus Error 28",
+          "29": "VE.Bus Error 29",
+          "30": "VE.Bus Error 30",
+          "31": "VE.Bus Error 31",
+          "32": "VE.Bus Error 32"
+        }
+      }
+    ]
+  },
+  "output-accharger": {
+    "help": "<p>This node is for controlling the AC charger.</p>",
+    "charger": [
+      {
+        "path": "/Ac/In/CurrentLimit",
+        "type": "float",
+        "name": "AC Current limit (A)",
+        "writable": true
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Charger on/off",
+        "enum": {
+          "1": "On",
+          "4": "Off"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay on the charger",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      }
+    ]
+  },
+  "output-ess": {
+    "help": "<p>This node allows for controlling the Energy Storage System (ESS).</p>",
+    "vebus": [
+      {
+        "path": "/Hub4/DisableCharge",
+        "type": "enum",
+        "name": "Disable charge",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Hub4/DisableFeedIn",
+        "type": "enum",
+        "name": "Disable feed-in",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Hub4/DoNotFeedInOvervoltage",
+        "type": "enum",
+        "name": "Feed in overvoltage",
+        "enum": {
+          "0": "Yes",
+          "1": "No"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Hub4/L1/AcPowerSetpoint",
+        "type": "integer",
+        "name": "AC Power L1 setpoint (W)",
+        "writable": true
+      },
+      {
+        "path": "/Hub4/L1/MaxFeedInPower",
+        "type": "integer",
+        "name": "Maximum overvoltage feed-in power L1 (W)",
+        "writable": true
+      },
+      {
+        "path": "/Hub4/L2/AcPowerSetpoint",
+        "type": "integer",
+        "name": "AC Power L2 setpoint (W)",
+        "writable": true
+      },
+      {
+        "path": "/Hub4/L2/MaxFeedInPower",
+        "type": "integer",
+        "name": "Maximum overvoltage feed-in power L2 (W)",
+        "writable": true
+      },
+      {
+        "path": "/Hub4/L3/AcPowerSetpoint",
+        "type": "integer",
+        "name": "AC Power L3 setpoint (W)",
+        "writable": true
+      },
+      {
+        "path": "/Hub4/L3/MaxFeedInPower",
+        "type": "integer",
+        "name": "Maximum overvoltage feed-in power L3 (W)",
+        "writable": true
+      },
+      {
+        "path": "/PvInverter/Disable",
+        "type": "enum",
+        "name": "Disable PV inverter",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        },
+        "writable": true
+      },
+      {
+        "path": "/SystemReset",
+        "type": "enum",
+        "name": "VE.Bus Reset",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        },
+        "writable": true
+      }
+    ],
+    "settings": [
+      {
+        "path": "/Settings/CGwacs/AcPowerSetPoint",
+        "type": "integer",
+        "name": "Grid set-point (W)",
+        "writable": true
+      },
+      {
+        "path": "/Settings/CGwacs/BatteryLife/MinimumSocLimit",
+        "type": "integer",
+        "name": "Minimum Discharge SOC (%)",
+        "writable": true
+      },
+      {
+        "path": "/Settings/CGwacs/BatteryLife/State",
+        "type": "enum",
+        "name": "ESS state",
+        "enum": {
+          "1": "BatteryLife enabled (GUI controlled)",
+          "2": "Optimized Mode /w BatteryLife: self consumption",
+          "3": "Optimized Mode /w BatteryLife: self consumption, SoC exceeds 85%",
+          "4": "Optimized Mode /w BatteryLife: self consumption, SoC at 100%",
+          "5": "Optimized Mode /w BatteryLife: SoC below dynamic SoC limit",
+          "6": "Optimized Mode /w BatteryLife: SoC has been below SoC limit for more than 24 hours. Charging the battery (5A)",
+          "7": "Optimized Mode /w BatteryLife: Inverter/Charger is in sustain mode",
+          "8": "Optimized Mode /w BatteryLife: recharging, SoC dropped by 5% or more below the minimum SoC",
+          "9": "'Keep batteries charged' mode is enabled",
+          "10": "Optimized mode w/o BatteryLife: self consumption, SoC at or above minimum SoC",
+          "11": "Optimized mode w/o BatteryLife: self consumption, SoC is below minimum SoC",
+          "12": "Optimized mode w/o BatteryLife: recharging, SoC dropped by 5% or more below minimum SoC"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Settings/CGwacs/Hub4Mode",
+        "type": "enum",
+        "name": "ESS mode",
+        "enum": {
+          "1": "Optimized mode or 'keep batteries charged' and phase compensation enabled",
+          "2": "Optimized mode or 'keep batteries charged' and phase compensation disabled",
+          "3": "External control"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Settings/CGwacs/MaxDischargePower",
+        "type": "integer",
+        "name": "Max inverter power (W)",
+        "writable": true
+      },
+      {
+        "path": "/Settings/CGwacs/OvervoltageFeedIn",
+        "type": "enum",
+        "name": "Feed-in excess solar charger power",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Settings/CGwacs/PreventFeedback",
+        "type": "enum",
+        "name": "PV Inverter zero feed-in (on/off)",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Settings/SystemSetup/MaxChargeCurrent",
+        "type": "float",
+        "name": "Charge current limit (A)",
+        "writable": true
+      }
+    ]
+  },
+  "output-evcharger": {
+    "help": "<p>With this node the ev charger can be controlled.</p>",
+    "evcharger": [
+      {
+        "path": "/MaxCurrent",
+        "type": "float",
+        "name": "Maximum charge current (A)",
+        "writable": true
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Mode",
+        "enum": {
+          "0": "Manual",
+          "1": "Auto"
+        },
+        "writable": true
+      },
+      {
+        "path": "/SetCurrent",
+        "type": "float",
+        "name": "Set charge current (manual mode) (A)",
+        "writable": true
+      },
+      {
+        "path": "/StartStop",
+        "type": "enum",
+        "name": "Start/stop charging (manual mode)",
+        "enum": {
+          "0": "Stop",
+          "1": "Start"
+        },
+        "writable": true
+      }
+    ]
+  },
+  "output-inverter": {
+    "help": "<p>This node can be used for controlling the inverter.</p>",
+    "inverter": [
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Mode",
+        "enum": {
+          "2": "Inverter on",
+          "4": "Off",
+          "5": "Low Power/ECO"
+        },
+        "writable": true
+      }
+    ]
+  },
+  "output-multi": {
+    "help": "<p>Multi RS output node.</p>",
+    "multi": [
+      {
+        "path": "/Ac/In/1/CurrentLimit",
+        "type": "float",
+        "name": "Ac input 1 current limit (A)",
+        "writable": true
+      },
+      {
+        "path": "/Ac/In/2/CurrentLimit",
+        "type": "float",
+        "name": "Ac input 2 current limit (A)",
+        "writable": true
+      },
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Switch position",
+        "enum": {
+          "1": "Charger Only",
+          "2": "Inverter Only",
+          "3": "On",
+          "4": "Off"
+        },
+        "writable": true
+      }
+    ]
+  },
+  "output-relay": {
+    "help": "<p>The relays of the Venus device can be controled with this node. Make sure to set the relay(s) to <b>Manual</b> via the Venus OS GUI first. </p>",
+    "system": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Venus relay 1 state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Relay/1/State",
+        "type": "enum",
+        "name": "Venus relay 2 state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Relay/2/State",
+        "type": "enum",
+        "name": "Venus relay 3 state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      },
+      {
+        "path": "/Relay/3/State",
+        "type": "enum",
+        "name": "Venus relay 4 state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      }
+    ],
+    "battery": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay status",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      }
+    ],
+    "charger": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay on the charger",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      }
+    ],
+    "solarcharger": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay on the charger",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      }
+    ],
+    "inverter": [
+      {
+        "path": "/Relay/0/State",
+        "type": "enum",
+        "name": "Relay state",
+        "enum": {
+          "0": "Open",
+          "1": "Closed"
+        },
+        "writable": true
+      }
+    ]
+  },
+  "output-solarcharger": {
+    "help": "<p>With this node the solar charger can be switched on and off.</p>",
+    "solarcharger": [
+      {
+        "path": "/Mode",
+        "type": "enum",
+        "name": "Charger on/off",
+        "enum": {
+          "1": "On",
+          "4": "Off"
+        },
+        "writable": true
+      }
+    ]
+  }
 }

--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -132,7 +132,7 @@ class SystemConfiguration {
             "input-dcdc": this.getNodeServices("input-dcdc"),
             "input-dcload": this.getNodeServices("input-dcload"),
             "input-dcsource": this.getNodeServices("input-dcsource"),
-            "input-dcsystem": this.getNodeServices("input-dcystem"),
+            "input-dcsystem": this.getNodeServices("input-dcsystem"),
             "input-digitalinput": this.getNodeServices("input-digitalinput"),
             "input-ess": this.getNodeServices("input-ess"),
             "input-evcharger": this.getNodeServices("input-evcharger"),

--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -127,13 +127,17 @@ class SystemConfiguration {
             // input node services
             "input-accharger": this.getNodeServices("input-accharger"),
             "input-acload": this.getNodeServices("input-acload"),
-            "input-battery": this.getNodeServices("input-battery"),
             "input-alternator": this.getNodeServices("input-alternator"),
+            "input-battery": this.getNodeServices("input-battery"),
             "input-dcdc": this.getNodeServices("input-dcdc"),
             "input-dcload": this.getNodeServices("input-dcload"),
             "input-dcsource": this.getNodeServices("input-dcsource"),
+            "input-dcsystem": this.getNodeServices("input-dcystem"),
             "input-digitalinput": this.getNodeServices("input-digitalinput"),
             "input-ess": this.getNodeServices("input-ess"),
+            "input-evcharger": this.getNodeServices("input-evcharger"),
+            "input-generator": this.getNodeServices("input-generator"),
+            "input-genset": this.getNodeServices("input-genset"),
             "input-gps": this.getNodeServices("input-gps"),
             "input-gridmeter": this.getNodeServices("input-gridmeter"),
             "input-inverter": this.getNodeServices("input-inverter"),
@@ -150,11 +154,11 @@ class SystemConfiguration {
             // output services
             "output-accharger": this.getNodeServices("output-accharger"),
             "output-ess": this.getNodeServices("output-ess"),
+            "output-evcharger": this.getNodeServices("output-evcharger"),
             "output-inverter": this.getNodeServices("output-inverter"),
             "output-multi": this.getNodeServices("output-multi"),
             "output-relay": this.getRelayServices(),
             "output-solarcharger": this.getNodeServices("output-solarcharger"),
-            "output-vebus": this.getNodeServices("output-vebus"),
         }
 
         return device !== null


### PR DESCRIPTION
- Added several missing nodes:
  - input-dcsystem
  - input-evcharger
  - input-generator
  - input-genset
  - output-evcharger
  - output-multi
- Also alphabetized the items within the nodes by path name
- Fixed typo in victron-system.js, which caused a crash
- Missed in the input nodes some paths that where present in the output nodes. Added these paths, so they can also be read.
- Updated documentation to reflect the changes in order and paths