### PR TITLE
Remove polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.6.24",
             "license": "MIT",
             "dependencies": {
-                "dbus-native-victron": "^0.4.3",
+                "dbus-native-victron": "^0.4.4",
                 "dbus-victron-virtual": "^0.1.12",
                 "debug": "^4.4.0",
                 "lodash": "^4.17.21",
@@ -1121,20 +1121,17 @@
             }
         },
         "node_modules/dbus-native-victron": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/dbus-native-victron/-/dbus-native-victron-0.4.3.tgz",
-            "integrity": "sha512-zDKiluaAH9tfAm0APp8Vdgomcbuoxih7omroCWseMoV2bBmuUsNJsMNfdOgWfIXN6hiXyiZfngiYb0RiiiNJKw==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/dbus-native-victron/-/dbus-native-victron-0.4.4.tgz",
+            "integrity": "sha512-UifR1kzfWwyifWI6mmHO0J6WoXQpWPFZj5a39pnS/+d/hfIMkagoUQkfbTqXYDy48fgQkslUy81ZHO7VY3WUoA==",
+            "license": "MIT",
             "dependencies": {
                 "event-stream": "^4.0.0",
                 "hexy": "^0.2.10",
                 "long": "^4.0.0",
-                "optimist": "^0.5.2",
                 "put": "0.0.6",
                 "safe-buffer": "^5.1.1",
                 "xml2js": "^0.6.2"
-            },
-            "bin": {
-                "dbus2js": "bin/dbus2js.js"
             },
             "optionalDependencies": {
                 "abstract-socket": "^2.0.0"
@@ -3042,14 +3039,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/optimist": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.5.2.tgz",
-            "integrity": "sha512-r9M8ZpnM9SXV5Wii7TCqienfcaY3tAiJe9Jchof87icbmbruKgK0xKXngmrnowTDnEawmmI1Qbha59JEoBkBGA==",
-            "dependencies": {
-                "wordwrap": "~0.0.2"
-            }
-        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4460,14 +4449,6 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "Custom Node-RED Nodes for Victron Energy",
     "version": "1.6.24",
     "dependencies": {
-        "dbus-native-victron": "^0.4.3",
+        "dbus-native-victron": "^0.4.4",
         "dbus-victron-virtual": "^0.1.12",
         "debug": "^4.4.0",
         "lodash": "^4.17.21",

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -62,6 +62,8 @@ module.exports = function (RED) {
           setTimeout(migrateSubscriptions, 1000, this)
         }
 
+        const isPollingEnabled = process.env.ENABLE_POLLING !== 'false'
+        const callbackPeriodically = !this.node.onlyChanges && !isPollingEnabled
         this.subscription = this.client.subscribe(this.service, this.path, (msg) => {
           let topic = this.defaulttopic
           if (this.node.name) {
@@ -105,7 +107,7 @@ module.exports = function (RED) {
           if (!this.sentInitialValue) {
             this.sentInitialValue = true
           }
-        }, { callbackPeriodically: !this.node.onlyChanges })
+        }, { callbackPeriodically })
       }
 
       this.on('close', function (done) {

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -33,7 +33,7 @@ module.exports = function (RED) {
   }
 
   class BaseInputNode {
-    constructor (nodeDefinition) {
+    constructor(nodeDefinition) {
       RED.nodes.createNode(this, nodeDefinition)
 
       this.node = this
@@ -105,7 +105,7 @@ module.exports = function (RED) {
           if (!this.sentInitialValue) {
             this.sentInitialValue = true
           }
-        })
+        }, { callbackPeriodically: !this.node.onlyChanges })
       }
 
       this.on('close', function (done) {
@@ -118,7 +118,7 @@ module.exports = function (RED) {
   }
 
   class BaseOutputNode {
-    constructor (nodeDefinition) {
+    constructor(nodeDefinition) {
       RED.nodes.createNode(this, nodeDefinition)
 
       this.node = this
@@ -211,8 +211,8 @@ module.exports = function (RED) {
 
       // Set initial value only if it's not empty
       if (this.initialValue !== undefined &&
-            this.initialValue !== null &&
-            this.initialValue !== '') {
+        this.initialValue !== null &&
+        this.initialValue !== '') {
         setValue(this.initialValue)
       }
 

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -33,7 +33,7 @@ module.exports = function (RED) {
   }
 
   class BaseInputNode {
-    constructor(nodeDefinition) {
+    constructor (nodeDefinition) {
       RED.nodes.createNode(this, nodeDefinition)
 
       this.node = this
@@ -120,7 +120,7 @@ module.exports = function (RED) {
   }
 
   class BaseOutputNode {
-    constructor(nodeDefinition) {
+    constructor (nodeDefinition) {
       RED.nodes.createNode(this, nodeDefinition)
 
       this.node = this

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -130,12 +130,12 @@ class VictronDbusListener {
           console.warn('Polling is disabled, which is new behavior and a potentially breaking change. Set ENABLE_POLLING to "true" to enable it.')
           // without polling, we request all roots once
           this._requestAllRoots()
-          .then(() => {
-            console.log('Polling is disabled. All roots have been requested once successfully.')
-          })
-          .catch(err => {
-            console.error('Error requesting all roots:', err)
-          })
+            .then(() => {
+              console.log('Polling is disabled. All roots have been requested once successfully.')
+            })
+            .catch(err => {
+              console.error('Error requesting all roots:', err)
+            })
         }
 
         // The following callbacks should be initialized
@@ -235,10 +235,9 @@ class VictronDbusListener {
         resolve()
       })
     })
-
   }
 
-  async _requestAllRoots() {
+  async _requestAllRoots () {
     // Previously, we did this:
     // _.values(this.services).forEach(service => this._requestRoot(service))
     // ... but now we need to request all roots in more than one place,

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -8,6 +8,8 @@ const debug = require('debug')('node-red-contrib-victron:dbus')
 const _ = require('lodash')
 
 /**
+ * TODO: this documentation comment is outdated
+ *
  * VictronDbusListener encapsulates the dbus communications
  * between Node-RED and Venus system. It establishes a dbus
  * connection and exposes relevant callbacks to its owner.
@@ -198,7 +200,7 @@ class VictronDbusListener {
         const data = {}
         const getTargetValue = (arr) => arr[arr.findIndex(innerArr => innerArr[0] === 'Value')]?.[1]?.[1]?.[0]
 
-        console.log('requestRoot, service.name, res.length', service.name, res.length)
+        debug('requestRoot, service.name, res.length', service.name, res.length)
         res.forEach(([path, values]) => {
           data[path] = getTargetValue(values)
         })
@@ -222,6 +224,7 @@ class VictronDbusListener {
             fluidType: service.fluidType
           }
         })
+        debug('requestRoot, messages', messages)
         this.messageHandler(messages)
         resolve()
       })
@@ -231,16 +234,15 @@ class VictronDbusListener {
 
   async _requestAllRoots() {
       const start = new Date()
-      console.log('POLLING, start', start)
+      debug('POLLING, start', start)
       const promises = []
       for (const key in this.services) {
-        console.log('POLLING', key)
+        debug('POLLING', key)
         await this._requestRoot(this.services[key])
       }
-      // await Promise.all(promises)
+      // await Promise.all(promises) // TODO: alternatively, we can use Promise.all to run all requests in parallel
       const end = new Date()
-      console.log('POLLING, end', end)
-      console.log('POLLING, duration', end - start)
+      debug('POLLING, duration', end - start)
       // _.values(this.services).forEach(service => this._requestRoot(service))
   }
 
@@ -273,7 +275,7 @@ class VictronDbusListener {
     const messages = []
     switch (msg.member) {
       case 'ItemsChanged': {
-        console.log('ItemsChanged', msg)
+        debug('ItemsChanged', msg)
         msg.body[0].forEach(entry => {
           const m = { changed: true }
           m.path = entry[0]
@@ -305,7 +307,7 @@ class VictronDbusListener {
         break
       }
       case 'PropertiesChanged': {
-        console.log('PropertiesChanged', msg)
+        debug('PropertiesChanged', msg)
         if (msg.body[0] && msg.body[0].length === 2) {
           const m = msg
           msg.body[0].forEach(v => {

--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -43,6 +43,10 @@ class VictronClient {
         const trail = ('/' + (msg.deviceInstance != null ? msg.deviceInstance : '')).replace(/\/$/, '')
         const msgKey = `${msg.senderName}${trail}:${msg.path}`
         debug(`[MESSAGE HANDLER] ${msgKey} | ${JSON.stringify(msg, null, 2)}`)
+        // we remove msg.text, as we don't use it, and removing it makes it "in line" with what
+        // we do in case of using regular callbacks from the cache, instead of polling (see
+        // option callbackPeriodically)
+        delete msg.text
         if (msgKey in _this.subscriptions) { _this.subscriptions[msgKey].forEach(sub => sub.callback(msg)) }
       })
     }
@@ -80,11 +84,8 @@ class VictronClient {
      * receive ItemsChanged or PropertiesChanged events). Without the polling, the option.callbackPeriodically
      * is needed to get the same effect for subscriptions that need periodic updates.
      */
-    // TODO
-    // open question: how do we stop this interval? Are we listening to a disconnect somewhere? And then how do we reconnect?
-    // we can probably use this.client.connected?
     setInterval(() => {
-      // TODO: we never stop this interval. This may be okay, as there is no mechanism to
+      // we never stop this interval. This may be okay, as there is no mechanism to
       // disconnect from dbus. In other words, once an instance of VictronClient is created,
       // it will always be connected (or try to be connected) to dbus. Thus, we can run the
       // interval indefinitely.
@@ -105,8 +106,7 @@ class VictronClient {
                 senderName,
                 deviceInstance,
                 value,
-                changed: false,
-                text: `${value}` // TODO: we have no text representation in the cache
+                changed: false
               })
             }
           })

--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -14,7 +14,7 @@ const utils = require('./utils.js')
  * @param {string} address IP address for dbus over TCP, both address and port. E.g. 127.0.0.1:78
  */
 class VictronClient {
-  constructor(address) {
+  constructor (address) {
     this.dbusAddress = address
     this.client = null
 
@@ -32,7 +32,7 @@ class VictronClient {
      *     let vc = new VictronClient()
      *     await vc.connect()
      */
-  async connect() {
+  async connect () {
     const _this = this
 
     // messageHandler gets a list of received messages as a parameter
@@ -75,7 +75,7 @@ class VictronClient {
     /**
      * Subscriptions with option.callbackPeriodically set to true will be called every 5 seconds.
      *
-     * This is part of replacing the polling we do in VictronDbusListener._requestRoot(): VictronDbusListener 
+     * This is part of replacing the polling we do in VictronDbusListener._requestRoot(): VictronDbusListener
      * would cause, by polling dbus every 5 seconds, that each subscription is called every 5 seconds (plus whenever we
      * receive ItemsChanged or PropertiesChanged events). Without the polling, the option.callbackPeriodically
      * is needed to get the same effect for subscriptions that need periodic updates.
@@ -93,7 +93,6 @@ class VictronClient {
           const topicSubscription = this.subscriptions[topic]
           topicSubscription.forEach(sub => {
             if (sub.options && sub.options.callbackPeriodically) {
-
               // we need to get the value from the cache
               const data = this.system.cache[sub.dbusInterface]
               debug(`[CALLBACK PERIODICALLY], about to callback, subscriptionId=${sub.subscriptionId} | dbusInterface=${sub.dbusInterface} path=${sub.path} data: ${JSON.stringify(data)}`)
@@ -109,7 +108,6 @@ class VictronClient {
                 changed: false,
                 text: `${value}` // TODO: we have no text representation in the cache
               })
-
             }
           })
         })
@@ -122,13 +120,13 @@ class VictronClient {
         .connect()
         .catch(retry)
     },
-      {
-        factor: 2,
-        forever: true,
-        minTimeout: 5 * 1000,
-        maxTimeout: 60 * 1000
+    {
+      factor: 2,
+      forever: true,
+      minTimeout: 5 * 1000,
+      maxTimeout: 60 * 1000
 
-      })
+    })
       .catch(() => console.error('Unable to connect to dbus.'))
   }
 
@@ -138,7 +136,7 @@ class VictronClient {
      *
      * @param {object} msg a message object received from the dbus-listener
      */
-  saveToCache(msg) {
+  saveToCache (msg) {
     let dbusPaths = {}
 
     const trail = ('/' + (msg.deviceInstance != null ? msg.deviceInstance : '')).replace(/\/$/, '')
@@ -168,7 +166,7 @@ class VictronClient {
      * @param {string} path specific path to subscribe to, e.g. /Dc/Battery/Voltage
      * @param {function} callback a callback function which is invoked upon receiving a message that matches both the interface and path
      */
-  subscribe(dbusInterface, path, callback, options) {
+  subscribe (dbusInterface, path, callback, options) {
     const subscriptionId = utils.UUID()
     const newSubscription = { callback, dbusInterface, path, subscriptionId, options }
 
@@ -185,7 +183,7 @@ class VictronClient {
      *
      * @param {string} subscriptionId a semi-unique string identifying a single node-specific message listener
      */
-  unsubscribe(subscriptionId) {
+  unsubscribe (subscriptionId) {
     Object.keys(this.subscriptions).forEach(topic => {
       const topicSubscription = this.subscriptions[topic]
       const removed = _.remove(topicSubscription, { subscriptionId })
@@ -207,7 +205,7 @@ class VictronClient {
      * @param {string} path specific path to publish to, e.g. /Relay/0/State
      * @param {string} value value to write to the given dbus service, e.g. 1
      */
-  publish(dbusInterface, path, value, cb) {
+  publish (dbusInterface, path, value, cb) {
     if (this.client && this.client.connected) {
       debug(`[PUBLISH] ${dbusInterface} ${path} | ${value}`)
       this.client.setValue(dbusInterface, path, value, cb)

--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -42,7 +42,7 @@ class VictronClient {
         _this.saveToCache(msg)
         const trail = ('/' + (msg.deviceInstance != null ? msg.deviceInstance : '')).replace(/\/$/, '')
         const msgKey = `${msg.senderName}${trail}:${msg.path}`
-        console.log(`[MESSAGE HANDLER] ${msgKey} | ${JSON.stringify(msg, null, 2)}`)
+        debug(`[MESSAGE HANDLER] ${msgKey} | ${JSON.stringify(msg, null, 2)}`)
         if (msgKey in _this.subscriptions) { _this.subscriptions[msgKey].forEach(sub => sub.callback(msg)) }
       })
     }


### PR DESCRIPTION
Introduces an environment variable `ENABLE_POLLING`, so that polling (compare #219, #185) can optionally be replaced with periodically calling subscribers with data from the cache of dbus properties we maintain.

Unless you set `ENABLE_POLLING=false`, the behavior in terms of polling is as before, so *not polling* is opt-in for now. At a later stage, default behavior can be flipped to not poll by default.

More testing is required. Specifically, I haven't tested yet that a dbus service joining the bus will be detected and cached with its properties correctly. @dirkjanfaber , I'd appreciate if you can test this :)

Once we are happy with this, it should resolve related performance concerns, as per #219.