### PR TITLE
dependencies upgrade and cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.6.20",
             "license": "MIT",
             "dependencies": {
-                "dbus-native-victron": "^0.4.3",
+                "dbus-native-victron": "^0.4.4",
                 "dbus-victron-virtual": "^0.1.12",
                 "debug": "^4.4.0",
                 "lodash": "^4.17.21",
@@ -1121,20 +1121,17 @@
             }
         },
         "node_modules/dbus-native-victron": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/dbus-native-victron/-/dbus-native-victron-0.4.3.tgz",
-            "integrity": "sha512-zDKiluaAH9tfAm0APp8Vdgomcbuoxih7omroCWseMoV2bBmuUsNJsMNfdOgWfIXN6hiXyiZfngiYb0RiiiNJKw==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/dbus-native-victron/-/dbus-native-victron-0.4.4.tgz",
+            "integrity": "sha512-UifR1kzfWwyifWI6mmHO0J6WoXQpWPFZj5a39pnS/+d/hfIMkagoUQkfbTqXYDy48fgQkslUy81ZHO7VY3WUoA==",
+            "license": "MIT",
             "dependencies": {
                 "event-stream": "^4.0.0",
                 "hexy": "^0.2.10",
                 "long": "^4.0.0",
-                "optimist": "^0.5.2",
                 "put": "0.0.6",
                 "safe-buffer": "^5.1.1",
                 "xml2js": "^0.6.2"
-            },
-            "bin": {
-                "dbus2js": "bin/dbus2js.js"
             },
             "optionalDependencies": {
                 "abstract-socket": "^2.0.0"
@@ -3042,14 +3039,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/optimist": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.5.2.tgz",
-            "integrity": "sha512-r9M8ZpnM9SXV5Wii7TCqienfcaY3tAiJe9Jchof87icbmbruKgK0xKXngmrnowTDnEawmmI1Qbha59JEoBkBGA==",
-            "dependencies": {
-                "wordwrap": "~0.0.2"
-            }
-        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4460,14 +4449,6 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "Custom Node-RED Nodes for Victron Energy",
     "version": "1.6.20",
     "dependencies": {
-        "dbus-native-victron": "^0.4.3",
+        "dbus-native-victron": "^0.4.4",
         "dbus-victron-virtual": "^0.1.12",
         "debug": "^4.4.0",
         "lodash": "^4.17.21",


### PR DESCRIPTION
This upgrades to the latest version of [dbus-native-victron](https://github.com/Chris927/dbus-native), and thereby removes 4 now unnecessary dependencies.

I've done smoke-screen testing by running Node-RED against my local Cerbo CX. More testing may be required :)
