### PR TITLE
Added "DVCC" text with consolidated charge parameters (issue #140) 

### DIFF
--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -1268,10 +1268,10 @@ Questions can also be asked on the Victron Energy community:
   <li>1 - Yes</li>
 </ul>
 </dd>
-  <dt class="optional">Charge current limit (A)<span class="property-type">float</dt>
+  <dt class="optional">DVCC Charge current limit (A)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeCurrent</b>
 </dd>
-  <dt class="optional">Maximum charge voltage (V)<span class="property-type">float</dt>
+  <dt class="optional">DVCC Maximum charge voltage (V)<span class="property-type">float</dt>
   <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeVoltage</b>
 </dd>
 </dl>

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -1616,12 +1616,12 @@
       {
         "path": "/Settings/SystemSetup/MaxChargeCurrent",
         "type": "float",
-        "name": "Charge current limit (A)"
+        "name": "DVCC Charge current limit (A)"
       },
       {
         "path": "/Settings/SystemSetup/MaxChargeVoltage",
         "type": "float",
-        "name": "Maximum charge voltage (V)"
+        "name": "DVCC Maximum charge voltage (V)"
       }
     ]
   },


### PR DESCRIPTION
- Added "DVCC" prefix for clarification in line with parameter description from the GUI.
- In addition to changes discussed in #140:
-- Consolidate DVCC parameters to the settings nodes (instead of ESS)
-- Add reading maximum charge voltage