### PR TITLE
Add Relay-Option to SolarCharger Output

### DIFF
--- a/scripts/service-whitelist.js
+++ b/scripts/service-whitelist.js
@@ -461,7 +461,8 @@ module.exports = {
   'output-solarcharger': {
     solarcharger: [
       '/Mode',
-      '/MppOperationMode'
+      '/MppOperationMode',
+      '/Relay/0/State'
     ]
   },
   'output-ess': {


### PR DESCRIPTION
Add Relay-Option to SolarCharger Output
Needed, to control the Reley of e.g.
SmartSolar 450 MPPT