### PR TITLE
Add missing TemperatureTypes to Virtual Temp Devices

### DIFF
--- a/scripts/missingpaths.json
+++ b/scripts/missingpaths.json
@@ -572,7 +572,11 @@
             "enum": {
                 "0": "battery",
                 "1": "fridge",
-                "2": "generic"
+                "2": "generic",
+                "3": "room;",
+                "4": "outdoor",
+                "5": "waterheater",
+                "6": "freezer"
             }
         }
     },

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -221,6 +221,10 @@
                 <option value="0">Battery</option>
                 <option value="1">Fridge</option>
                 <option value="2">Generic</option>
+                <option value="3">Room</option>
+                <option value="4">Outdoor</option>
+                <option value="5">WaterHeater</option>
+                <option value="6">Freezer</option>
             </select>
         </div>
 

--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -22,7 +22,11 @@ const properties = {
       format: (v) => ({
         0: 'Battery',
         1: 'Fridge',
-        2: 'Generic'
+        2: 'Generic',
+        3: 'Room',
+        4: 'Outdoor',
+        5: 'WaterHeater',
+        6: 'Freezer'
       }[v] || 'unknown')
     },
     Pressure: { type: 'd', format: (v) => v != null ? v.toFixed(0) + 'hPa' : '' },


### PR DESCRIPTION
Hi, while testing the 3.60 beta i found that the Virtual Temp-Devices did not support other Types then Battery, Fridge and Generic.
So is added the other Types.
