### PR TITLE
feat(victron-virtual): add UI control visibility for virtual switches

### DIFF
--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -800,7 +800,8 @@ module.exports = function (RED) {
                 }[v] || 'unknown'),
                 persist: false
               },
-              { name: 'Settings/ValidTypes', type: 'i', value: 0x7 }
+              { name: 'Settings/ValidTypes', type: 'i', value: 0x7 },
+              { name: 'Settings/ShowUIControl', type: 'i', value: 1, persist: true }
             ]
 
             for (let i = 1; i <= switchCount; i++) {


### PR DESCRIPTION
Just a minor thing I noticed the gui-v2 complaining about. 
This field controls the visibility in gui-v2. Keeping it persistent to make sure that, if the value is set, it gets remembered.