### PR TITLE
Add configurable default voltage for virtual battery

### DIFF
--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -49,6 +49,18 @@
         }
     }
 
+    function updateBatteryVoltageVisibility() {
+        const defaultValues = $('#node-input-default_values').is(':checked')
+        const preset = $('#node-input-battery_voltage_preset').val()
+
+        // Show voltage row only when default values is enabled
+        $('#battery-voltage-row').toggle(defaultValues)
+
+        // Show custom input only when custom is selected
+        $('#node-input-battery_voltage_custom').toggle(preset === 'custom')
+        $('#battery-voltage-custom-label').toggle(preset === 'custom')
+    }
+
     function checkSelectedVirtualDevice() {
         [
             'battery', 'generator', 'gps', 'grid', 'motordrive', 'pvinverter',
@@ -57,6 +69,13 @@
 
         const selected = $('select#node-input-device').val()
         $('.input-'+selected).show()
+
+        if (selected === 'battery') {
+            $('#node-input-default_values').off('change.battery-voltage').on('change.battery-voltage', updateBatteryVoltageVisibility)
+            $('#node-input-battery_voltage_preset').off('change.battery-voltage').on('change.battery-voltage', updateBatteryVoltageVisibility)
+
+            updateBatteryVoltageVisibility()
+        }
 
         if (selected === 'temperature') {
             // Show/hide battery voltage input based on checkbox
@@ -101,6 +120,8 @@
             default_values: {value: false, required: false},
             // battery
             battery_capacity: {value: 25, required: false},
+            battery_voltage_preset: {value: "24", required: false},
+            battery_voltage_custom: {value: 24, required: false},
             include_battery_temperature: {value: false},
             // generator
             generator_type: {value: "ac", required: false},
@@ -212,6 +233,20 @@
             <div class="form-tips" style="display: block;">
                 <p><strong>Note:</strong> The battery will include most standard alarm and error fields required for proper integration with VRM and GX devices.</p>
             </div>
+        </div>
+
+        <!-- Battery voltage configuration (only show when default_values is enabled) -->
+        <div class="form-row input-battery" id="battery-voltage-row" style="display: none;">
+            <label for="node-input-battery_voltage_preset" style="width:auto;">Default Voltage:</label>
+            <select id="node-input-battery_voltage_preset" style="width:100px;">
+                <option value="12">12V</option>
+                <option value="24">24V</option>
+                <option value="48">48V</option>
+                <option value="custom">Custom</option>
+            </select>
+            <input type="number" id="node-input-battery_voltage_custom" style="width:80px; margin-left:10px;"
+                placeholder="V" step="0.1" min="0" max="1000">
+            <span id="battery-voltage-custom-label" style="margin-left:5px;">V</span>
         </div>
     </div>
 

--- a/src/nodes/victron-virtual/device-types/battery.js
+++ b/src/nodes/victron-virtual/device-types/battery.js
@@ -4,7 +4,7 @@
 
 const alarmFormat = (v) => ({
   0: 'OK',
-  1: 'Warning', 
+  1: 'Warning',
   2: 'Alarm'
 }[v] || 'unknown')
 
@@ -50,16 +50,34 @@ const batteryProperties = {
  */
 function configureBatteryDevice (config, iface, ifaceDesc) {
   // Set battery capacity from configuration - only if valid number
-  if (config.battery_capacity != null && 
-      config.battery_capacity !== '' && 
+  if (config.battery_capacity != null &&
+      config.battery_capacity !== '' &&
       !isNaN(Number(config.battery_capacity))) {
     const capacity = Number(config.battery_capacity)
     iface.Capacity = capacity
   }
 
   if (config.default_values) {
+    let voltage = 24 // fallback
+
+    if (config.battery_voltage_preset === '12') {
+      voltage = 12
+    } else if (config.battery_voltage_preset === '24') {
+      voltage = 24
+    } else if (config.battery_voltage_preset === '48') {
+      voltage = 48
+    } else if (config.battery_voltage_preset === 'custom') {
+      if (config.battery_voltage_custom != null &&
+          config.battery_voltage_custom !== '' &&
+          !isNaN(Number(config.battery_voltage_custom))) {
+        voltage = Number(config.battery_voltage_custom)
+      }
+      // If custom is selected but no valid value provided, use default
+    }
+    // For any other invalid preset, use default
+
     iface['Dc/0/Current'] = 0
-    iface['Dc/0/Voltage'] = 24
+    iface['Dc/0/Voltage'] = voltage
     iface['Dc/0/Power'] = 0
     iface['Dc/0/Temperature'] = 25
     iface.Soc = 80

--- a/test/battery-device.test.js
+++ b/test/battery-device.test.js
@@ -487,3 +487,98 @@ describe('Battery Device Configuration', () => {
     })
   })
 })
+
+describe('Battery voltage selection', () => {
+  test('should use 12V when selected and default_values enabled', () => {
+    const config = {
+      default_values: true,
+      battery_voltage_preset: '12'
+    }
+    const iface = createIface(batteryProperties)
+    const ifaceDesc = { properties: { ...batteryProperties } }
+
+    configureBatteryDevice(config, iface, ifaceDesc)
+
+    expect(iface['Dc/0/Voltage']).toBe(12)
+  })
+
+  test('should use 24V when selected and default_values enabled', () => {
+    const config = {
+      default_values: true,
+      battery_voltage_preset: '24'
+    }
+    const iface = createIface(batteryProperties)
+    const ifaceDesc = { properties: { ...batteryProperties } }
+
+    configureBatteryDevice(config, iface, ifaceDesc)
+
+    expect(iface['Dc/0/Voltage']).toBe(24)
+  })
+
+  test('should use 48V when selected and default_values enabled', () => {
+    const config = {
+      default_values: true,
+      battery_voltage_preset: '48'
+    }
+    const iface = createIface(batteryProperties)
+    const ifaceDesc = { properties: { ...batteryProperties } }
+
+    configureBatteryDevice(config, iface, ifaceDesc)
+
+    expect(iface['Dc/0/Voltage']).toBe(48)
+  })
+
+  test('should use custom voltage when selected and default_values enabled', () => {
+    const config = {
+      default_values: true,
+      battery_voltage_preset: 'custom',
+      battery_voltage_custom: 36.5
+    }
+    const iface = createIface(batteryProperties)
+    const ifaceDesc = { properties: { ...batteryProperties } }
+
+    configureBatteryDevice(config, iface, ifaceDesc)
+
+    expect(iface['Dc/0/Voltage']).toBe(36.5)
+  })
+
+  test('should fallback to 24V when custom selected but no custom value provided', () => {
+    const config = {
+      default_values: true,
+      battery_voltage_preset: 'custom'
+      // battery_voltage_custom not provided
+    }
+    const iface = createIface(batteryProperties)
+    const ifaceDesc = { properties: { ...batteryProperties } }
+
+    configureBatteryDevice(config, iface, ifaceDesc)
+
+    expect(iface['Dc/0/Voltage']).toBe(24)
+  })
+
+  test('should fallback to 24V when invalid preset provided', () => {
+    const config = {
+      default_values: true,
+      battery_voltage_preset: 'invalid'
+    }
+    const iface = createIface(batteryProperties)
+    const ifaceDesc = { properties: { ...batteryProperties } }
+
+    configureBatteryDevice(config, iface, ifaceDesc)
+
+    expect(iface['Dc/0/Voltage']).toBe(24)
+  })
+
+  test('should not set voltage when default_values is false', () => {
+    const config = {
+      default_values: false,
+      battery_voltage_preset: '12'
+    }
+    const iface = createIface(batteryProperties)
+    const ifaceDesc = { properties: { ...batteryProperties } }
+
+    configureBatteryDevice(config, iface, ifaceDesc)
+
+    expect(iface['Dc/0/Voltage']).toBe(null)
+  })
+})


### PR DESCRIPTION
## Problem
Virtual batteries currently hardcode the default voltage to 24V when "Initialize with default values" is enabled. This isn't ideal for users who want to virtualize 12V, 48V, or custom voltage batteries.

## Solution
Adds a voltage selection dropdown to the battery configuration panel with options:
- **12V** - Common for automotive/marine systems  
- **24V** - Current default (maintains backward compatibility)
- **48V** - Common for larger installations
- **Custom** - User-defined voltage with validation

The voltage selection only appears when "Initialize with default values" is checked, keeping the UI clean.

## Implementation Details
- Backend logic in `battery.js` with comprehensive validation
- Frontend UI with conditional show/hide behavior
- Fallback to 24V for invalid inputs or missing custom values
- Full test coverage (7 new tests, all passing)
- Maintains existing API and backward compatibility

## Testing
```bash
jest test/battery-device.test.js --testNamePattern="Battery voltage selection"
````
(or just run the full test)

Supersedes: https://github.com/victronenergy/node-red-contrib-victron/pull/264 and lives on top of  #273 
This implementation provides a more complete solution with proper validation, testing, and UI integration.
