### PR TITLE
Setting values on virtual devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "dbus-native-victron": "^0.4.4",
-                "dbus-victron-virtual": "^0.1.16",
+                "dbus-victron-virtual": "github:Chris927/dbus-victron-virtual#8aef9aa",
                 "debug": "^4.4.0",
                 "lodash": "^4.17.21",
                 "promise-retry": "^2.0.1",
@@ -58,9 +58,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.7.tgz",
-            "integrity": "sha512-xgu/ySj2mTiUFmdE9yCMfBxLp4DHd5DwmbbD05YAuICfodYT3VvRxbrh81LGQ/8UpSdtMdfKMn3KouYDX59DGQ==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
+            "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
             "dev": true,
             "peer": true,
             "engines": {
@@ -68,22 +68,22 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
-            "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
+            "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.5",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.27.3",
-                "@babel/helpers": "^7.27.6",
-                "@babel/parser": "^7.27.7",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.27.7",
-                "@babel/types": "^7.27.7",
+                "@babel/generator": "^7.27.1",
+                "@babel/helper-compilation-targets": "^7.27.1",
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helpers": "^7.27.1",
+                "@babel/parser": "^7.27.1",
+                "@babel/template": "^7.27.1",
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -99,9 +99,9 @@
             }
         },
         "node_modules/@babel/eslint-parser": {
-            "version": "7.27.5",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.27.5.tgz",
-            "integrity": "sha512-HLkYQfRICudzcOtjGwkPvGc5nF1b4ljLZh1IRDj50lRZ718NAKVgQpIAUX8bfg6u/yuSKY3L7E0YzIV+OxrB8Q==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.27.1.tgz",
+            "integrity": "sha512-q8rjOuadH0V6Zo4XLMkJ3RMQ9MSBqwaDByyYB0izsYdaIWGNLmEblbCOf1vyFHICcg16CD7Fsi51vcQnYxmt6Q==",
             "dev": true,
             "dependencies": {
                 "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -117,14 +117,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.27.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-            "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
+            "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.27.5",
-                "@babel/types": "^7.27.3",
+                "@babel/parser": "^7.27.1",
+                "@babel/types": "^7.27.1",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^3.0.2"
@@ -165,15 +165,15 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-            "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
+            "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
             "dev": true,
             "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.27.1",
                 "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.27.3"
+                "@babel/traverse": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -213,27 +213,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
+            "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.6"
+                "@babel/template": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.7.tgz",
-            "integrity": "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+            "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@babel/types": "^7.27.7"
+                "@babel/types": "^7.27.1"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -258,17 +258,17 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.7.tgz",
-            "integrity": "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
+            "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
             "dev": true,
             "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.5",
-                "@babel/parser": "^7.27.7",
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.7",
+                "@babel/generator": "^7.27.1",
+                "@babel/parser": "^7.27.1",
+                "@babel/template": "^7.27.1",
+                "@babel/types": "^7.27.1",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -277,9 +277,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
-            "integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+            "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -327,9 +327,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-            "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+            "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
             "dependencies": {
                 "@eslint/object-schema": "^2.1.6",
                 "debug": "^4.3.1",
@@ -340,9 +340,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-            "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+            "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -392,9 +392,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.30.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.0.tgz",
-            "integrity": "sha512-Wzw3wQwPvc9sHM+NjakWTcPx11mbZyiYHuwWa/QfZ7cIRX7WK54PSk7bdyXDaoaopUcMatv1zaQvOAAO8hCdww==",
+            "version": "9.27.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
+            "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -411,23 +411,12 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-            "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+            "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
             "dependencies": {
-                "@eslint/core": "^0.15.1",
+                "@eslint/core": "^0.14.0",
                 "levn": "^0.4.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-            "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-            "dependencies": {
-                "@types/json-schema": "^7.0.15"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -510,14 +499,18 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.10.tgz",
-            "integrity": "sha512-HM2F4B9N4cA0RH2KQiIZOHAZqtP4xGS4IZ+SFe1SIbO4dyjf9MTY2Bo3vHYnm0hglWfXqBrzUBSa+cJfl3Xvrg==",
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+            "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/set-array": "^1.2.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
                 "@jridgewell/trace-mapping": "^0.3.24"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -530,17 +523,27 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@jridgewell/set-array": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.2.tgz",
-            "integrity": "sha512-gKYheCylLIedI+CSZoDtGkFV9YEBxRRVcfCH7OfAqh4TyUyRjEE6WVE/aXDXX0p8BIe/QgLcaAoI0220KRRFgg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "dev": true,
             "peer": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.27",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.27.tgz",
-            "integrity": "sha512-VO95AxtSFMelbg3ouljAYnfvTEwSWVt/2YLf+U5Ejd8iT5mXE2Sa/1LGyvySMne2CGsepGLI7KpF3EzE3Aq9Mg==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -595,9 +598,9 @@
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="
         },
         "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
@@ -614,28 +617,10 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
         },
-        "node_modules/abstract-socket": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/abstract-socket/-/abstract-socket-2.1.1.tgz",
-            "integrity": "sha512-YZJizsvS1aBua5Gd01woe4zuyYBGgSMeqDOB6/ChwdTI904KP6QGtJswXl4hcqWxbz86hQBe++HWV0hF1aGUtA==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "dependencies": {
-                "bindings": "^1.2.1",
-                "nan": "^2.12.1"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.14.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -709,18 +694,16 @@
             }
         },
         "node_modules/array-includes": {
-            "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-            "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+            "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
+                "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.24.0",
-                "es-object-atoms": "^1.1.1",
-                "get-intrinsic": "^1.3.0",
-                "is-string": "^1.1.1",
-                "math-intrinsics": "^1.1.0"
+                "es-abstract": "^1.23.2",
+                "es-object-atoms": "^1.0.0",
+                "get-intrinsic": "^1.2.4",
+                "is-string": "^1.0.7"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -864,28 +847,20 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "optional": true,
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
         "node_modules/browserslist": {
-            "version": "4.25.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-            "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+            "version": "4.24.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+            "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
             "dev": true,
             "funding": [
                 {
@@ -903,8 +878,8 @@
             ],
             "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001726",
-                "electron-to-chromium": "^1.5.173",
+                "caniuse-lite": "^1.0.30001716",
+                "electron-to-chromium": "^1.5.149",
                 "node-releases": "^2.0.19",
                 "update-browserslist-db": "^1.1.3"
             },
@@ -987,9 +962,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001726",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
-            "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
+            "version": "1.0.30001718",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+            "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
             "dev": true,
             "funding": [
                 {
@@ -1149,8 +1124,8 @@
         },
         "node_modules/dbus-victron-virtual": {
             "version": "0.1.16",
-            "resolved": "https://registry.npmjs.org/dbus-victron-virtual/-/dbus-victron-virtual-0.1.16.tgz",
-            "integrity": "sha512-2fyyaYs8y6DUctUQhRtlIAD5ftGCwjafg21Beeg8xoFNqIypsL33+Swyil9GvTuYErXQFJVJkBcFNp1YtFZRnw==",
+            "resolved": "git+ssh://git@github.com/Chris927/dbus-victron-virtual.git#8aef9aafbff4114b1576b631c10c9a192ae857ef",
+            "license": "MIT",
             "dependencies": {
                 "dbus-native-victron": "^0.4.3",
                 "debug": "^4.3.7"
@@ -1239,9 +1214,9 @@
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.177",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.177.tgz",
-            "integrity": "sha512-7EH2G59nLsEMj97fpDuvVcYi6lwTcM1xuWw3PssD8xzboAW7zj7iB3COEEEATUfjLHrs5uKBLQT03V/8URx06g==",
+            "version": "1.5.158",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.158.tgz",
+            "integrity": "sha512-9vcp2xHhkvraY6AHw2WMi+GDSLPX42qe2xjYaVoZqFRJiOcilVQFq9mZmpuHEQpzlgGDelKlV7ZiGcmMsc8WxQ==",
             "dev": true,
             "peer": true
         },
@@ -1265,9 +1240,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.24.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-            "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+            "version": "1.23.10",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.10.tgz",
+            "integrity": "sha512-MtUbM072wlJNyeYAe0mhzrD+M6DIJa96CZAOBBrhDbgKnB4MApIKefcyAB1eOdYn8cUNZgvwBvEzdoAYsxgEIw==",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.2",
                 "arraybuffer.prototype.slice": "^1.0.4",
@@ -1296,9 +1271,7 @@
                 "is-array-buffer": "^3.0.5",
                 "is-callable": "^1.2.7",
                 "is-data-view": "^1.0.2",
-                "is-negative-zero": "^2.0.3",
                 "is-regex": "^1.2.1",
-                "is-set": "^2.0.3",
                 "is-shared-array-buffer": "^1.0.4",
                 "is-string": "^1.1.1",
                 "is-typed-array": "^1.1.15",
@@ -1313,7 +1286,6 @@
                 "safe-push-apply": "^1.0.0",
                 "safe-regex-test": "^1.1.0",
                 "set-proto": "^1.0.0",
-                "stop-iteration-iterator": "^1.1.0",
                 "string.prototype.trim": "^1.2.10",
                 "string.prototype.trimend": "^1.0.9",
                 "string.prototype.trimstart": "^1.0.8",
@@ -1446,17 +1418,17 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.30.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.0.tgz",
-            "integrity": "sha512-iN/SiPxmQu6EVkf+m1qpBxzUhE12YqFLOSySuOyVLJLEF9nzTf+h/1AJYc1JWzCnktggeNrjvQGLngDzXirU6g==",
+            "version": "9.27.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
+            "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.0",
-                "@eslint/config-helpers": "^0.3.0",
+                "@eslint/config-array": "^0.20.0",
+                "@eslint/config-helpers": "^0.2.1",
                 "@eslint/core": "^0.14.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.30.0",
+                "@eslint/js": "9.27.0",
                 "@eslint/plugin-kit": "^0.3.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -1468,9 +1440,9 @@
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.4.0",
-                "eslint-visitor-keys": "^4.2.1",
-                "espree": "^10.4.0",
+                "eslint-scope": "^8.3.0",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -1535,9 +1507,9 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-            "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+            "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
             "dependencies": {
                 "debug": "^3.2.7"
             },
@@ -1599,28 +1571,28 @@
             }
         },
         "node_modules/eslint-plugin-import": {
-            "version": "2.32.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-            "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+            "version": "2.31.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
+            "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
-                "array-includes": "^3.1.9",
-                "array.prototype.findlastindex": "^1.2.6",
-                "array.prototype.flat": "^1.3.3",
-                "array.prototype.flatmap": "^1.3.3",
+                "array-includes": "^3.1.8",
+                "array.prototype.findlastindex": "^1.2.5",
+                "array.prototype.flat": "^1.3.2",
+                "array.prototype.flatmap": "^1.3.2",
                 "debug": "^3.2.7",
                 "doctrine": "^2.1.0",
                 "eslint-import-resolver-node": "^0.3.9",
-                "eslint-module-utils": "^2.12.1",
+                "eslint-module-utils": "^2.12.0",
                 "hasown": "^2.0.2",
-                "is-core-module": "^2.16.1",
+                "is-core-module": "^2.15.1",
                 "is-glob": "^4.0.3",
                 "minimatch": "^3.1.2",
                 "object.fromentries": "^2.0.8",
                 "object.groupby": "^1.0.3",
-                "object.values": "^1.2.1",
+                "object.values": "^1.2.0",
                 "semver": "^6.3.1",
-                "string.prototype.trimend": "^1.0.9",
+                "string.prototype.trimend": "^1.0.8",
                 "tsconfig-paths": "^3.15.0"
             },
             "engines": {
@@ -1781,9 +1753,9 @@
             }
         },
         "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+            "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -1796,9 +1768,9 @@
             }
         },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -1815,13 +1787,13 @@
             }
         },
         "node_modules/espree": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
             "dependencies": {
-                "acorn": "^8.15.0",
+                "acorn": "^8.14.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.1"
+                "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1831,9 +1803,9 @@
             }
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -1943,12 +1915,6 @@
             "engines": {
                 "node": ">=16.0.0"
             }
-        },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "optional": true
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -2547,17 +2513,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-negative-zero": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-number-object": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -2931,12 +2886,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "node_modules/nan": {
-            "version": "2.22.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-            "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
-            "optional": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -4025,18 +3974,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/stop-iteration-iterator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "internal-slot": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/stream-combiner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "dbus-native-victron": "^0.4.4",
-                "dbus-victron-virtual": "github:Chris927/dbus-victron-virtual#8aef9aa",
+                "dbus-victron-virtual": "^0.1.17",
                 "debug": "^4.4.0",
                 "lodash": "^4.17.21",
                 "promise-retry": "^2.0.1",
@@ -1123,8 +1123,9 @@
             }
         },
         "node_modules/dbus-victron-virtual": {
-            "version": "0.1.16",
-            "resolved": "git+ssh://git@github.com/Chris927/dbus-victron-virtual.git#8aef9aafbff4114b1576b631c10c9a192ae857ef",
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/dbus-victron-virtual/-/dbus-victron-virtual-0.1.17.tgz",
+            "integrity": "sha512-6IDtixIw0/xXkUhr5JPXEInirN8d8eAHsnM+XnxX4VOwGLXuEnsOB2b4jwhzxQLbXYl8T2+pwNPQAVdRnxOuWg==",
             "license": "MIT",
             "dependencies": {
                 "dbus-native-victron": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.6.36",
     "dependencies": {
         "dbus-native-victron": "^0.4.4",
-        "dbus-victron-virtual": "^0.1.16",
+        "dbus-victron-virtual": "github:Chris927/dbus-victron-virtual#8aef9aa",
         "debug": "^4.4.0",
         "lodash": "^4.17.21",
         "promise-retry": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.6.36",
     "dependencies": {
         "dbus-native-victron": "^0.4.4",
-        "dbus-victron-virtual": "github:Chris927/dbus-victron-virtual#8aef9aa",
+        "dbus-victron-virtual": "^0.1.17",
         "debug": "^4.4.0",
         "lodash": "^4.17.21",
         "promise-retry": "^2.0.1",

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -145,7 +145,7 @@
             temp_battery_voltage: { value: 3.3 }
         },
         icon: "victronenergy.svg",
-        inputs:0,
+        inputs:1,
         outputs:0,
         label: function() {
             return (this.name||"Virtual "+this.device)

--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -1028,6 +1028,10 @@ module.exports = function (RED) {
     node.on('close', function (done) {
       nodeInstances.delete(node)
 
+      // TODO: previously, we called end() on the connection only if no nodeInstances
+      // were left. Calling end() here resolves an issue with the VictronDbusListener
+      // not responding to ItemsChanged signals any more after a redeploy here:
+      // https://github.com/victronenergy/node-red-contrib-victron/blob/5626b44b426a3ab1c7d9a6a2d36f035f72d9faa2/src/services/dbus-listener.js#L309
       this.bus.connection.end()
 
       // If this was the last instance and the timeout is still pending

--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -373,7 +373,7 @@ module.exports = function (RED) {
         node.status({
           fill: 'green',
           shape: 'dot',
-          text: `Updated values for ${config.device} (${node.iface.DeviceInstance}) to ${JSON.stringify(msg.payload)}`
+          text: `Updated ${Object.keys(msg.payload).length} values for ${config.device} (${node.iface.DeviceInstance})`
         })
         done()
       } catch (err) {

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -399,7 +399,7 @@ class VictronDbusListener {
     if (typeof value === 'string') { numType = 's' }
 
     try {
-      console.warn(`Setting value for ${destination}, ${path}, ${value} (${numType})`)
+      debug(`Setting value for ${destination}, ${path}, ${value} (${numType})`)
       this.bus.invoke({
         path,
         destination,

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -399,6 +399,7 @@ class VictronDbusListener {
     if (typeof value === 'string') { numType = 's' }
 
     try {
+      console.warn(`Setting value for ${destination}, ${path}, ${value} (${numType})`)
       this.bus.invoke({
         path,
         destination,


### PR DESCRIPTION
Virtual nodes can now receive input, so that properties of virtual devices can be updated.

Example: Use an "inject" node to set the payload to `{ "Capacity":122, "Level":23.73 }` to update properties for a virtual tank. Alternatively, the property names can start with `/`, e.g. `/Capacity` instead of `Capacity`.

This also fixes an unrelated bug: Previously, after a re-deploy, `VictronDbusListener` might have stopped responding to `ItemsChanged` signals, see the comment in `node.on('close', ...`.