### PR TITLE
Disallow changing the device type after deployment

### DIFF
--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -87,6 +87,12 @@
             return (this.name||"Virtual "+this.device)
         },
         oneditprepare: function oneditprepare() {
+            if (this.id) {
+                $('#node-input-device')
+                    .prop('disabled', true)
+                    .attr('title', 'Device type cannot be changed after deployment.');
+            }
+
             $('#node-input-device').on('change', () => {
                 checkSelectedVirtualDevice.call(this);
             });


### PR DESCRIPTION
Couldn't get the a test script ready. But tested manually, which works as expected.
If the node has an id, the dropdown for selecting a device gets disabled. 

If a user wants another type of device, (s)he can add a new virtual device and select the new type and delete the old one.

Closes issue #288