### PR TITLE
Make custom name and group name no longer persistent

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -62,8 +62,8 @@
 
 
   const COMMON_SWITCH_FIELDS = [
-    { id: 'customname', type: 'text', placeholder: 'Name', title: 'Name', style: 'width:120px;', tooltip: 'Custom name for the switch' },
-    { id: 'group', type: 'text', placeholder: 'Group', title: 'Group', style: 'width:120px;', tooltip: 'Initial group for the switch. If the group gets changed in the gui after initial deploy, the value set there will be persisted (also on re-deploy).' }
+    { id: 'customname', type: 'text', placeholder: 'Name', title: 'Name', style: 'width:120px;', tooltip: 'Custom name for the switch. If the custom name gets changed in the gui after initial deploy, that value will be overwritten on restart and re-deploy of Node-RED.' },
+    { id: 'group', type: 'text', placeholder: 'Group', title: 'Group', style: 'width:120px;', tooltip: 'Group name for the switch. If the group gets changed in the gui after initial deploy, that value will be overwritten on restart and re-deploy of Node-RED.' }
   ];
 
   function checkGeneratorType () {

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -16,8 +16,8 @@ export {
 }
 
 const COMMON_SWITCH_FIELDS = [
-  { id: 'customname', type: 'text', placeholder: 'Name', title: 'Name', style: 'width:120px;', tooltip: 'Custom name for the switch' },
-  { id: 'group', type: 'text', placeholder: 'Group', title: 'Group', style: 'width:120px;', tooltip: 'Initial group for the switch. If the group gets changed in the gui after initial deploy, the value set there will be persisted (also on re-deploy).' }
+  { id: 'customname', type: 'text', placeholder: 'Name', title: 'Name', style: 'width:120px;', tooltip: 'Custom name for the switch. If the custom name gets changed in the gui after initial deploy, that value will be overwritten on restart and re-deploy of Node-RED.' },
+  { id: 'group', type: 'text', placeholder: 'Group', title: 'Group', style: 'width:120px;', tooltip: 'Group name for the switch. If the group gets changed in the gui after initial deploy, that value will be overwritten on restart and re-deploy of Node-RED.' }
 ]
 
 export function checkGeneratorType () {

--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -808,8 +808,8 @@ module.exports = function (RED) {
               { name: 'State', type: 'i', format: (v) => ({ 0: 'Off', 1: 'On' }[v] || 'unknown'), persist: true },
               { name: 'Status', type: 'i', format: (v) => v != null ? v : '' },
               { name: 'Name', type: 's', persist: true },
-              { name: 'Settings/Group', type: 's', value: '', persist: true },
-              { name: 'Settings/CustomName', type: 's', value: '', persist: true },
+              { name: 'Settings/Group', type: 's', value: '', persist: false },
+              { name: 'Settings/CustomName', type: 's', value: '', persist: false },
               {
                 name: 'Settings/Type',
                 type: 'i',


### PR DESCRIPTION
Users were confused when flow configuration changes were ignored due to persisted GUI values taking precedence. The flow is now the source of truth.