### PR TITLE
config node, set 'hasUsers' to false

### DIFF
--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -78,7 +78,8 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
         label: function label() {
             return "Victron Energy Client";
         },
-        hasUsers: true,
+        // setting hasUsers to false means we don't get a warning on deployment, if/when there is no node referring to this config node.
+        hasUsers: false,
         onpaletteremove: function onpaletteremove() {
             RED.nodes.eachConfig(function (n) {
                 if (n.id === 'victron-client-id') RED.nodes.remove(n.id);


### PR DESCRIPTION
Context: In order to fix [this regression](https://github.com/victronenergy/venus/issues/1506), we [now](https://github.com/victronenergy/meta-victronenergy/pull/28/commits/5fb890ddf8dee7a708346433298837b5130eff31) place a default flows.json file into node-red's working directory (if there is nothing yet).

This resulted in a warning at deploy time, i.e. when pushing "Deploy" from the node-red browser interface: "You have some unused configuration nodes".

By setting 'hasUsers' to false, node-red understand that it's fine to have no users for the config node, so no warning.