### PR TITLE
Virtual switch: add bilge pump

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -67,6 +67,10 @@
     9: {
       label: 'Three-state switch',
       fields: [] // No extra config fields
+    },
+    10: {
+      label: 'Bilge pump control',
+      fields: [] // No extra config fields
     }
   };
 

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -64,6 +64,10 @@ export const SWITCH_TYPE_CONFIGS = {
   9: {
     label: 'Three-state switch',
     fields: [] // No extra config fields
+  },
+  10: {
+    label: 'Bilge pump control',
+    fields: [] // No extra config fields
   }
 }
 

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -598,6 +598,7 @@ monitored remotely. There are currently seven types of switches available:
 - **Stepped switch** : Select up to 7 discrete steps (e.g., fan speeds)
 - **Numeric input**: A numeric input control with configurable minimum/maximum values, step size, and display unit that allows precise manual entry of setpoint values.
 - **Three-state switch**: Select from three states (On, Off, Auto)
+- **Bilge pump control**: Special switch type for bilge pumps with automatic and manual modes (A bilge pump is a device on a boat that removes accumulated water from the lowest part of the hull, known as the bilge, and pumps it overboard).
 
 You can configure up to 4 switches within a virtual switch, and each switch can be individually set to any
 of the types. This allows mixing different switch types in a single virtual


### PR DESCRIPTION
Special switch type for bilge pumps with automatic and manual modes (A bilge pump is a device on a boat that removes accumulated water from the lowest part of the hull, known as the bilge, and pumps it overboard)