### PR TITLE
Faberd/improve edit panel layout

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -4,7 +4,7 @@
   /* global $ */
 
   const COMMON_SWITCH_FIELDS = [
-    { id: 'customname', type: 'text', placeholder: 'Output name', title: 'Custom Name', style: 'width:120px;' },
+    { id: 'customname', type: 'text', placeholder: 'Name', title: 'Name', style: 'width:120px;' },
     { id: 'group', type: 'text', placeholder: 'Group', title: 'Group', style: 'width:120px;' }
   ];
 
@@ -90,7 +90,7 @@
       .join('');
     const switchRow = $(`
         <div class="form-row">
-            <label for="node-input-switch_1_type"><i class="fa fa-toggle-on"></i> Switch 1 type</label>
+            <label for="node-input-switch_1_type"><i class="fa fa-toggle-on"></i> Switch type</label>
             <select id="node-input-switch_1_type">${typeOptions}</select>
         </div>
     `);
@@ -107,28 +107,27 @@
       const cfg = SWITCH_TYPE_CONFIGS[type];
 
       if (cfg && cfg.fields.length) {
-        // Split fields
-        const commonFields = cfg.fields.filter(f => COMMON_SWITCH_FIELDS.some(cf => cf.id === f.id));
-        const extraFields = cfg.fields.filter(f => !COMMON_SWITCH_FIELDS.some(cf => cf.id === f.id));
-
-        // Render common fields in one row
-        const commonFieldsHtml = commonFields.map(field => {
+        // Render each field as a separate row
+        const fieldsHtml = cfg.fields.map(field => {
           const stepAttr = field.id === 'step' || field.id === 'stepsize' ? 'step="any"' : '';
-          return `<input type="${field.type}" id="node-input-switch_1_${field.id}" placeholder="${field.placeholder}" title="${field.title}" style="${field.style}" ${field.min ? `min="${field.min}"` : ''} ${field.max ? `max="${field.max}"` : ''} ${stepAttr} required>`
+          return `
+          <div class="form-row" style="align-items:center;">
+            <label for="node-input-switch_1_${field.id}" style="min-width:120px;">${field.title || field.placeholder}</label>
+            <input type="${field.type}" id="node-input-switch_1_${field.id}"
+                   placeholder="${field.placeholder}"
+                   style="${field.style}"
+                   ${field.min ? `min="${field.min}"` : ''}
+                   ${field.max ? `max="${field.max}"` : ''}
+                   ${stepAttr} required>
+          </div>
+        `
         }).join('');
 
-        // Render extra fields in a new row
-        const extraFieldsHtml = extraFields.map(field => {
-          const stepAttr = field.id === 'step' || field.id === 'stepsize' ? 'step="any"' : '';
-          return `<input type="${field.type}" id="node-input-switch_1_${field.id}" placeholder="${field.placeholder}" title="${field.title}" style="${field.style}" ${field.min ? `min="${field.min}"` : ''} ${field.max ? `max="${field.max}"` : ''} ${stepAttr} required>`
-        }).join('');
-
-        // Build the config row with two lines
+        // Build the config row
         const configRow = $(`
-        <div class="form-row" id="switch-1-config-row">
-          <label>${cfg.label} Config</label>
-          <div style="display:flex;gap:8px;">${commonFieldsHtml}</div>
-          ${extraFieldsHtml ? `<div style="display:flex;gap:8px;margin-top:8px;">${extraFieldsHtml}</div>` : ''}
+        <div id="switch-1-config-row">
+          <label style="font-weight:bold;">${cfg.label} configuration</label>
+          ${fieldsHtml}
         </div>
       `);
         $('#node-input-switch_1_type').closest('.form-row').after(configRow);
@@ -208,7 +207,8 @@
     for (let j = 0; j < count; j++) {
       const value = savedLabels[j] || '';
       const labelHtml = $(`
-      <div style="display:flex;gap:8px;align-items:center;">
+      <div class="form-row" style="align-items:center;">
+        <label for="node-input-switch_1_value_${j}" style="min-width:120px;">Option ${j + 1}</label>
         <input type="text"
                id="node-input-switch_1_value_${j}"
                placeholder="Label"
@@ -281,6 +281,13 @@
 
     if (selected === 'switch') {
       updateSwitchConfig.call(this);
+      // Hide the default values checkbox and info box for switches
+      $('#node-input-default_values').closest('.form-row').hide();
+      $('#default-values-info').hide();
+    } else {
+      // Show for other device types
+      $('#node-input-default_values').closest('.form-row').show();
+      $('#default-values-info').show();
     }
   }
 

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -84,26 +84,26 @@
     }
   };
 
-  function renderSwitchConfigRow (i, context) {
+  function renderSwitchConfigRow (context) {
     const typeOptions = Object.entries(SWITCH_TYPE_CONFIGS)
       .map(([value, cfg]) => `<option value="${value}">${cfg.label}</option>`)
       .join('');
     const switchRow = $(`
         <div class="form-row">
-            <label for="node-input-switch_${i}_type"><i class="fa fa-toggle-on"></i> Switch ${i} type</label>
-            <select id="node-input-switch_${i}_type" data-switch-index="${i}">${typeOptions}</select>
+            <label for="node-input-switch_1_type"><i class="fa fa-toggle-on"></i> Switch 1 type</label>
+            <select id="node-input-switch_1_type">${typeOptions}</select>
         </div>
     `);
     $('#switch-config-container').append(switchRow);
 
-    const savedType = context[`switch_${i}_type`] !== undefined ? context[`switch_${i}_type`] : 1;
-    $(`#node-input-switch_${i}_type`).val(String(savedType));
+    const savedType = context.switch_1_type !== undefined ? context.switch_1_type : 1;
+    $('#node-input-switch_1_type').val(String(savedType));
 
     function renderTypeConfig () {
-      $(`#switch-${i}-config-row`).remove();
-      $(`#switch-${i}-pairs-row`).remove();
+      $('#switch-1-config-row').remove();
+      $('#switch-1-pairs-row').remove();
 
-      const type = $(`#node-input-switch_${i}_type`).val();
+      const type = $('#node-input-switch_1_type').val();
       const cfg = SWITCH_TYPE_CONFIGS[type];
 
       if (cfg && cfg.fields.length) {
@@ -114,83 +114,88 @@
         // Render common fields in one row
         const commonFieldsHtml = commonFields.map(field => {
           const stepAttr = field.id === 'step' || field.id === 'stepsize' ? 'step="any"' : '';
-          return `<input type="${field.type}" id="node-input-switch_${i}_${field.id}" placeholder="${field.placeholder}" title="${field.title}" style="${field.style}" ${field.min ? `min="${field.min}"` : ''} ${field.max ? `max="${field.max}"` : ''} ${stepAttr} required>`
+          return `<input type="${field.type}" id="node-input-switch_1_${field.id}" placeholder="${field.placeholder}" title="${field.title}" style="${field.style}" ${field.min ? `min="${field.min}"` : ''} ${field.max ? `max="${field.max}"` : ''} ${stepAttr} required>`
         }).join('');
 
         // Render extra fields in a new row
         const extraFieldsHtml = extraFields.map(field => {
           const stepAttr = field.id === 'step' || field.id === 'stepsize' ? 'step="any"' : '';
-          return `<input type="${field.type}" id="node-input-switch_${i}_${field.id}" placeholder="${field.placeholder}" title="${field.title}" style="${field.style}" ${field.min ? `min="${field.min}"` : ''} ${field.max ? `max="${field.max}"` : ''} ${stepAttr} required>`
+          return `<input type="${field.type}" id="node-input-switch_1_${field.id}" placeholder="${field.placeholder}" title="${field.title}" style="${field.style}" ${field.min ? `min="${field.min}"` : ''} ${field.max ? `max="${field.max}"` : ''} ${stepAttr} required>`
         }).join('');
 
         // Build the config row with two lines
         const configRow = $(`
-        <div class="form-row" id="switch-${i}-config-row">
+        <div class="form-row" id="switch-1-config-row">
           <label>${cfg.label} Config</label>
           <div style="display:flex;gap:8px;">${commonFieldsHtml}</div>
           ${extraFieldsHtml ? `<div style="display:flex;gap:8px;margin-top:8px;">${extraFieldsHtml}</div>` : ''}
         </div>
       `);
-        $(`#node-input-switch_${i}_type`).closest('.form-row').after(configRow);
+        $('#node-input-switch_1_type').closest('.form-row').after(configRow);
 
         // Restore saved values
         cfg.fields.forEach(field => {
-          const val = context[`switch_${i}_${field.id}`];
+          const val = context[`switch_1_${field.id}`];
           if (typeof val !== 'undefined') {
-            $(`#node-input-switch_${i}_${field.id}`).val(val);
+            $(`#node-input-switch_1_${field.id}`).val(val);
           }
         });
 
         // Special handling for dropdown type
         if (type === '6') {
-          if (!context[`switch_${i}_count`]) {
-            const savedLabel = context[`switch_${i}_label`];
-            if (savedLabel) {
-              try {
-                const keyValueObj = JSON.parse(savedLabel);
-                const keyCount = Object.keys(keyValueObj).length;
-                if (keyCount > 0) {
-                  $(`#node-input-switch_${i}_count`).val(keyCount);
-                }
-              } catch (e) {
-                $(`#node-input-switch_${i}_count`).val(2); // default count
+          // Restore count for dropdown options
+          let restoredCount = 2; // default
+          const savedLabel = context.switch_1_label;
+          if (!context.switch_1_count && savedLabel) {
+            try {
+              const parsed = JSON.parse(savedLabel);
+              // If legacy format (object), use its key count
+              if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                restoredCount = Object.keys(parsed).length || 2;
               }
-            } else {
-              $(`#node-input-switch_${i}_count`).val(2); // default count
+              // If new format (array), use its length
+              if (Array.isArray(parsed)) {
+                restoredCount = parsed.length || 2;
+              }
+            } catch (e) {
+              restoredCount = 2;
             }
+            $('#node-input-switch_1_count').val(restoredCount);
+          } else if (context.switch_1_count) {
+            $('#node-input-switch_1_count').val(context.switch_1_count);
           }
 
-          renderDropdownLabels(i, context);
+          renderDropdownLabels(context);
 
           // Watch count field changes
-          $(`#node-input-switch_${i}_count`).on('change', () => {
-            renderDropdownLabels(i, context);
+          $('#node-input-switch_1_count').on('change', () => {
+            renderDropdownLabels(context);
           });
         }
       }
     }
 
-    $(`#node-input-switch_${i}_type`).on('change', renderTypeConfig);
+    $('#node-input-switch_1_type').on('change', renderTypeConfig);
     renderTypeConfig();
   }
 
-  function renderDropdownLabels (i, context) {
-    $(`#switch-${i}-pairs-row`).remove();
+  function renderDropdownLabels (context) {
+    $('#switch-1-pairs-row').remove();
 
-    const count = parseInt($(`#node-input-switch_${i}_count`).val()) || 2;
+    const count = parseInt($('#node-input-switch_1_count').val()) || 2;
 
     // Create labels container
     const labelsContainer = $(`
-    <div class="form-row" id="switch-${i}-pairs-row">
+    <div class="form-row" id="switch-1-pairs-row">
         <label>Options</label>
-        <div id="switch-${i}-pairs-container" style="display:flex;flex-direction:column;gap:4px;"></div>
+        <div id="switch-1-pairs-container" style="display:flex;flex-direction:column;gap:4px;"></div>
     </div>
   `);
-    $(`#switch-${i}-config-row`).after(labelsContainer);
+    $('#switch-1-config-row').after(labelsContainer);
 
     // Parse saved data from string array
     let savedLabels = [];
-    const savedLabel = context[`switch_${i}_label`];
+    const savedLabel = context.switch_1_label;
     if (savedLabel) {
       try {
         savedLabels = JSON.parse(savedLabel);
@@ -204,25 +209,22 @@
       const value = savedLabels[j] || '';
       const labelHtml = $(`
       <div style="display:flex;gap:8px;align-items:center;">
-        <input type="text" 
-               id="node-input-switch_${i}_value_${j}" 
+        <input type="text"
+               id="node-input-switch_1_value_${j}"
                placeholder="Label"
                style="width:180px;"
                value="${value}" required>
       </div>
     `);
-      $(`#switch-${i}-pairs-container`).append(labelHtml);
+      $('#switch-1-pairs-container').append(labelHtml);
     }
   }
 
   function updateSwitchConfig () {
-    const count = parseInt($('#node-input-switch_count').val()) || 1;
     const container = $('#switch-config-container');
     container.empty();
     if ($('select#node-input-device').val() !== 'switch') return
-    for (let i = 1; i <= count; i++) {
-      renderSwitchConfigRow(i, this);
-    }
+    renderSwitchConfigRow(this);
   }
 
   function updateBatteryVoltageVisibility () {
@@ -279,65 +281,48 @@
 
     if (selected === 'switch') {
       updateSwitchConfig.call(this);
-
-      $('#node-input-switch_count').off('change.switch-config').on('change.switch-config', () => {
-        updateSwitchConfig.call(this);
-      });
     }
   }
 
   function validateSwitchConfig () {
-    const count = parseInt($('#node-input-switch_count').val()) || 1;
-    for (let i = 1; i <= count; i++) {
-      const type = $(`#node-input-switch_${i}_type`).val();
-      const cfg = SWITCH_TYPE_CONFIGS[type];
+    const type = $('#node-input-switch_1_type').val();
+    const cfg = SWITCH_TYPE_CONFIGS[type];
 
-      if (cfg && cfg.fields.length) {
-        for (const field of cfg.fields) {
-          const $input = $(`#node-input-switch_${i}_${field.id}`);
-          if ($input.length && !$input.val()) {
-            $input[0].setCustomValidity('This field is required');
-            $input[0].reportValidity();
-            return false
-          } else if ($input.length) {
-            // Only validate integer for stepped switch max, not for step size
-            if (field.id === 'max' && type === '4') {
-              const maxVal = parseInt($input.val(), 10);
-              if (isNaN(maxVal) || maxVal < 1 || maxVal > 7) {
-                $input[0].setCustomValidity('Max steps must be between 1 and 7');
-                $input[0].reportValidity();
-                return false
-              } else {
-                $input[0].setCustomValidity('');
-              }
+    if (cfg && cfg.fields.length) {
+      for (const field of cfg.fields) {
+        const $input = $(`#node-input-switch_1_${field.id}`);
+        if ($input.length && !$input.val()) {
+          $input[0].setCustomValidity('This field is required');
+          $input[0].reportValidity();
+          return false
+        } else if ($input.length) {
+          if (field.id === 'max' && type === '4') {
+            const maxVal = parseInt($input.val(), 10);
+            if (isNaN(maxVal) || maxVal < 1 || maxVal > 7) {
+              $input[0].setCustomValidity('Max steps must be between 1 and 7');
+              $input[0].reportValidity();
+              return false
             } else {
               $input[0].setCustomValidity('');
             }
+          } else {
+            $input[0].setCustomValidity('');
           }
         }
       }
+    }
 
-      // Special validation for dropdown type (6)
-      if (type === '6') {
-        const pairCount = parseInt($(`#node-input-switch_${i}_count`).val()) || 2;
-        for (let j = 0; j < pairCount; j++) {
-          const $key = $(`#node-input-switch_${i}_key_${j}`);
-          const $value = $(`#node-input-switch_${i}_value_${j}`);
-
-          if ($key.length && !$key.val()) {
-            $key[0].setCustomValidity('Key is required');
-            $key[0].reportValidity();
-            return false
-          }
-          if ($value.length && !$value.val()) {
-            $value[0].setCustomValidity('Value is required');
-            $value[0].reportValidity();
-            return false
-          }
-
-          if ($key.length) $key[0].setCustomValidity('');
-          if ($value.length) $value[0].setCustomValidity('');
+    // Special validation for dropdown type (6)
+    if (type === '6') {
+      const pairCount = parseInt($('#node-input-switch_1_count').val()) || 2;
+      for (let j = 0; j < pairCount; j++) {
+        const $value = $(`#node-input-switch_1_value_${j}`);
+        if ($value.length && !$value.val()) {
+          $value[0].setCustomValidity('Label is required');
+          $value[0].reportValidity();
+          return false
         }
+        if ($value.length) $value[0].setCustomValidity('');
       }
     }
     return true

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1,7 +1,7 @@
 /* global $ */
 
 const COMMON_SWITCH_FIELDS = [
-  { id: 'customname', type: 'text', placeholder: 'Output name', title: 'Custom Name', style: 'width:120px;' },
+  { id: 'customname', type: 'text', placeholder: 'Name', title: 'Name', style: 'width:120px;' },
   { id: 'group', type: 'text', placeholder: 'Group', title: 'Group', style: 'width:120px;' }
 ]
 
@@ -87,7 +87,7 @@ export function renderSwitchConfigRow (context) {
     .join('')
   const switchRow = $(`
         <div class="form-row">
-            <label for="node-input-switch_1_type"><i class="fa fa-toggle-on"></i> Switch 1 type</label>
+            <label for="node-input-switch_1_type"><i class="fa fa-toggle-on"></i> Switch type</label>
             <select id="node-input-switch_1_type">${typeOptions}</select>
         </div>
     `)
@@ -104,28 +104,27 @@ export function renderSwitchConfigRow (context) {
     const cfg = SWITCH_TYPE_CONFIGS[type]
 
     if (cfg && cfg.fields.length) {
-      // Split fields
-      const commonFields = cfg.fields.filter(f => COMMON_SWITCH_FIELDS.some(cf => cf.id === f.id))
-      const extraFields = cfg.fields.filter(f => !COMMON_SWITCH_FIELDS.some(cf => cf.id === f.id))
-
-      // Render common fields in one row
-      const commonFieldsHtml = commonFields.map(field => {
+      // Render each field as a separate row
+      const fieldsHtml = cfg.fields.map(field => {
         const stepAttr = field.id === 'step' || field.id === 'stepsize' ? 'step="any"' : ''
-        return `<input type="${field.type}" id="node-input-switch_1_${field.id}" placeholder="${field.placeholder}" title="${field.title}" style="${field.style}" ${field.min ? `min="${field.min}"` : ''} ${field.max ? `max="${field.max}"` : ''} ${stepAttr} required>`
+        return `
+          <div class="form-row" style="align-items:center;">
+            <label for="node-input-switch_1_${field.id}" style="min-width:120px;">${field.title || field.placeholder}</label>
+            <input type="${field.type}" id="node-input-switch_1_${field.id}"
+                   placeholder="${field.placeholder}"
+                   style="${field.style}"
+                   ${field.min ? `min="${field.min}"` : ''}
+                   ${field.max ? `max="${field.max}"` : ''}
+                   ${stepAttr} required>
+          </div>
+        `
       }).join('')
 
-      // Render extra fields in a new row
-      const extraFieldsHtml = extraFields.map(field => {
-        const stepAttr = field.id === 'step' || field.id === 'stepsize' ? 'step="any"' : ''
-        return `<input type="${field.type}" id="node-input-switch_1_${field.id}" placeholder="${field.placeholder}" title="${field.title}" style="${field.style}" ${field.min ? `min="${field.min}"` : ''} ${field.max ? `max="${field.max}"` : ''} ${stepAttr} required>`
-      }).join('')
-
-      // Build the config row with two lines
+      // Build the config row
       const configRow = $(`
-        <div class="form-row" id="switch-1-config-row">
-          <label>${cfg.label} Config</label>
-          <div style="display:flex;gap:8px;">${commonFieldsHtml}</div>
-          ${extraFieldsHtml ? `<div style="display:flex;gap:8px;margin-top:8px;">${extraFieldsHtml}</div>` : ''}
+        <div id="switch-1-config-row">
+          <label style="font-weight:bold;">${cfg.label} configuration</label>
+          ${fieldsHtml}
         </div>
       `)
       $('#node-input-switch_1_type').closest('.form-row').after(configRow)
@@ -205,7 +204,8 @@ function renderDropdownLabels (context) {
   for (let j = 0; j < count; j++) {
     const value = savedLabels[j] || ''
     const labelHtml = $(`
-      <div style="display:flex;gap:8px;align-items:center;">
+      <div class="form-row" style="align-items:center;">
+        <label for="node-input-switch_1_value_${j}" style="min-width:120px;">Option ${j + 1}</label>
         <input type="text"
                id="node-input-switch_1_value_${j}"
                placeholder="Label"
@@ -278,6 +278,13 @@ export function checkSelectedVirtualDevice () {
 
   if (selected === 'switch') {
     updateSwitchConfig.call(this)
+    // Hide the default values checkbox and info box for switches
+    $('#node-input-default_values').closest('.form-row').hide()
+    $('#default-values-info').hide()
+  } else {
+    // Show for other device types
+    $('#node-input-default_values').closest('.form-row').show()
+    $('#default-values-info').show()
   }
 }
 

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -32,7 +32,6 @@
             position: { value: 0, required: false},
             pvinverter_nrofphases: {value: 1, required: false},
             // switch
-            switch_count: {value: 1, required: false},
             switch_1_type: {value: 1, required: false},
             switch_1_min: {value: 0, required: false},
             switch_1_max: {value: "", required: false},
@@ -42,33 +41,6 @@
             switch_1_step: {value: 1, required: false},
             switch_1_customname: {value: "", required: false},
             switch_1_group: {value: "", required: false},
-            switch_2_type: {value: 1, required: false},
-            switch_2_min: {value: 0, required: false},
-            switch_2_max: {value: "", required: false},
-            switch_2_initial: {value: 0, required: false},
-            switch_2_step: {value: 1, required: false},
-            switch_2_label: {value: "", required: false},
-            switch_2_unit: {value: "", required: false},
-            switch_2_customname: {value: "", required: false},
-            switch_2_group: {value: "", required: false},
-            switch_3_type: {value: 1, required: false},
-            switch_3_min: {value: 0, required: false},
-            switch_3_max: {value: "", required: false},
-            switch_3_initial: {value: 0, required: false},
-            switch_3_step: {value: 1, required: false},
-            switch_3_label: {value: "", required: false},
-            switch_3_unit: {value: "", required: false},
-            switch_3_customname: {value: "", required: false},
-            switch_3_group: {value: "", required: false},
-            switch_4_type: {value: 1, required: false},
-            switch_4_min: {value: 0, required: false},
-            switch_4_max: {value: "", required: false},
-            switch_4_initial: {value: 0, required: false},
-            switch_4_step: {value: 1, required: false},
-            switch_4_label: {value: "", required: false},
-            switch_4_unit: {value: "", required: false},
-            switch_4_customname: {value: "", required: false},
-            switch_4_group: {value: "", required: false},
             // tank
             fluid_type: { value: 0, required: false},
             include_tank_battery: { value: false },
@@ -113,55 +85,53 @@
                     // Prevent save if validation fails
                     return false;
                 }
-                const switchCount = parseInt($('#node-input-switch_count').val());
-                for (let i = 1; i <= 4; i++) {
-                    const switchTypeInput = $(`#node-input-switch_${i}_type`);
-                    if (switchTypeInput.length) {
-                        const type = parseInt(switchTypeInput.val());
-                        this[`switch_${i}_type`] = type;
-                        
-                        // Save config fields for this type
-                        const cfg = SWITCH_TYPE_CONFIGS[type];
-                        if (cfg && cfg.fields.length) {
-                            cfg.fields.forEach(field => {
-                              let val = $(`#node-input-switch_${i}_${field.id}`).val()
-                              if (field.id === 'step' && val !== '') {
-                                val = parseFloat(val)
-                              }
-                              this[`switch_${i}_${field.id}`] = val
-                            });
-                        }
-                        
-                        // Special handling for dropdown type (6)
-                        if (type === 6) {
-                            const pairCount = parseInt($(`#node-input-switch_${i}_count`).val()) || 2;
-                            const labelsArray = [];
-                            for (let j = 0; j < pairCount; j++) {
-                                const value = $(`#node-input-switch_${i}_value_${j}`).val();
-                                if (value) {
-                                    labelsArray.push(value);
-                                }
+
+                const switchTypeInput = $(`#node-input-switch_1_type`);
+                if (switchTypeInput.length) {
+                    const type = parseInt(switchTypeInput.val());
+                    this[`switch_1_type`] = type;
+
+                    // Save config fields for this type
+                    const cfg = SWITCH_TYPE_CONFIGS[type];
+                    if (cfg && cfg.fields.length) {
+                        cfg.fields.forEach(field => {
+                            let val = $(`#node-input-switch_1_${field.id}`).val()
+                            if (field.id === 'step' && val !== '') {
+                            val = parseFloat(val)
                             }
-                            // Store as JSON string array
-                            this[`switch_${i}_label`] = JSON.stringify(labelsArray);
-                        }
-
-                        // For type 7 (basic slider), save unit field
-                        if (type === 7) {
-                            this[`switch_${i}_unit`] = $(`#node-input-switch_${i}_unit`).val();
-                        }
-
-                        // Clear any previously set config fields for other types
-                        Object.values(SWITCH_TYPE_CONFIGS).forEach(c => {
-                            c.fields.forEach(field => {
-                                if (cfg && cfg.fields.some(f => f.id === field.id)) {
-                                    // Keep current type's fields
-                                    return;
-                                }
-                                this[`switch_${i}_${field.id}`] = undefined;
-                            });
+                            this[`switch_1_${field.id}`] = val
                         });
                     }
+
+                    // Special handling for dropdown type (6)
+                    if (type === 6) {
+                        const pairCount = parseInt($(`#node-input-switch_1_count`).val()) || 2;
+                        const labelsArray = [];
+                        for (let j = 0; j < pairCount; j++) {
+                            const value = $(`#node-input-switch_1_value_${j}`).val();
+                            if (value) {
+                                labelsArray.push(value);
+                            }
+                        }
+                        // Store as JSON string array
+                        this[`switch_1_label`] = JSON.stringify(labelsArray);
+                    }
+
+                    // For type 7 (basic slider), save unit field
+                    if (type === 7) {
+                        this[`switch_1_unit`] = $(`#node-input-switch_1_unit`).val();
+                    }
+
+                    // Clear any previously set config fields for other types
+                    Object.values(SWITCH_TYPE_CONFIGS).forEach(c => {
+                        c.fields.forEach(field => {
+                            if (cfg && cfg.fields.some(f => f.id === field.id)) {
+                                // Keep current type's fields
+                                return;
+                            }
+                            this[`switch_1_${field.id}`] = undefined;
+                        });
+                    });
                 }
             }
         }
@@ -278,15 +248,6 @@
     </div>
 
     <div class="input-switch">
-        <div class="form-row">
-            <label for="node-input-switch_count"><i class="fa fa-plug"></i> Number of switches</label>
-            <select id="node-input-switch_count">
-                <option value="1">1</option>
-                <option value="2">2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-            </select>
-        </div>
         <div id="switch-config-container">
             <!-- Dynamic switch configuration will be added here -->
         </div>
@@ -593,7 +554,7 @@ These additional parameters can help monitor the performance and status of your 
 ### Virtual switch
 
 The virtual switch creates a switch device on the dbus that can be controlled and
-monitored remotely. There are currently seven types of switches available:
+monitored remotely. There are several types of switches available:
 
 - **Momentary**: Acts like a push button - automatically returns to off state
 - **Toggle**: Standard on/off switch that maintains its state
@@ -606,13 +567,13 @@ monitored remotely. There are currently seven types of switches available:
 - **Three-state switch**: Select from three states (On, Off, Auto)
 - **Bilge pump control**: Special switch type for bilge pumps with automatic and manual modes (A bilge pump is a device on a boat that removes accumulated water from the lowest part of the hull, known as the bilge, and pumps it overboard).
 
-You can configure up to 4 switches within a virtual switch, and each switch can be individually set to any
-of the types. This allows mixing different switch types in a single virtual
-device (e.g., toggle switches for lights and dimmable switches for fans).
+The virtual switch can be set to any of the types mentioned above. By setting the group name of the switch, multiple switches can be grouped together, allowing them
+to be seen within a group of switches on the GX device.
 
 As the virtual switches become available on the dbus, they will also appear on the (remote)
 console and attached screen of the GX device. Settings things like name and group can be
-done from the GX device directly.
+done while setting up in the edit panel, but can also be done from the GX device directly.
+On restart of Node-RED, the stored name and group will be applied again.
 
 The switch types correspond to the Venus OS dbus switch specification, which can be found 
 [here](https://github.com/victronenergy/venus/wiki/dbus#switch).

--- a/test/victron-virtual-functions.switch.test.js
+++ b/test/victron-virtual-functions.switch.test.js
@@ -64,7 +64,7 @@ describe('Switch Configuration Tests', () => {
       })
 
       const context = { switch_1_type: 6 }
-      renderSwitchConfigRow(1, context)
+      renderSwitchConfigRow(context)
 
       expect(mockContainer.append).toHaveBeenCalled()
       // The append call should have been made with a jQuery object, not a string
@@ -87,7 +87,7 @@ describe('Switch Configuration Tests', () => {
       })
 
       const context = {} // No switch_1_type defined
-      renderSwitchConfigRow(1, context)
+      renderSwitchConfigRow(context)
 
       expect(mockContainer.append).toHaveBeenCalled()
       expect(mockTypeSelect.val).toHaveBeenCalledWith('1') // Default type is 1
@@ -108,7 +108,7 @@ describe('Switch Configuration Tests', () => {
       })
 
       const context = { switch_1_type: 6 }
-      renderSwitchConfigRow(1, context)
+      renderSwitchConfigRow(context)
 
       expect(mockTypeSelect.on).toHaveBeenCalledWith('change', expect.any(Function))
     })
@@ -117,9 +117,6 @@ describe('Switch Configuration Tests', () => {
   describe('validateSwitchConfig', () => {
     test('returns true when no switches configured', () => {
       global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '0' })
-        }
         return createMockElement({ length: 0 })
       })
 
@@ -129,9 +126,6 @@ describe('Switch Configuration Tests', () => {
 
     test('returns true for momentary switch (no fields to validate)', () => {
       global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '1' })
-        }
         if (selector === '#node-input-switch_1_type') {
           return createMockElement({ val: '0' }) // Momentary type
         }
@@ -142,55 +136,10 @@ describe('Switch Configuration Tests', () => {
       expect(result).toBe(true)
     })
 
-    // test('validates dropdown count field is required', () => {
-    //   const mockCountField = createMockElement({ val: '' })
-      
-    //   global.$.mockImplementation((selector) => {
-    //     if (selector === '#node-input-switch_count') {
-    //       return createMockElement({ val: '1' })
-    //     }
-    //     if (selector === '#node-input-switch_1_type') {
-    //       return createMockElement({ val: '6' }) // Dropdown type
-    //     }
-    //     if (selector === '#node-input-switch_1_count') {
-    //       return mockCountField
-    //     }
-    //     return createMockElement({ length: 0 })
-    //   })
-
-    //   const result = validateSwitchConfig()
-    //   expect(result).toBe(false)
-    //   expect(mockCountField[0].setCustomValidity).toHaveBeenCalledWith('This field is required')
-    // })
-
-    // test('passes validation for dropdown with valid count', () => {
-    //   const mockCountField = createMockElement({ val: '3' })
-      
-    //   global.$.mockImplementation((selector) => {
-    //     if (selector === '#node-input-switch_count') {
-    //       return createMockElement({ val: '1' })
-    //     }
-    //     if (selector === '#node-input-switch_1_type') {
-    //       return createMockElement({ val: '6' })
-    //     }
-    //     if (selector === '#node-input-switch_1_count') {
-    //       return mockCountField
-    //     }
-    //     return createMockElement({ length: 0 })
-    //   })
-
-    //   const result = validateSwitchConfig()
-    //   expect(result).toBe(true)
-    //   expect(mockCountField[0].setCustomValidity).toHaveBeenCalledWith('')
-    // })
-
     test('validates stepped switch max field (type 4)', () => {
       const mockMaxField = createMockElement({ val: '' })
       
       global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '1' })
-        }
         if (selector === '#node-input-switch_1_type') {
           return createMockElement({ val: '4' })
         }
@@ -209,9 +158,6 @@ describe('Switch Configuration Tests', () => {
       const mockMaxField = createMockElement({ val: '10' }) // Above max
       
       global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '1' })
-        }
         if (selector === '#node-input-switch_1_type') {
           return createMockElement({ val: '4' })
         }
@@ -230,9 +176,6 @@ describe('Switch Configuration Tests', () => {
       const mockMaxField = createMockElement({ val: '5' })
       
       global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '1' })
-        }
         if (selector === '#node-input-switch_1_type') {
           return createMockElement({ val: '4' })
         }
@@ -247,50 +190,16 @@ describe('Switch Configuration Tests', () => {
       expect(mockMaxField[0].setCustomValidity).toHaveBeenCalledWith('')
     })
 
-    test('validates dropdown key is required when key field exists', () => {
-      const mockKeyField = createMockElement({ val: '' })
-      const mockCountField = createMockElement({ val: '2' })
-      
-      global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '1' })
-        }
-        if (selector === '#node-input-switch_1_type') {
-          return createMockElement({ val: '6' })
-        }
-        if (selector === '#node-input-switch_1_count') {
-          return mockCountField
-        }
-        if (selector === '#node-input-switch_1_key_0') {
-          return mockKeyField
-        }
-        if (selector === '#node-input-switch_1_value_0') {
-          return createMockElement({ val: 'value1' })
-        }
-        return createMockElement({ length: 0 })
-      })
-
-      const result = validateSwitchConfig()
-      expect(result).toBe(false)
-      expect(mockKeyField[0].setCustomValidity).toHaveBeenCalledWith('Key is required')
-    })
-
     test('validates dropdown value is required when value field exists', () => {
       const mockValueField = createMockElement({ val: '' })
       const mockCountField = createMockElement({ val: '2' })
       
       global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '1' })
-        }
         if (selector === '#node-input-switch_1_type') {
           return createMockElement({ val: '6' })
         }
         if (selector === '#node-input-switch_1_count') {
           return mockCountField
-        }
-        if (selector === '#node-input-switch_1_key_0') {
-          return createMockElement({ val: 'key1' })
         }
         if (selector === '#node-input-switch_1_value_0') {
           return mockValueField
@@ -300,39 +209,14 @@ describe('Switch Configuration Tests', () => {
 
       const result = validateSwitchConfig()
       expect(result).toBe(false)
-      expect(mockValueField[0].setCustomValidity).toHaveBeenCalledWith('Value is required')
+      expect(mockValueField[0].setCustomValidity).toHaveBeenCalledWith('Label is required')
     })
 
-    test('validates multiple switches with mixed types', () => {
-      global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '2' })
-        }
-        // Switch 1: Dropdown type with valid count
-        if (selector === '#node-input-switch_1_type') {
-          return createMockElement({ val: '6' })
-        }
-        if (selector === '#node-input-switch_1_count') {
-          return createMockElement({ val: '3' })
-        }
-        // Switch 2: Momentary type (no fields to validate)
-        if (selector === '#node-input-switch_2_type') {
-          return createMockElement({ val: '0' })
-        }
-        return createMockElement({ length: 0 })
-      })
-
-      const result = validateSwitchConfig()
-      expect(result).toBe(true)
-    })
   })
 
   describe('edge cases', () => {
     test('handles missing switch type gracefully', () => {
       global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '1' })
-        }
         if (selector === '#node-input-switch_1_type') {
           return createMockElement({ val: undefined })
         }
@@ -343,23 +227,8 @@ describe('Switch Configuration Tests', () => {
       expect(result).toBe(true) // Should handle gracefully
     })
 
-    test('handles non-numeric switch count', () => {
-      global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: 'invalid' })
-        }
-        return createMockElement({ length: 0 })
-      })
-
-      const result = validateSwitchConfig()
-      expect(result).toBe(true) // Should default to 1 and process normally
-    })
-
     test('passes validation when key/value elements do not exist', () => {
       global.$.mockImplementation((selector) => {
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '1' })
-        }
         if (selector === '#node-input-switch_1_type') {
           return createMockElement({ val: '6' })
         }
@@ -378,12 +247,4 @@ describe('Switch Configuration Tests', () => {
     })
   })
 
-  // describe('SWITCH_TYPE_CONFIGS', () => {
-  //   test('all switch types include customname and group fields first', () => {
-  //     Object.values(SWITCH_TYPE_CONFIGS).forEach(cfg => {
-  //       expect(cfg.fields[0].id).toBe('customname');
-  //       expect(cfg.fields[1].id).toBe('group');
-  //     });
-  //   });
-  // });
 })

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -311,16 +311,12 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
     })
 
     test('handles switch device selection with context', () => {
-      const mockSwitchCount = createMockElement()
       const mockContainer = createMockElement()
       const context = {}
 
       global.$.mockImplementation((selector) => {
         if (selector === 'select#node-input-device') {
           return createMockElement({ val: 'switch' })
-        }
-        if (selector === '#node-input-switch_count') {
-          return mockSwitchCount
         }
         if (selector === '#switch-config-container') {
           return mockContainer
@@ -333,8 +329,7 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
 
       checkSelectedVirtualDevice.call(context)
 
-      expect(mockSwitchCount.off).toHaveBeenCalledWith('change.switch-config')
-      expect(mockSwitchCount.on).toHaveBeenCalledWith('change.switch-config', expect.any(Function))
+      // Only check that the switch config container is emptied for a switch device
       expect(mockContainer.empty).toHaveBeenCalled()
     })
   })
@@ -359,28 +354,6 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockContainer.empty).toHaveBeenCalled()
     })
 
-    test('processes switch device with valid count', () => {
-      const mockContainer = createMockElement()
-      const context = {}
-
-      global.$.mockImplementation((selector) => {
-        if (selector === 'select#node-input-device') {
-          return createMockElement({ val: 'switch' })
-        }
-        if (selector === '#node-input-switch_count') {
-          return createMockElement({ val: '2' })
-        }
-        if (selector === '#switch-config-container') {
-          return mockContainer
-        }
-        return createMockElement()
-      })
-
-      updateSwitchConfig.call(context)
-
-      expect(mockContainer.empty).toHaveBeenCalled()
-      expect(global.$).toHaveBeenCalledWith('#node-input-switch_count')
-    })
   })
 
   describe('updateBatteryVoltageVisibility', () => {


### PR DESCRIPTION
Previously the layout of the edit panel wasn't too UX friendly. These changes help in making it more userfriendly by aligning everything better.
The switches don't appear on VRM, so hide the "initialize with default values" when the switch is selected.

Note, this builds on top of the`faberd/virtual-device-only-1-switch-instead-of-4` branch