### PR TITLE
fix: use msg.source_path instead of msg.path on virtual switch outputs

### DIFF
--- a/src/nodes/victron-virtual.js
+++ b/src/nodes/victron-virtual.js
@@ -1591,7 +1591,7 @@ module.exports = function (RED) {
                   outputMsgs[1] = {
                     payload: Number(propValue),
                     topic: `${node.name || 'Virtual ' + config.device}/${topicSuffix}`,
-                    path: '/SwitchableOutput/output_1/Dimming'
+                    source_path: '/SwitchableOutput/output_1/Dimming'
                   }
                   hasChanges = true
                 }
@@ -1606,7 +1606,7 @@ module.exports = function (RED) {
                   outputMsgs[1] = {
                     payload: propValue,
                     topic: `${node.name || 'Virtual ' + config.device}/state`,
-                    path: '/SwitchableOutput/output_1/State'
+                    source_path: '/SwitchableOutput/output_1/State'
                   }
                   hasChanges = true
                 }
@@ -1628,7 +1628,7 @@ module.exports = function (RED) {
                 outputMsgs[2] = {
                   payload: propValue,
                   topic: `${node.name || 'Virtual ' + config.device}/${topicLabel.toLowerCase()}`,
-                  path: '/SwitchableOutput/output_1/Dimming'
+                  source_path: '/SwitchableOutput/output_1/Dimming'
                 }
                 hasChanges = true
               }
@@ -1650,7 +1650,7 @@ module.exports = function (RED) {
                 outputMsgs[2] = {
                   payload: propValue, // Send the array directly
                   topic: `${node.name || 'Virtual ' + config.device}/${topicLabel.toLowerCase()}`,
-                  path: '/SwitchableOutput/output_1/LightControls',
+                  source_path: '/SwitchableOutput/output_1/LightControls',
                   rgb, // RGB as #RRGGBB string
                   hsb: { hue, saturation, brightness }, // HSB object
                   white, // White level (0-100%)


### PR DESCRIPTION
Prevents `msg.path` from overriding configured paths in downstream control nodes when using secondary or third outputs.