### PR TITLE
Fix: Label "L3 Current (A)" for /Ac/L3/Current

### DIFF
--- a/src/services/services.json
+++ b/src/services/services.json
@@ -2256,7 +2256,7 @@
       {
         "path": "/Ac/L3/Current",
         "type": "float",
-        "name": "L2 Current (A)"
+        "name": "L3 Current (A)"
       },
       {
         "path": "/Ac/L3/Energy/Forward",


### PR DESCRIPTION
..as described in Bug #166