### PR TITLE
feat: Enable Virtual Battery to become active BMS in a system

### DIFF
--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -13,6 +13,7 @@ const properties = {
     'Info/MaxChargeVoltage': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '' },
     'Info/MaxChargeCurrent': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
     'Info/MaxDischargeCurrent': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
+    'Info/ChargeRequest': { type: 'i', format: (v) => v != null ? v : '', value: 1 },
     Soc: { type: 'd', min: 0, max: 100, format: (v) => v != null ? v.toFixed(0) + '%' : '' },
     Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
   },

--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -9,6 +9,10 @@ const properties = {
     'Dc/0/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
     'Dc/0/Voltage': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '' },
     'Dc/0/Temperature': { type: 'd', format: (v) => v != null ? v.toFixed(1) + 'C' : '' },
+    'Info/BatteryLowVoltage': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '' },
+    'Info/MaxChargeVoltage': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '' },
+    'Info/MaxChargeCurrent': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
+    'Info/MaxDischargeCurrent': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
     Soc: { type: 'd', min: 0, max: 100, format: (v) => v != null ? v.toFixed(0) + '%' : '' },
     Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
   },


### PR DESCRIPTION
Without these dbus paths Virtual Battery can't be used as active BMS monitor
This allows to make VE.bus/VE.can inverters happy with BMS controlled mode as well as fix some of the badly factory configured BMSes with wrong limit voltage or/and current

This change helps to get it as "Controlling BMS"
![image](https://github.com/user-attachments/assets/edfffa87-3a15-497c-bf9c-0e372f92abab)

Flow I use to prove 
![image](https://github.com/user-attachments/assets/de5298ba-fcfd-47a1-b99d-a13ea88d6f29)

```json
[
    {
        "id": "6167fb1a3a50da34",
        "type": "victron-virtual",
        "z": "eabbf1f3d406ee01",
        "name": "Virtual",
        "device": "battery",
        "default_values": false,
        "battery_capacity": "175",
        "include_battery_temperature": true,
        "grid_nrofphases": 1,
        "position": 0,
        "pvinverter_nrofphases": 1,
        "switch_nrofoutput": 1,
        "switch_nrofpwm": 1,
        "fluid_type": 0,
        "include_tank_battery": false,
        "include_tank_temperature": false,
        "tank_battery_voltage": 3.3,
        "tank_capacity": 0.2,
        "temperature_type": 2,
        "include_humidity": false,
        "include_pressure": false,
        "include_temp_battery": false,
        "temp_battery_voltage": 3.3,
        "x": 1030,
        "y": 60,
        "wires": []
    },
    {
        "id": "193dd767834968df",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/Connected",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/Connected",
            "name": "/Connected",
            "type": "number",
            "value": 1
        },
        "name": "",
        "onlyChanges": false,
        "x": 890,
        "y": 180,
        "wires": [
            [
                "835e1ba74eb93778"
            ]
        ]
    },
    {
        "id": "835e1ba74eb93778",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/Connected",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/Connected",
            "name": "/Connected",
            "type": "number",
            "value": 1
        },
        "name": "",
        "onlyChanges": false,
        "x": 1210,
        "y": 180,
        "wires": []
    },
    {
        "id": "789c5b6cd16b8e65",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/Dc/0/Current",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/Dc/0/Current",
            "name": "/Dc/0/Current",
            "type": "number",
            "value": -2.5999999046325684
        },
        "name": "",
        "onlyChanges": false,
        "x": 890,
        "y": 260,
        "wires": [
            [
                "651447203c83ecc9"
            ]
        ]
    },
    {
        "id": "651447203c83ecc9",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/Dc/0/Current",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/Dc/0/Current",
            "name": "/Dc/0/Current",
            "type": "object",
            "value": null
        },
        "name": "",
        "onlyChanges": false,
        "x": 1220,
        "y": 260,
        "wires": []
    },
    {
        "id": "3b3ff2afba9e94e7",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/Dc/0/Power",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/Dc/0/Power",
            "name": "/Dc/0/Power",
            "type": "number",
            "value": -139
        },
        "name": "",
        "onlyChanges": false,
        "x": 890,
        "y": 340,
        "wires": [
            [
                "dc509e5acfb2f863"
            ]
        ]
    },
    {
        "id": "dc509e5acfb2f863",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/Dc/0/Power",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/Dc/0/Power",
            "name": "/Dc/0/Power",
            "type": "object",
            "value": null
        },
        "name": "",
        "onlyChanges": false,
        "x": 1210,
        "y": 340,
        "wires": []
    },
    {
        "id": "527405493639640e",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/Dc/0/Voltage",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/Dc/0/Voltage",
            "name": "/Dc/0/Voltage",
            "type": "number",
            "value": 49.95000076293945
        },
        "name": "",
        "onlyChanges": false,
        "x": 890,
        "y": 420,
        "wires": [
            [
                "17032555d2900423"
            ]
        ]
    },
    {
        "id": "17032555d2900423",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/Dc/0/Voltage",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/Dc/0/Voltage",
            "name": "/Dc/0/Voltage",
            "type": "object",
            "value": null
        },
        "name": "",
        "onlyChanges": false,
        "x": 1220,
        "y": 420,
        "wires": []
    },
    {
        "id": "c04a15671eca727e",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/Soc",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/Soc",
            "name": "/Soc",
            "type": "number",
            "value": 84
        },
        "name": "",
        "onlyChanges": false,
        "x": 860,
        "y": 500,
        "wires": [
            [
                "be95b741743d82b8"
            ]
        ]
    },
    {
        "id": "be95b741743d82b8",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/Soc",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/Soc",
            "name": "/Soc",
            "type": "object",
            "value": null
        },
        "name": "",
        "onlyChanges": false,
        "x": 1190,
        "y": 500,
        "wires": []
    },
    {
        "id": "95a12e8002179ec0",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/ProductId",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/ProductId",
            "name": "/ProductId",
            "type": "number",
            "value": 45065
        },
        "name": "",
        "onlyChanges": false,
        "x": 880,
        "y": 560,
        "wires": [
            [
                "138a9b9ad0ae0a3f"
            ]
        ]
    },
    {
        "id": "138a9b9ad0ae0a3f",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/ProductId",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/ProductId",
            "name": "/ProductId",
            "type": "number",
            "value": 49253
        },
        "name": "",
        "onlyChanges": false,
        "x": 1210,
        "y": 560,
        "wires": []
    },
    {
        "id": "9dbf0f059e73bb61",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/Info/MaxChargeCurrent",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/Info/MaxChargeCurrent",
            "name": "/Info/MaxChargeCurrent",
            "type": "number",
            "value": 117
        },
        "name": "",
        "onlyChanges": false,
        "x": 930,
        "y": 640,
        "wires": [
            [
                "b1e378284a0bb515"
            ]
        ]
    },
    {
        "id": "b1e378284a0bb515",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/Info/MaxChargeCurrent",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/Info/MaxChargeCurrent",
            "name": "/Info/MaxChargeCurrent",
            "type": "object",
            "value": null
        },
        "name": "",
        "onlyChanges": false,
        "x": 1250,
        "y": 640,
        "wires": []
    },
    {
        "id": "25f0581bf7212325",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/Info/MaxChargeVoltage",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/Info/MaxChargeVoltage",
            "name": "/Info/MaxChargeVoltage",
            "type": "number",
            "value": 53.20000076293945
        },
        "name": "",
        "onlyChanges": false,
        "x": 930,
        "y": 700,
        "wires": [
            [
                "f1c928408d1384aa"
            ]
        ]
    },
    {
        "id": "f1c928408d1384aa",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/Info/MaxChargeVoltage",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/Info/MaxChargeVoltage",
            "name": "/Info/MaxChargeVoltage",
            "type": "object",
            "value": null
        },
        "name": "",
        "onlyChanges": false,
        "x": 1250,
        "y": 700,
        "wires": []
    },
    {
        "id": "f4b3135accede5ad",
        "type": "victron-input-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/512",
        "path": "/Info/MaxDischargeCurrent",
        "serviceObj": {
            "service": "com.victronenergy.battery/512",
            "name": "8kWh (512)"
        },
        "pathObj": {
            "path": "/Info/MaxDischargeCurrent",
            "name": "/Info/MaxDischargeCurrent",
            "type": "number",
            "value": 117
        },
        "name": "",
        "onlyChanges": false,
        "x": 930,
        "y": 760,
        "wires": [
            [
                "307abef6d17a32e6"
            ]
        ]
    },
    {
        "id": "307abef6d17a32e6",
        "type": "victron-output-custom",
        "z": "eabbf1f3d406ee01",
        "service": "com.victronenergy.battery/100",
        "path": "/Info/MaxDischargeCurrent",
        "serviceObj": {
            "service": "com.victronenergy.battery/100",
            "name": "Virtual (100)"
        },
        "pathObj": {
            "path": "/Info/MaxDischargeCurrent",
            "name": "/Info/MaxDischargeCurrent",
            "type": "object",
            "value": null
        },
        "name": "",
        "onlyChanges": false,
        "x": 1260,
        "y": 760,
        "wires": []
    }
]
```
