### PR TITLE
Include gridmeter /Ac/Power as "Power (W)"

### DIFF
--- a/src/services/services.json
+++ b/src/services/services.json
@@ -2204,6 +2204,11 @@
         "name": "Total Reverse Energy (sold) (kWh)"
       },
       {
+        "path": "/Ac/Power",
+        "type": "float",
+        "name": "Power (W)"
+      },
+      {
         "path": "/Ac/L1/Current",
         "type": "float",
         "name": "L1 Current (A)"


### PR DESCRIPTION
..otherwise the L1+L2+L3 Power values had to be summed up The /Ac/Power value is already offered in service-whitelist.js, ready for use.