### PR TITLE
When using /victron/cache, do not render arbitrary data without stringification

### DIFF
--- a/src/nodes/config-client.js
+++ b/src/nodes/config-client.js
@@ -43,9 +43,9 @@ module.exports = function (RED) {
     }
   })
 
-  RED.httpNode.get('/victron/cache', RED.auth.needsPermission('victron-client.read'), (req, res) => {
+  RED.httpNode.get('/victron/cache', RED.auth.needsPermission('victron-client.read'), (_req, res) => {
     if (!globalClient) return res.status(503).send('Client not initialized')
-    const serialized = JSON.stringify(globalClient.system.cache)
+    const serialized = utils.mapCacheToJsonResponse(globalClient.system.cache)
     res.setHeader('Content-Type', 'application/json')
     return res.send(serialized)
   })

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -224,7 +224,7 @@ const TEMPLATE = (service, name, deviceInstance, paths) => {
  * Shown in the UI if the system relay mode is set to any other than 'manual'
  */
 const RELAY_MODE_WARNING = (func) =>
-    `The relay is configured for <strong>${func}</strong> function. Please navigate to Settings > Integrations > Relays and change it to manual.`
+  `The relay is configured for <strong>${func}</strong> function. Please navigate to Settings > Integrations > Relays and change it to manual.`
 
 /**
  * All possible system relay functions
@@ -250,6 +250,35 @@ const STATUS = {
   SERVICE_MIGRATE: 8
 }
 
+/**
+  * Maps a cache value to a JSON-serializable value.
+  * - Strings, numbers, booleans, and null are returned as-is.
+  * - Dates are converted to ISO strings.
+  * - Objects and arrays are stringified.
+  * - Other types (e.g., functions) are converted to their string representation.
+*/
+function mapCacheValueToJsonResponseValue (value) {
+  if (value === null) return null
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'object') return JSON.stringify(value)
+  if (typeof value === 'function') return value.toString()
+  return value
+}
+
+/**
+  * Maps the cache (see VictronClient.system.cache) to a JSON string.
+  */
+function mapCacheToJsonResponse (cache) {
+  const result = {}
+  for (const [device, value] of Object.entries(cache)) {
+    result[device] = {}
+    for (const [path, pathValue] of Object.entries(value)) {
+      result[device][path] = mapCacheValueToJsonResponseValue(pathValue)
+    }
+  }
+  return JSON.stringify(result)
+}
+
 module.exports = {
   CONNECTED,
   DISCONNECTED,
@@ -262,5 +291,7 @@ module.exports = {
   UUID,
   DEFAULT_SERVICE_NAMES,
   WILDCARD_MAPPINGS,
-  expandWildcardPaths
+  expandWildcardPaths,
+  mapCacheValueToJsonResponseValue,
+  mapCacheToJsonResponse
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,107 @@
+const { mapCacheToJsonResponse, mapCacheValueToJsonResponseValue } = require('../src/services/utils');
+
+describe('utils', () => {
+
+  describe('mapCacheToJsonResponse', () => {
+
+    it('should map a simple cache correctly', () => {
+      const cache = {
+        'com.some.device': {
+          '/DeviceInstance': 123,
+          '/ProductName': 'Victron Device',
+        }
+      };
+
+      const expected = JSON.stringify({
+        'com.some.device': {
+          '/DeviceInstance': 123,
+          '/ProductName': 'Victron Device',
+        }
+      });
+
+      const result = mapCacheToJsonResponse(cache);
+      expect(result).toEqual(expected);
+    });
+
+    it('handles an empty cache', () => {
+      const cache = {};
+      const expected = JSON.stringify({});
+      const result = mapCacheToJsonResponse(cache);
+      expect(result).toEqual(expected);
+    });
+
+    it('handles some values (other than string, boolean, number) special by stringifying them', () => {
+
+      const cache = {
+        'com.some.device': {
+          '/SomeArray': [1, 2, 3],
+          '/SomeObject': { key: 'value' },
+          '/NormalValue': 'test',
+          '/SomeBoolean': true,
+          '/SomeNumber': 42,
+          '/SomeNull': null,
+          '/SomeDate': new Date(2024, 0, 1),  // Dates are objects, so will be iso-formatted
+        }
+      };
+
+      const expected = JSON.stringify({
+        'com.some.device': {
+          '/SomeArray': '[1,2,3]',
+          '/SomeObject': '{"key":"value"}',
+          '/NormalValue': 'test',
+          '/SomeBoolean': true,
+          '/SomeNumber': 42,
+          '/SomeNull': null,
+          '/SomeDate': (new Date(2024, 0, 1)).toISOString(),
+        }
+      });
+
+      const result = mapCacheToJsonResponse(cache);
+      expect(result).toEqual(expected);
+    });
+
+  })
+
+  describe('mapCacheValueToJsonResponseValue', () => {
+
+    it('returns strings as-is', () => {
+      expect(mapCacheValueToJsonResponseValue('test string')).toBe('test string');
+    });
+
+    it('returns numbers as-is', () => {
+      expect(mapCacheValueToJsonResponseValue(42)).toBe(42);
+      expect(mapCacheValueToJsonResponseValue(3.14)).toBe(3.14);
+    });
+
+    it('returns booleans as-is', () => {
+      expect(mapCacheValueToJsonResponseValue(true)).toBe(true);
+      expect(mapCacheValueToJsonResponseValue(false)).toBe(false);
+    });
+
+    it('returns null as-is', () => {
+      expect(mapCacheValueToJsonResponseValue(null)).toBeNull();
+    });
+
+    it('stringifies arrays', () => {
+      expect(mapCacheValueToJsonResponseValue([1, 2, 3])).toBe('[1,2,3]');
+      expect(mapCacheValueToJsonResponseValue(['a', 'b', 'c'])).toBe('["a","b","c"]');
+    });
+
+    it('stringifies objects', () => {
+      expect(mapCacheValueToJsonResponseValue({ key: 'value' })).toBe('{"key":"value"}');
+      expect(mapCacheValueToJsonResponseValue({ a: 1, b: 2 })).toBe('{"a":1,"b":2}');
+    });
+
+    it('stringifies dates to ISO format', () => {
+      const date = new Date(2024, 0, 1);
+      expect(mapCacheValueToJsonResponseValue(date)).toBe(date.toISOString());
+    });
+
+    it('stringifies other types (e.g., functions) to their string representation', () => {
+      const func = function() { return 'test'; };
+      expect(mapCacheValueToJsonResponseValue(func)).toBe(func.toString());
+    });
+
+  })
+
+})


### PR DESCRIPTION

This is a backwards-incompatible change. However, but we assume nobody depends on the exact format of the cache output (yet). If we have to make it backwards-compatible, we could introduce a query parameter 'unsanitized-format=true' or similar.

Squashed commit of the following:

commit 0bc62060bc1b10d694bedc7c2e7d010e7287f382
Author: Chris Oloff <chris@uber5.com>
Date:   Mon Sep 22 16:41:05 2025 +0200

    formatting, add comments

commit 3deeefe8576d097fbe5ebed240daf9c315005761
Author: Chris Oloff <chris@uber5.com>
Date:   Mon Sep 22 16:09:07 2025 +0200

    run linter

commit 78c63d5cb95f6a0dffe1189fec7336bd22033882
Author: Chris Oloff <chris@uber5.com>
Date:   Mon Sep 22 16:06:15 2025 +0200

    change the format of values for the cache http response

commit f4e5f6276cd0677905d5f0deb7882d33c9bb7db0
Author: Chris Oloff <chris@uber5.com>
Date:   Mon Sep 22 15:37:10 2025 +0200

    add functions to format cache as JSON, naive implementation for now

    Also added unit test(s) which don't do much yet. I verified manually that
    utils.mapCacheToJsonResponse() produces the same result as the previous direct
    JSON.stringify() call.