### PR TITLE
feat: support ShowUIControl bitmask values 0-6

### DIFF
--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -862,14 +862,29 @@ module.exports = function (RED) {
                 persist: false
               },
               { name: 'Settings/ValidTypes', type: 'i', value: 0x7 },
-              { name: 'Settings/ShowUIControl', type: 'i', value: 1, persist: true }
+              {
+                name: 'Settings/ShowUIControl',
+                type: 'i',
+                value: 1,
+                min: 0,
+                max: 6,
+                persist: true,
+                format: (v) => {
+                  if (v === 0) return 'Hidden'
+                  const parts = []
+                  if (v & 0b001) parts.push('All UIs')
+                  if (v & 0b010) parts.push('Local UI')
+                  if (v & 0b100) parts.push('Remote UIs')
+                  return parts.length > 0 ? parts.join(' + ') : 'Hidden'
+                }
+              }
             ]
 
             const switchType = Number(config.switch_1_type ?? 1)
 
-            baseProperties.forEach(({ name, type, value, format, persist }) => {
+            baseProperties.forEach(({ name, type, value, format, persist, min, max }) => {
               const switchableOutputPropertyKey = `SwitchableOutput/output_1/${name}`
-              ifaceDesc.properties[switchableOutputPropertyKey] = { type, format, persist }
+              ifaceDesc.properties[switchableOutputPropertyKey] = { type, format, persist, min, max }
 
               let propValue = value
               if (name === 'Name') {

--- a/test/victron-virtual-showuicontrol.test.js
+++ b/test/victron-virtual-showuicontrol.test.js
@@ -1,0 +1,63 @@
+// test/victron-virtual-showuicontrol.test.js
+// Tests for ShowUIControl bitmask support
+
+describe('ShowUIControl bitmask support', () => {
+  test('should accept valid bitmask values 0-6', () => {
+    const validValues = [0, 1, 2, 3, 4, 5, 6]
+
+    validValues.forEach(value => {
+      expect(value).toBeGreaterThanOrEqual(0)
+      expect(value).toBeLessThanOrEqual(6)
+    })
+  })
+
+  test('bitmask value 0 means do not show', () => {
+    const value = 0b000
+    expect(value).toBe(0)
+  })
+
+  test('bitmask value 1 means show in all UIs', () => {
+    const value = 0b001
+    expect(value).toBe(1)
+    expect(value & 0b001).toBeTruthy() // bit 0 set
+  })
+
+  test('bitmask value 2 means show in local UI only', () => {
+    const value = 0b010
+    expect(value).toBe(2)
+    expect(value & 0b010).toBeTruthy() // bit 1 set
+  })
+
+  test('bitmask value 3 means show in all UIs and local UI', () => {
+    const value = 0b011
+    expect(value).toBe(3)
+    expect(value & 0b001).toBeTruthy() // bit 0 set
+    expect(value & 0b010).toBeTruthy() // bit 1 set
+  })
+
+  test('bitmask value 4 means show in all remote UIs', () => {
+    const value = 0b100
+    expect(value).toBe(4)
+    expect(value & 0b100).toBeTruthy() // bit 2 set
+  })
+
+  test('bitmask value 5 means show in all UIs and all remote UIs', () => {
+    const value = 0b101
+    expect(value).toBe(5)
+    expect(value & 0b001).toBeTruthy() // bit 0 set
+    expect(value & 0b100).toBeTruthy() // bit 2 set
+  })
+
+  test('bitmask value 6 means show in local UI and all remote UIs', () => {
+    const value = 0b110
+    expect(value).toBe(6)
+    expect(value & 0b010).toBeTruthy() // bit 1 set
+    expect(value & 0b100).toBeTruthy() // bit 2 set
+  })
+
+  test('default value should be 1 (show in all UIs)', () => {
+    const defaultValue = 1
+    expect(defaultValue).toBe(1)
+    expect(defaultValue & 0b001).toBeTruthy()
+  })
+})


### PR DESCRIPTION
See https://github.com/victronenergy/venus/issues/1554:

The `/ShowUiContro`l path has been updated to an integer value:

Path values:
- `0b000`: Do not show the control item
- `0bxx1:` Show in all UI's
- `0bx10:` Show in the local UI
- `0b1x0`: Show in all remote UI's

The default behavior should be to show it in all UI's, so the value should be set to 1. This is currently also the default behavior. Only thing that needs to be checked is whether values other than 0 and 1 are accepted by the driver. A value of up to 0b110 = 6 must be accepted.