### PR TITLE
switch name and group, sync from dbus cache

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -581,6 +581,26 @@
     }
   }
 
+  function fetchSwitchNodeNameAndGroupFromCache (id) {
+    if (!id) {
+      return Promise.reject(new Error('id is required'))
+    }
+
+    return fetch(`/victron/cache?filter_by_serial=${id}`)
+      .then(response => response.json())
+      .then(data => {
+        for (const key in data) {
+          if (key.match(/^com.victronenergy\./) && data[key]['/Serial'] === id) {
+            const name = data[key]['/SwitchableOutput/output_1/Settings/CustomName'];
+            const group = data[key]['/SwitchableOutput/output_1/Settings/Group'];
+            return { name, group }
+          }
+        }
+        // No matching entry found
+        return {}
+      })
+  }
+
   function updateSwitchConfig (context) {
     const container = $('#switch-config-container');
     container.empty();
@@ -792,6 +812,7 @@
     updateSwitchConfig,
     checkSelectedVirtualDevice,
     validateSwitchConfig,
+    fetchSwitchNodeNameAndGroupFromCache,
     updateBatteryVoltageVisibility,
     calculateOutputs,
     updateOutputs,

--- a/src/nodes/config-client.js
+++ b/src/nodes/config-client.js
@@ -43,9 +43,12 @@ module.exports = function (RED) {
     }
   })
 
-  RED.httpNode.get('/victron/cache', RED.auth.needsPermission('victron-client.read'), (_req, res) => {
+  RED.httpNode.get('/victron/cache', RED.auth.needsPermission('victron-client.read'), (req, res) => {
     if (!globalClient) return res.status(503).send('Client not initialized')
-    const serialized = utils.mapCacheToJsonResponse(globalClient.system.cache)
+    const filtered = utils.filterCache(globalClient.system.cache, {
+      filterBySerial: req.query.filter_by_serial
+    })
+    const serialized = utils.mapCacheToJsonResponse(filtered)
     res.setHeader('Content-Type', 'application/json')
     return res.send(serialized)
   })

--- a/src/nodes/victron-virtual-browser.js
+++ b/src/nodes/victron-virtual-browser.js
@@ -6,6 +6,7 @@ import {
   updateSwitchConfig,
   checkSelectedVirtualDevice,
   validateSwitchConfig,
+  fetchSwitchNodeNameAndGroupFromCache,
   updateBatteryVoltageVisibility,
   calculateOutputs,
   updateOutputs
@@ -19,6 +20,7 @@ window.__victron = {
   updateSwitchConfig,
   checkSelectedVirtualDevice,
   validateSwitchConfig,
+  fetchSwitchNodeNameAndGroupFromCache,
   updateBatteryVoltageVisibility,
   calculateOutputs,
   updateOutputs,

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -453,6 +453,26 @@ function renderDropdownLabels (context) {
   }
 }
 
+export function fetchSwitchNodeNameAndGroupFromCache (id) {
+  if (!id) {
+    return Promise.reject(new Error('id is required'))
+  }
+
+  return fetch(`/victron/cache?filter_by_serial=${id}`)
+    .then(response => response.json())
+    .then(data => {
+      for (const key in data) {
+        if (key.match(/^com.victronenergy\./) && data[key]['/Serial'] === id) {
+          const name = data[key]['/SwitchableOutput/output_1/Settings/CustomName']
+          const group = data[key]['/SwitchableOutput/output_1/Settings/Group']
+          return { name, group }
+        }
+      }
+      // No matching entry found
+      return {}
+    })
+}
+
 export function updateSwitchConfig (context) {
   const container = $('#switch-config-container')
   container.empty()

--- a/src/nodes/victron-virtual-switch.html
+++ b/src/nodes/victron-virtual-switch.html
@@ -68,7 +68,12 @@
             return 'Output ' + (index + 1)
         },
         oneditprepare: function oneditprepare() {
-            const { renderSwitchConfigRow, updateOutputs, initializeTooltips } = window.__victron;
+            const {
+                renderSwitchConfigRow,
+                updateOutputs,
+                initializeTooltips, 
+                fetchSwitchNodeNameAndGroupFromCache
+            } = window.__victron;
 
             this.device = 'switch';
             renderSwitchConfigRow(this);
@@ -83,6 +88,18 @@
             if (typeof initializeTooltips === 'function') {
                 initializeTooltips();
             }
+
+            fetchSwitchNodeNameAndGroupFromCache(this.id).then(({name, group}) => {
+                if (name) {
+                    $(`#node-input-switch_1_customname`).val(name);
+                }
+                if (group) {
+                    $(`#node-input-switch_1_group`).val(group);
+                }
+            }).catch(error => {
+                console.error('Error fetching name and group from cache for switch node:', error);
+            });
+
         },
         oneditsave: function() {
             const { validateSwitchConfig, SWITCH_TYPE_CONFIGS, updateOutputs } = window.__victron;

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -284,6 +284,25 @@ function mapCacheToJsonResponse (cache) {
 }
 
 /**
+ * Filter cache, so that the result can be limited for efficiency.
+ * For now, the only filter supported is by device serial.
+ */
+function filterCache (cache, options = {}) {
+  const { filterBySerial } = options
+  if (!filterBySerial) {
+    return cache
+  }
+
+  const filteredCache = {}
+  for (const [device, paths] of Object.entries(cache)) {
+    if (filterBySerial && device.match(/^com\.victronenergy\./) && paths['/Serial'] === filterBySerial) {
+      filteredCache[device] = paths
+    }
+  }
+  return filteredCache
+}
+
+/**
  * Validates that a payload object is valid for setting virtual device values
  * @param {any} payload - The payload to validate
  * @returns {{ valid: boolean, error?: string, invalidKeys?: string[] }}
@@ -454,6 +473,7 @@ module.exports = {
   expandWildcardPaths,
   mapCacheValueToJsonResponseValue,
   mapCacheToJsonResponse,
+  filterCache,
   validateVirtualDevicePayload,
   validateLightControls,
   debounce,


### PR DESCRIPTION
name and group of a switch might have been changed outside of Node-RED. In this case, we have the old values in the Node-RED flow, so we retrieve the updated values from the cache we maintain of dbus values.
