### PR TITLE
refactor: rename Motor drive to E-drive in UI

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -620,7 +620,7 @@
 
   function checkSelectedVirtualDevice (context) {
     [
-      'acload', 'battery', 'generator', 'gps', 'grid', 'motordrive',
+      'acload', 'battery', 'generator', 'gps', 'grid', 'e-drive',
       'pvinverter', 'switch', 'tank', 'temperature'
     ].forEach(x => { $('.input-' + x).hide(); });
 

--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -5038,8 +5038,8 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 <script type="text/x-red" data-help-name="victron-input-motordrive">
 <h3>Details</h3>
 <p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>This is the motordrive node. See <a href="https://bitbucket.org/oceanvolt/dbus_motordrive/src">https://bitbucket.org/oceanvolt/dbus_motordrive/src</a> for more information.</p>
-<h3>Motordrive</h3>
+<p>This is the E-drive node. See <a href="https://bitbucket.org/oceanvolt/dbus_motordrive/src">https://bitbucket.org/oceanvolt/dbus_motordrive/src</a> for more information.</p>
+<h3>E-drive</h3>
 <dl class="message-properties">
   <dt class="optional">Controller Temperature (°C)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Controller/Temperature</b><span class="property-mode"></span>
@@ -5065,8 +5065,8 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 <script type="text/x-red" data-help-name="victron-output-motordrive">
 <h3>Details</h3>
 <p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>This is the motordrive node. See <a href="https://bitbucket.org/oceanvolt/dbus_motordrive/src">https://bitbucket.org/oceanvolt/dbus_motordrive/src</a> for more information.</p>
-<h3>Motordrive</h3>
+<p>This is the E-drive node. See <a href="https://bitbucket.org/oceanvolt/dbus_motordrive/src">https://bitbucket.org/oceanvolt/dbus_motordrive/src</a> for more information.</p>
+<h3>E-drive</h3>
 <dl class="message-properties">
   <dt class="optional">Controller Temperature (°C)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Controller/Temperature</b><span class="property-mode"></span>
@@ -5119,6 +5119,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Ac input <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> current limit (A)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/CurrentLimit</b><span class="property-mode"> (Mode: both)</span>
 </dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> current limit is adjustable<span class="property-type">enum</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/CurrentLimitIsAdjustable</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> frequency phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (Hz)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/F</b><span class="property-mode"></span>
 </dd>
@@ -5378,6 +5384,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Ac input <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> current limit (A)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/CurrentLimit</b><span class="property-mode"> (Mode: both)</span>
 </dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> current limit is adjustable<span class="property-type">enum</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/CurrentLimitIsAdjustable</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> frequency phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (Hz)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/F</b><span class="property-mode"></span>
 </dd>
@@ -7442,9 +7454,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>1 - AC Input 2</li>
   <li>240 - Disconnected</li>
 </ul></dd>
-  <dt class="optional">Active input current limit (A)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/CurrentLimit</b><span class="property-mode"> (Mode: both)</span>
-</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input frequency phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> (Hz)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/ActiveIn/L<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/F</b><span class="property-mode"></span>
 </dd>
@@ -7757,9 +7766,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>1 - AC Input 2</li>
   <li>240 - Disconnected</li>
 </ul></dd>
-  <dt class="optional">Active input current limit (A)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Ac/ActiveIn/CurrentLimit</b><span class="property-mode"> (Mode: both)</span>
-</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input frequency phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> (Hz)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/ActiveIn/L<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/F</b><span class="property-mode"></span>
 </dd>

--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -533,7 +533,7 @@
     registerInputNode('victron-input-gridmeter', 'Grid Meter', 'gridmeter');
     registerInputNode('victron-input-inverter', 'Inverter', 'inverter');
     registerInputNode('victron-input-meteo', 'Meteo', 'meteo');
-    registerInputNode('victron-input-motordrive', 'Motordrive', 'motordrive');
+    registerInputNode('victron-input-motordrive', 'E-drive', 'motordrive');
     registerInputNode('victron-input-multi', 'Multi RS', 'multi');
     registerInputNode('victron-input-pulsemeter', 'Pulsemeter', 'pulsemeter');
     registerInputNode('victron-input-pump', 'Pump', 'pump');

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -530,7 +530,7 @@ export function updateBatteryVoltageVisibility () {
 
 export function checkSelectedVirtualDevice (context) {
   [
-    'acload', 'battery', 'generator', 'gps', 'grid', 'motordrive',
+    'acload', 'battery', 'generator', 'gps', 'grid', 'e-drive',
     'pvinverter', 'switch', 'tank', 'temperature'
   ].forEach(x => { $('.input-' + x).hide() })
 

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -126,6 +126,10 @@
         oneditprepare: function oneditprepare() {
             const { checkSelectedVirtualDevice, updateOutputs } = window.__victron;
 
+            if (this.device === 'motordrive') {
+                this.device = 'e-drive';
+            }
+
             if (this.id && this.changed === false && this.device && this.device !== '') {
                 $('#node-input-device')
                     .prop('disabled', true)
@@ -231,11 +235,11 @@
         <select id="node-input-device" required>
             <option value="acload">AC Load</option>
             <option value="battery">Battery</option>
+            <option value="e-drive">E-drive</option>
             <option value="generator">Generator</option>
             <option value="gps">GPS</option>
             <option value="grid">Grid meter</option>
             <option value="meteo">Meteo</option>
-            <option value="motordrive">Motor drive</option>
             <option value="pvinverter">PV inverter</option>
             <option value="switch">Switch</option>
             <option value="tank">Tank sensor</option>
@@ -401,7 +405,7 @@
         </div>
     </div>
 
-    <div class="input-motordrive">
+    <div class="input-e-drive">
         <div class="form-row">
             <label>&nbsp;</label>
             <label for="node-input-include_motor_rpm" style="width:70%;">
@@ -535,10 +539,11 @@ Important note: Please be aware that using virtual devices on Victron systems ma
 
 To get started, pull a virtual device to the canvas and configure it. First the
 device type needs to be selected. At the moment the system supports:
+- AC Load
 - Battery
+- E-drive
 - Grid meter
 - Meteo
-- Motor drive
 - PV inverter
 - Switch
 - Tank sensor
@@ -598,6 +603,9 @@ path + value combination (recommended) or use the _Custom Control_ node.
 The AC Load device can be configured by selecting the number of phases (1 or 3)
 that are available on the device.
 
+Note that the S2 support is experimental and subject to change. Only enable it
+if you really know what you are doing.
+
 ### Battery
 
 The battery device allows for setting the capacity of the battery. The capacity
@@ -649,11 +657,11 @@ The meteo device only supports the irradiance and windspeed. Typically you
 would use it to send data from your weather stations to both a virtual meteo
 device and a virtual temperature sensor.
 
-### Motor drive
+### E-drive
 
-The motor drive device represents an electric drive system, which can be used for various electric propulsion applications such as boats or electric vehicles.
+The E-drive device represents an electric drive system, which can be used for various electric propulsion applications such as boats or electric vehicles.
 
-The basic parameters for a motor drive are voltage, current, and power, which function similar to a battery device. The motor drive can have both positive and negative values for current and power, depending on whether the motor is consuming power or regenerating (when braking or going downhill).
+The basic parameters for an E-drive are voltage, current, and power, which function similar to a battery device. The E-drive can have both positive and negative values for current and power, depending on whether the motor is consuming power or regenerating (when braking or going downhill).
 
 Additionally, you can enable optional monitoring parameters:
 - Motor RPM
@@ -688,7 +696,7 @@ console and attached screen of the GX device. Settings things like name and grou
 done while setting up in the edit panel, but can also be done from the GX device directly.
 On restart of Node-RED, the stored name and group will be applied again.
 
-The switch types correspond to the Venus OS dbus switch specification, which can be found 
+The switch types correspond to the Venus OS dbus switch specification, which can be found
 [here](https://github.com/victronenergy/venus/wiki/dbus#switch).
 
 For dimmable switches, an additional "Dimming" property is available that accepts

--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -300,7 +300,7 @@ const properties = {
 }
 
 function getIfaceDesc (dev) {
-  const actualDev = dev === 'generator' ? 'genset' : dev
+  const actualDev = dev === 'generator' ? 'genset' : dev === 'e-drive' ? 'motordrive' : dev
   if (!properties[actualDev]) {
     return {}
   }
@@ -323,7 +323,7 @@ function getIfaceDesc (dev) {
 }
 
 function getIface (dev) {
-  const actualDev = dev === 'generator' ? 'genset' : dev
+  const actualDev = dev === 'generator' ? 'genset' : dev === 'e-drive' ? 'motordrive' : dev
   if (!properties[actualDev]) {
     return {
       emit: function () {
@@ -574,7 +574,9 @@ module.exports = function (RED) {
 
       const actualDeviceType = config.device === 'generator'
         ? (config.generator_type === 'dc' ? 'dcgenset' : 'genset')
-        : config.device
+        : config.device === 'e-drive'
+          ? 'motordrive'
+          : config.device
 
       const serviceName = `com.victronenergy.${actualDeviceType}.virtual_${self.id}`
       const interfaceName = serviceName
@@ -836,7 +838,8 @@ module.exports = function (RED) {
             }
             break
           }
-          case 'motordrive': {
+          case 'motordrive':
+          case 'e-drive': {
             // Remove optional properties if not enabled
             if (!config.include_motor_temp) {
               delete ifaceDesc.properties['Motor/Temperature']
@@ -881,7 +884,7 @@ module.exports = function (RED) {
               }
             }
 
-            text = 'Virtual motor drive'
+            text = 'Virtual E-drive'
             // Add RPM and Direction to the node status text if they are enabled
             if (config.include_motor_rpm || config.include_motor_direction) {
               text += ' with'

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -3213,8 +3213,8 @@
     ]
   },
   "motordrive": {
-    "help": { 
-      "both": "<p>This is the motordrive node. See <a href=\"https://bitbucket.org/oceanvolt/dbus_motordrive/src\">https://bitbucket.org/oceanvolt/dbus_motordrive/src</a> for more information.</p>",
+    "help": {
+      "both": "<p>This is the E-drive node. See <a href=\"https://bitbucket.org/oceanvolt/dbus_motordrive/src\">https://bitbucket.org/oceanvolt/dbus_motordrive/src</a> for more information.</p>",
       "input": "",
       "output": ""
     },

--- a/test/service2doc.test.js
+++ b/test/service2doc.test.js
@@ -64,8 +64,9 @@ describe('Service Documentation Generator', () => {
   })
 
   test('generates complete HTML documentation', () => {
-    const doc = generateDocumentation(testServicesData, 'nodered')
-    
+    const registeredNodes = { inputNodes: new Set(['switch']), outputNodes: new Set(['switch']) }
+    const doc = generateDocumentation(testServicesData, registeredNodes, 'nodered')
+
     expect(doc).toContain('data-help-name="victron-input-switch"')
     expect(doc).toContain('data-help-name="victron-output-switch"')
     expect(doc).toContain('Wildcard Paths')
@@ -75,8 +76,9 @@ describe('Service Documentation Generator', () => {
   })
 
   test('generates complete markdown documentation', () => {
-    const doc = generateDocumentation(testServicesData, 'md')
-    
+    const registeredNodes = { inputNodes: new Set(['switch']), outputNodes: new Set(['switch']) }
+    const doc = generateDocumentation(testServicesData, registeredNodes, 'md')
+
     expect(doc).toContain('# Available Nodes')
     expect(doc).toContain('## Switch (input)')
     expect(doc).toContain('## Switch (output)')
@@ -98,9 +100,10 @@ describe('Service Documentation Generator', () => {
         ]
       }
     }
-    
-    const doc = generateDocumentation(simpleService, 'nodered')
-    
+
+    const registeredNodes = { inputNodes: new Set(['battery']), outputNodes: new Set() }
+    const doc = generateDocumentation(simpleService, registeredNodes, 'nodered')
+
     expect(doc).toContain('Battery voltage (V DC)')
     expect(doc).toContain('/Dc/0/Voltage')
     expect(doc).not.toContain('Wildcard Paths')


### PR DESCRIPTION
Renames "motordrive" to "E-drive" in user-facing strings and UI while maintaining dbus service name as 'motordrive' for compatibility. Existing flows with motordrive nodes will continue to work and auto-migrate to e-drive when edited.