### PR TITLE
fix: default service paths to input-only when mode field is missing

### DIFF
--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -51,10 +51,9 @@ class SystemConfiguration {
                 (expandedPathObj.path !== '/Ac/In/1/CurrentLimit' || _.get(cachedPaths, '/Ac/In/1/CurrentLimitIsAdjustable', 1)) &&
                 (expandedPathObj.path !== '/Ac/In/2/CurrentLimit' || _.get(cachedPaths, '/Ac/In/2/CurrentLimitIsAdjustable', 1))
               )) &&
-              (!expandedPathObj.mode ||
-              expandedPathObj.mode === 'both' ||
+              (expandedPathObj.mode === 'both' ||
               (isOutput && expandedPathObj.mode === 'output') ||
-              (!isOutput && expandedPathObj.mode === 'input'))
+              (!isOutput && (expandedPathObj.mode === 'input' || !expandedPathObj.mode)))
             )
 
             return pathAcc.concat(filtered)


### PR DESCRIPTION
Paths without an explicit "mode" field in services.json now default to input-only (read-only) instead of appearing in both input and output nodes. This prevents read-only paths like FirmwareVersion from appearing in output-control nodes.

This bug was introduced in 5e5a158d0550e4d84d4065f21d4e9a2df454dba7 on July 7, 2025.