### PR TITLE
fix: handle zero values correctly for initial value in output nodes

### DIFF
--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -198,9 +198,9 @@
                         var enumInput = $('#node-input-initial-enum');
                         populateSelect(enumInput, selectOptions);
                         enumInput.show();
-                        if (node.initial) enumInput.val(node.initial);
+                        if (node.initial !== undefined && node.initial !== null) enumInput.val(node.initial);
                         break;
-                        
+
                     case 'float':
                     case 'integer':
                         var numberInput = $('#node-input-initial-number');
@@ -210,13 +210,13 @@
                         } else {
                             numberInput.attr('step', 'any');
                         }
-                        if (node.initial) numberInput.val(node.initial);
+                        if (node.initial !== undefined && node.initial !== null) numberInput.val(node.initial);
                         break;
-                        
+
                     case 'string':
                         var stringInput = $('#node-input-initial-string');
                         stringInput.show();
-                        if (node.initial) stringInput.val(node.initial);
+                        if (node.initial !== undefined && node.initial !== null) stringInput.val(node.initial);
                         break;
                     
                     default:

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -150,7 +150,20 @@ module.exports = function (RED) {
       this.pathObj = nodeDefinition.pathObj
       this.service = nodeDefinition.service
       this.path = nodeDefinition.path
-      this.initialValue = nodeDefinition.initial
+
+      // Migrate string initial values to proper types
+      let initialValue = nodeDefinition.initial
+      if (initialValue !== undefined && initialValue !== null && nodeDefinition.pathObj) {
+        const pathType = nodeDefinition.pathObj.type
+        if ((pathType === 'float' || pathType === 'integer' || pathType === 'enum') && typeof initialValue === 'string') {
+          const numValue = pathType === 'integer' || pathType === 'enum' ? parseInt(initialValue) : parseFloat(initialValue)
+          if (!isNaN(numValue)) {
+            initialValue = numValue
+            debug(`Migrated initial value from string "${nodeDefinition.initial}" to number ${numValue}`)
+          }
+        }
+      }
+      this.initialValue = initialValue
 
       this.configNode = RED.nodes.getNode('victron-client-id')
       this.client = this.configNode.client


### PR DESCRIPTION
Fix bug where initial values of 0 were not loaded into the node editor. The truthy check (if (node.initial)) fails for falsy values like 0.

Also add migration logic to convert string initial values to proper numeric types for float/integer/enum paths.

Changes:
- victron-nodes.html: Replace truthy checks with explicit undefined/null checks when loading initial values
- victron-nodes.js: Add type conversion in BaseOutputNode constructor

Originally introduced in 9c937a6 (Feb 2019), persisted through c740754 (Dec 2024) and 2f5d1c1 (Mar 2025)

Resolves issue #279.

Tested on our test system - this should be backported to 3.66. 