### PR TITLE
fix: allow device type selection when deployed without type

### DIFF
--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -115,7 +115,7 @@
         oneditprepare: function oneditprepare() {
             const { checkSelectedVirtualDevice, updateOutputs } = window.__victron;
 
-            if (this.id && this.changed === false) {
+            if (this.id && this.changed === false && this.device && this.device !== '') {
                 $('#node-input-device')
                     .prop('disabled', true)
                     .attr('title', 'Device type cannot be changed after deployment.');


### PR DESCRIPTION
Fixes an issue where a virtual device was deployed without selecting a type first.
