### PR TITLE
Fix/issue 224 relay control

### DIFF
--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -132,7 +132,7 @@ class SystemConfiguration {
 
     // Filter all paths that begin with '/Relay'.
     // Construct and return an array of relay nodes representing their settings.
-    return Object.entries(this.cache)
+    const services = Object.entries(this.cache)
       .reduce((acc, [service, pathObj]) => {
         const relayPaths = Object.keys(pathObj).filter(path => path.startsWith('/Relay'))
         if (relayPaths.length) {
@@ -143,6 +143,11 @@ class SystemConfiguration {
         }
         return acc
       }, [])
+
+    return {
+      communityTag: _.get(utils.SERVICES, ['relay', 'communityTag']) || null,
+      services
+    }
   }
 
   getCachedServices () {

--- a/test/relay-expansion.test.js
+++ b/test/relay-expansion.test.js
@@ -38,14 +38,16 @@ describe('SystemConfiguration.getRelayServices wildcard expansion (PR #256)', ()
   test('getRelayServices returns relay services when paths exist in cache', () => {
     const result = systemConfig.getRelayServices()
 
-    expect(Array.isArray(result)).toBe(true)
-    
+    expect(result).toHaveProperty('communityTag')
+    expect(result).toHaveProperty('services')
+    expect(Array.isArray(result.services)).toBe(true)
+
     // Should find system service with relay paths
-    if (result.length > 0) {
-      const systemService = result.find(service => 
+    if (result.services.length > 0) {
+      const systemService = result.services.find(service =>
         service.service === 'com.victronenergy.system/0'
       )
-      
+
       if (systemService) {
         expect(systemService.name).toBe('Venus device')
         expect(systemService.paths).toBeDefined()
@@ -62,16 +64,18 @@ describe('SystemConfiguration.getRelayServices wildcard expansion (PR #256)', ()
         system: [] // Empty array - no relay definitions
       }
     }
-    
+
     // Should not throw error even with missing relay definitions (this is what PR #256 fixes)
     expect(() => {
       const result = systemConfig.getRelayServices()
-      expect(Array.isArray(result)).toBe(true)
+      expect(result).toHaveProperty('services')
+      expect(Array.isArray(result.services)).toBe(true)
     }).not.toThrow()
-    
+
     // The function should complete without crashing (core fix for issue #253)
     const result = systemConfig.getRelayServices()
-    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveProperty('services')
+    expect(Array.isArray(result.services)).toBe(true)
   })
 
   test('getRelayServices filters out null relay objects', () => {
@@ -91,32 +95,35 @@ describe('SystemConfiguration.getRelayServices wildcard expansion (PR #256)', ()
         ]
       }
     }
-    
+
     const result = systemConfig.getRelayServices()
-    
+
     // Should handle null objects gracefully
     expect(() => {
       const result = systemConfig.getRelayServices()
-      expect(Array.isArray(result)).toBe(true)
+      expect(result).toHaveProperty('services')
+      expect(Array.isArray(result.services)).toBe(true)
     }).not.toThrow()
   })
 
   test('getRelayServices handles empty cache gracefully', () => {
     systemConfig.cache = {}
-    
+
     const result = systemConfig.getRelayServices()
-    
-    expect(Array.isArray(result)).toBe(true)
-    expect(result.length).toBe(0)
+
+    expect(result).toHaveProperty('services')
+    expect(Array.isArray(result.services)).toBe(true)
+    expect(result.services.length).toBe(0)
   })
 
   test('getRelayServices handles system relay function check', () => {
     // Test the system relay function logic (manual vs non-manual)
     systemConfig.cache['com.victronenergy.settings']['/Settings/Relay/Function'] = 1 // non-manual
-    
+
     expect(() => {
       const result = systemConfig.getRelayServices()
-      expect(Array.isArray(result)).toBe(true)
+      expect(result).toHaveProperty('services')
+      expect(Array.isArray(result.services)).toBe(true)
     }).not.toThrow()
   })
 
@@ -128,7 +135,7 @@ describe('SystemConfiguration.getRelayServices wildcard expansion (PR #256)', ()
         system: [
           {
             path: '/Relay/{relay}/State',
-            type: 'enum', 
+            type: 'enum',
             name: 'Venus relay {relay} state',
             enum: { '0': 'Open', '1': 'Closed' },
             mode: 'both'
@@ -136,11 +143,12 @@ describe('SystemConfiguration.getRelayServices wildcard expansion (PR #256)', ()
         ]
       }
     }
-    
+
     // Test that wildcard expansion doesn't break the function
     expect(() => {
       const result = systemConfig.getRelayServices()
-      expect(Array.isArray(result)).toBe(true)
+      expect(result).toHaveProperty('services')
+      expect(Array.isArray(result.services)).toBe(true)
     }).not.toThrow()
   })
 })


### PR DESCRIPTION
Fix getRelayServices() to return communityTag structure (issue #224)