### PR TITLE
Default customname of switch to the swich type

### DIFF
--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -812,7 +812,15 @@ module.exports = function (RED) {
                 ifaceDesc.properties[key] = { type, format, persist }
 
                 let propValue = value
-                if (name === 'Name') propValue = `Switch ${i}`
+                if (name === 'Name') {
+                  // Find the format function for Settings/Type
+                  const typeProp = baseProperties.find(p => p.name === 'Settings/Type');
+                  let typeLabel = `Switch ${i}`;
+                  if (typeProp && typeof typeProp.format === 'function') {
+                    typeLabel = typeProp.format(switchType);
+                  }
+                  propValue = typeLabel;
+                }
                 if (name === 'Settings/Type') propValue = switchType
 
                 iface[key] = propValue !== undefined ? propValue : 0


### PR DESCRIPTION
Instead of setting the Name of the switch to "Switch [1-4]", set it to reflect the type of the switch. E.g. "Temperature setpoint".