### PR TITLE
Updated naming for switch type 8

### DIFF
--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -53,7 +53,7 @@ export const SWITCH_TYPE_CONFIGS = {
   //   ]
   // },
   8: {
-    label: 'Unranged setpoint',
+    label: 'Numeric input box',
     fields: [
       { id: 'min', type: 'number', placeholder: 'Min value', title: 'Slider minimum', style: 'width:80px;' },
       { id: 'max', type: 'number', placeholder: 'Max value', title: 'Slider maximum', style: 'width:80px;' },

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -590,7 +590,7 @@ monitored remotely. There are currently seven types of switches available:
 - **Dimmable**: PWM-controlled switch with adjustable brightness from 0-100%
 - **Temperature setpoint**: Sets a target temperature value
 - **Stepped switch** : Select up to 7 discrete steps (e.g., fan speeds)
-- **Unranged setpoint**: Set any numeric value without predefined limits
+- **Numeric input**: A numeric input control with configurable minimum/maximum values, step size, and display unit that allows precise manual entry of setpoint values.
 - **Three-state switch**: Select from three states (On, Off, Auto)
 
 You can configure up to 4 switches within a virtual switch, and each switch can be individually set to any

--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -794,7 +794,7 @@ module.exports = function (RED) {
                   4: 'Stepped switch',
                   6: 'Dropdown',
                   7: 'Basic slider',
-                  8: 'Unranged setpoint',
+                  8: 'Numeric input box',
                   9: 'Three-state',
                   10: 'Bilge pump control'
                 }[v] || 'unknown'),
@@ -942,7 +942,7 @@ module.exports = function (RED) {
                 iface[labelsKey] = labelsJson
               }
 
-              if (switchType === 7 || switchType === 8) { // Basic slider or unranged setpoint
+              if (switchType === 7 || switchType === 8) { // Basic slider or Numeric input box
                 const dimmingKey = `SwitchableOutput/output_${i}/Dimming`
                 ifaceDesc.properties[dimmingKey] = {
                   type: 'd',


### PR DESCRIPTION
Now called "numeric input" instead of "unranged setpoint".