### PR TITLE
Resolve killing the dbus connection

### DIFF
--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -129,6 +129,10 @@ module.exports = function (RED) {
         }, { callbackPeriodically })
       }
 
+      if (this.client && this.client.client && this.client.client.connected) {
+        this.client.client.getValue(this.service, this.path)
+      }
+
       this.on('close', function (done) {
         this.node.client.unsubscribe(this.node.subscription)
         this.node.configNode.removeStatusListener(handlerId)

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -357,6 +357,10 @@ class VictronDbusListener {
   }
 
   getValue (destination, path) {
+    if (destination.split('/').length === 2) {
+      const deviceInstance = destination.split('/')[1]
+      destination = searchHaystack(this.services, deviceInstance, destination.split('/')[0])
+    }
     this.bus.invoke({
       path,
       destination,


### PR DESCRIPTION
By calling getValue wrongly, you can accidentally kill the dbus connection. If it is called with an interface name that does not exist, it terminates the dbus connection. This patch introduces searching in the known services list for the right destination when the getValue function is called with a `com.victronenergy.temperature/${deviceInstance}` way.