### PR TITLE
fix: relative resources paths when node-red runs under a prefix path

### DIFF
--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="/resources/@victronenergy/node-red-contrib-victron/victron-virtual-style.css">
-<script src="/resources/@victronenergy/node-red-contrib-victron/victron-virtual-functions.js"></script>
+<link rel="stylesheet" href="resources/@victronenergy/node-red-contrib-victron/victron-virtual-style.css">
+<script src="resources/@victronenergy/node-red-contrib-victron/victron-virtual-functions.js"></script>
 <script type="text/javascript">
     RED.nodes.registerType('victron-virtual',{
         category: 'Victron Energy',


### PR DESCRIPTION
This addresses #307, and should allow node-red running with a prefix path.

I tested it locally (not under a prefix path), it should not cause a regression.