### PR TITLE
fix(virtual-devices): fix device path creation regression

### DIFF
--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -27,7 +27,7 @@ function getIfaceDesc (dev) {
 
   const deviceConfig = getDeviceConfig(actualDev)
   if (deviceConfig) {
-    return createIfaceDesc(actualDev, deviceConfig.properties)
+    return createIfaceDesc(deviceConfig.properties)
   }
 
   return {}
@@ -38,7 +38,7 @@ function getIface (dev) {
 
   const deviceConfig = getDeviceConfig(actualDev)
   if (deviceConfig) {
-    return createIface(actualDev, deviceConfig.properties)
+    return createIface(deviceConfig.properties)
   }
 
   return {

--- a/src/nodes/victron-virtual/utils.js
+++ b/src/nodes/victron-virtual/utils.js
@@ -8,7 +8,7 @@
  * @returns {Object} Interface description
  */
 function createIfaceDesc (properties) {
-  if (!properties) {
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
     return {}
   }
 
@@ -36,7 +36,7 @@ function createIfaceDesc (properties) {
  * @returns {Object} Device interface
  */
 function createIface (properties) {
-  if (!properties) {
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
     return {
       emit: function () {}
     }


### PR DESCRIPTION
Virtual devices were showing numeric indices (0-6) instead of proper dbus paths. Fixed incorrect function parameters in getIfaceDesc/getIface and added regression tests.