### PR TITLE
Virtual switch: temperature setpoint fix output

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -24,7 +24,7 @@
   	  [SWITCH_TYPE_MAP.MOMENTARY]: 2, // passthrough + state
   	  [SWITCH_TYPE_MAP.TOGGLE]: 2, // passthrough + state
   	  [SWITCH_TYPE_MAP.DIMMABLE]: 3, // passthrough + state + dimming value
-  	  [SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT]: 3, // passthrough + state + temperature value
+  	  [SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT]: 2, // passthrough + temperature value
   	  [SWITCH_TYPE_MAP.STEPPED]: 3, // passthrough + state + stepped value
   	  [SWITCH_TYPE_MAP.DROPDOWN]: 2, // passthrough + state
   	  [SWITCH_TYPE_MAP.BASIC_SLIDER]: 3, // passthrough + state + slider value
@@ -33,7 +33,12 @@
   	  [SWITCH_TYPE_MAP.BILGE_PUMP]: 2 // passthrough + state
   	};
 
-  	// Output labels configuration: third label varies by switch type
+  	// Will default to 'State' if not defined here
+  	const SWITCH_SECOND_OUTPUT_LABEL = {
+  	  [SWITCH_TYPE_MAP.DROPDOWN]: 'Selected',
+  	  [SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT]: 'Temperature'
+  	};
+
   	const SWITCH_THIRD_OUTPUT_LABEL = {
   	  [SWITCH_TYPE_MAP.DIMMABLE]: 'Dimming',
   	  [SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT]: 'Temperature',
@@ -45,6 +50,7 @@
   	victronVirtualConstants = {
   	  SWITCH_TYPE_MAP,
   	  SWITCH_OUTPUT_CONFIG,
+  	  SWITCH_SECOND_OUTPUT_LABEL,
   	  SWITCH_THIRD_OUTPUT_LABEL
   	};
   	return victronVirtualConstants;
@@ -211,7 +217,6 @@
         <strong>Outputs:</strong>
         <ol>
           <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
-          <li><code>State</code> &mdash; <tt>msg.payload</tt> contains a <tt>0</tt> or <tt>1</tt> representing the  on/off state of the switch</li>
           <li><code>Temperature</code> &mdash; <tt>msg.payload</tt> contains the temperature value</li>
         </ol>
       </div>

--- a/src/nodes/victron-virtual-constants.js
+++ b/src/nodes/victron-virtual-constants.js
@@ -15,7 +15,7 @@ const SWITCH_OUTPUT_CONFIG = {
   [SWITCH_TYPE_MAP.MOMENTARY]: 2, // passthrough + state
   [SWITCH_TYPE_MAP.TOGGLE]: 2, // passthrough + state
   [SWITCH_TYPE_MAP.DIMMABLE]: 3, // passthrough + state + dimming value
-  [SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT]: 3, // passthrough + state + temperature value
+  [SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT]: 2, // passthrough + temperature value
   [SWITCH_TYPE_MAP.STEPPED]: 3, // passthrough + state + stepped value
   [SWITCH_TYPE_MAP.DROPDOWN]: 2, // passthrough + state
   [SWITCH_TYPE_MAP.BASIC_SLIDER]: 3, // passthrough + state + slider value
@@ -24,7 +24,12 @@ const SWITCH_OUTPUT_CONFIG = {
   [SWITCH_TYPE_MAP.BILGE_PUMP]: 2 // passthrough + state
 }
 
-// Output labels configuration: third label varies by switch type
+// Will default to 'State' if not defined here
+const SWITCH_SECOND_OUTPUT_LABEL = {
+  [SWITCH_TYPE_MAP.DROPDOWN]: 'Selected',
+  [SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT]: 'Temperature'
+}
+
 const SWITCH_THIRD_OUTPUT_LABEL = {
   [SWITCH_TYPE_MAP.DIMMABLE]: 'Dimming',
   [SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT]: 'Temperature',
@@ -36,5 +41,6 @@ const SWITCH_THIRD_OUTPUT_LABEL = {
 module.exports = {
   SWITCH_TYPE_MAP,
   SWITCH_OUTPUT_CONFIG,
+  SWITCH_SECOND_OUTPUT_LABEL,
   SWITCH_THIRD_OUTPUT_LABEL
 }

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -3,6 +3,7 @@
 import {
   SWITCH_TYPE_MAP,
   SWITCH_OUTPUT_CONFIG,
+  SWITCH_SECOND_OUTPUT_LABEL,
   SWITCH_THIRD_OUTPUT_LABEL
 } from './victron-virtual-constants'
 
@@ -10,6 +11,7 @@ import {
 export {
   SWITCH_TYPE_MAP,
   SWITCH_OUTPUT_CONFIG,
+  SWITCH_SECOND_OUTPUT_LABEL,
   SWITCH_THIRD_OUTPUT_LABEL
 }
 
@@ -169,7 +171,6 @@ export const SWITCH_TYPE_DOCS = {
         <strong>Outputs:</strong>
         <ol>
           <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
-          <li><code>State</code> &mdash; <tt>msg.payload</tt> contains a <tt>0</tt> or <tt>1</tt> representing the  on/off state of the switch</li>
           <li><code>Temperature</code> &mdash; <tt>msg.payload</tt> contains the temperature value</li>
         </ol>
       </div>
@@ -717,11 +718,9 @@ export function getOutputLabels (device, config) {
   // Start with common labels
   const labels = ['Passthrough']
 
-  // For dropdown, second output is 'Selected' instead of 'State'
-  if (outputCount === 2 && typeKey === SWITCH_TYPE_MAP.DROPDOWN) {
-    labels.push('Selected')
-  } else {
-    labels.push('State')
+  if (outputCount >= 2) {
+    const secondLabel = SWITCH_SECOND_OUTPUT_LABEL[typeKey] || 'State'
+    labels.push(secondLabel)
   }
 
   // Add third label if needed

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -73,11 +73,14 @@
             if (!this.device || this.device !== 'switch') {
                 return index === 0 ? 'Passthrough' : 'Output ' + (index + 1)
             }
-            
+
             const switchType = this.switch_1_type
             const typeKey = switchType !== undefined ? parseInt(switchType, 10) : 1 // TOGGLE = 1
-            
-            // Map of third output labels
+
+            const secondLabels = {
+                6: 'Selected',     // DROPDOWN
+                3: 'Temperature'   // TEMPERATURE_SETPOINT ← NEW
+            }
             const thirdLabels = {
                 2: 'Dimming',      // DIMMABLE
                 3: 'Temperature',  // TEMPERATURE_SETPOINT
@@ -88,13 +91,12 @@
             
             if (index === 0) return 'Passthrough'
             
-            // For dropdown (type 6), second output is 'selected' instead of 'state'
             if (index === 1) {
-                return typeKey === 6 ? 'Selected' : 'State'
+                return secondLabels[typeKey] || 'State'
             }
-            
+
             if (index === 2) return thirdLabels[typeKey] || 'Value'
-            
+
             return 'Output ' + (index + 1)
         },
         oneditprepare: function oneditprepare() {

--- a/test/victron-virtual-outputs.test.js
+++ b/test/victron-virtual-outputs.test.js
@@ -41,9 +41,9 @@ describe('calculateOutputs', () => {
       expect(calculateOutputs('switch', config)).toBe(3)
     })
 
-    test('temperature setpoint switch has 3 outputs (passthrough + state + value)', () => {
+    test('temperature setpoint switch has 2 outputs (passthrough + temperature, NO state)', () => {
       const config = { switch_1_type: String(SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT) }
-      expect(calculateOutputs('switch', config)).toBe(3)
+      expect(calculateOutputs('switch', config)).toBe(2) // Changed from 3 to 2
     })
 
     test('stepped switch has 3 outputs (passthrough + state + value)', () => {
@@ -148,9 +148,9 @@ describe('getOutputLabels', () => {
       expect(getOutputLabels('switch', config)).toEqual(['Passthrough', 'State', 'Dimming'])
     })
 
-    test('temperature setpoint has passthrough, state, and temperature labels', () => {
+    test('temperature setpoint has passthrough and temperature labels (NO state)', () => {
       const config = { switch_1_type: String(SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT) }
-      expect(getOutputLabels('switch', config)).toEqual(['Passthrough', 'State', 'Temperature'])
+      expect(getOutputLabels('switch', config)).toEqual(['Passthrough', 'Temperature']) // Removed 'State'
     })
 
     test('stepped switch has passthrough, state, and value labels', () => {


### PR DESCRIPTION
The gui implementation doesn't support state, so remove that from the node too. As the dropdown and temperature setpoint have the second output not as "state", add a `SWITCH_SECOND_OUTPUT_LABEL` for naming that second output.