### PR TITLE
Add linting on git commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+npm run build
+npm run build:test
+npm run lint
+npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
                 "eslint": "^9.26.0",
                 "eslint-config-google": "^0.14.0",
                 "gar": "^1.0.4",
+                "husky": "^9.1.7",
                 "jest": "^29.7.0",
-                "pre-commit": "^1.2.2",
                 "rollup": "^4.50.0",
                 "standard": "^17.1.2",
                 "yargs": "^17.7.2"
@@ -2631,33 +2631,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "engines": [
-                "node >= 0.8"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
-        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -4319,6 +4296,22 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/husky": {
+            "version": "9.1.7",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "husky": "bin.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/typicode"
             }
         },
         "node_modules/ignore": {
@@ -6209,15 +6202,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/os-shim": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-            "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/own-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -6558,85 +6542,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/pre-commit": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-            "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^5.0.1",
-                "spawn-sync": "^1.0.15",
-                "which": "1.2.x"
-            }
-        },
-        "node_modules/pre-commit/node_modules/cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            }
-        },
-        "node_modules/pre-commit/node_modules/lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
-        },
-        "node_modules/pre-commit/node_modules/shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "shebang-regex": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pre-commit/node_modules/shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pre-commit/node_modules/which": {
-            "version": "1.2.14",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-            "integrity": "sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "which": "bin/which"
-            }
-        },
-        "node_modules/pre-commit/node_modules/yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6674,13 +6579,6 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
-        },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
@@ -6727,13 +6625,6 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -6796,36 +6687,6 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/readable-stream/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true,
             "license": "MIT"
         },
@@ -7347,18 +7208,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "node_modules/spawn-sync": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-            "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "concat-stream": "^1.4.7",
-                "os-shim": "^0.1.2"
-            }
-        },
         "node_modules/split": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -7767,23 +7616,6 @@
                 "through": "~2.3.4"
             }
         },
-        "node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/string-length": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -8181,13 +8013,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/unbox-primitive": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -8254,13 +8079,6 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,82 +1,79 @@
 {
-    "name": "@victronenergy/node-red-contrib-victron",
-    "description": "Custom Node-RED Nodes for Victron Energy",
-    "version": "1.6.56",
-    "dependencies": {
-        "dbus-native-victron": "^0.4.5",
-        "dbus-victron-virtual": "^0.1.28",
-        "debug": "^4.4.0",
-        "lodash": "^4.17.21",
-        "promise-retry": "^2.0.1"
+  "name": "@victronenergy/node-red-contrib-victron",
+  "description": "Custom Node-RED Nodes for Victron Energy",
+  "version": "1.6.56",
+  "dependencies": {
+    "dbus-native-victron": "^0.4.5",
+    "dbus-victron-virtual": "^0.1.28",
+    "debug": "^4.4.0",
+    "lodash": "^4.17.21",
+    "promise-retry": "^2.0.1"
+  },
+  "files": [
+    "examples",
+    "src",
+    "resources",
+    "LICENSE"
+  ],
+  "node-red": {
+    "nodes": {
+      "victron-client": "./src/nodes/config-client.js",
+      "victron-nodes": "./src/nodes/victron-nodes.js",
+      "victron-virtual": "./src/nodes/victron-virtual.js",
+      "victron-virtual-switch": "./src/nodes/victron-virtual-switch.js",
+      "victron-inject": "./src/nodes/victron-inject.js"
     },
-    "files": [
-        "examples",
-        "src",
-        "resources",
-        "LICENSE"
+    "version": ">=3.0.2"
+  },
+  "devDependencies": {
+    "@babel/eslint-parser": "^7.27.1",
+    "@rollup/plugin-commonjs": "^28.0.6",
+    "@rollup/plugin-node-resolve": "^16.0.2",
+    "csv-parse": "^5.6.0",
+    "eslint": "^9.26.0",
+    "eslint-config-google": "^0.14.0",
+    "gar": "^1.0.4",
+    "husky": "^9.1.7",
+    "jest": "^29.7.0",
+    "rollup": "^4.50.0",
+    "standard": "^17.1.2",
+    "yargs": "^17.7.2"
+  },
+  "keywords": [
+    "node-red"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "build:test": "rollup -c rollup.test.config.mjs",
+    "test": "npm run lint && npm run build && npm run build:test && npm run test:unit",
+    "test:unit": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "standard --fix src/ scripts/",
+    "verify": "npm test",
+    "prerelease": "npm run verify",
+    "release": "git tag -d v$npm_package_version; git tag v$npm_package_version && git push --tags && git push && npm run create-release",
+    "documentation": "bash -c '( sed \"/^<!--/q\" src/nodes/config-client.html && node scripts/service2doc.js -s src/services/services.json -r src/nodes/victron-nodes.html -o nodered ) | sponge src/nodes/config-client.html'",
+    "wiki": "bash -c 'node scripts/service2doc.js -s src/services/services.json -r src/nodes/victron-nodes.html -o md | sponge ../node-red-contrib-victron.wiki/Available-nodes.md'",
+    "prepare": "husky"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/victronenergy/node-red-contrib-victron"
+  },
+  "engines": {
+    "node": ">=14.17.4"
+  },
+  "license": "MIT",
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/test/**/*.test.js"
     ],
-    "node-red": {
-        "nodes": {
-            "victron-client": "./src/nodes/config-client.js",
-            "victron-nodes": "./src/nodes/victron-nodes.js",
-            "victron-virtual": "./src/nodes/victron-virtual.js",
-            "victron-virtual-switch": "./src/nodes/victron-virtual-switch.js",
-            "victron-inject": "./src/nodes/victron-inject.js"
-        },
-        "version": ">=3.0.2"
-    },
-    "devDependencies": {
-        "@babel/eslint-parser": "^7.27.1",
-        "@rollup/plugin-commonjs": "^28.0.6",
-        "@rollup/plugin-node-resolve": "^16.0.2",
-        "csv-parse": "^5.6.0",
-        "eslint": "^9.26.0",
-        "eslint-config-google": "^0.14.0",
-        "gar": "^1.0.4",
-        "jest": "^29.7.0",
-        "pre-commit": "^1.2.2",
-        "rollup": "^4.50.0",
-        "standard": "^17.1.2",
-        "yargs": "^17.7.2"
-    },
-    "keywords": [
-        "node-red"
-    ],
-    "scripts": {
-        "build": "rollup -c",
-        "build:test": "rollup -c rollup.test.config.mjs",
-        "test": "npm run lint && npm run build && npm run build:test && npm run test:unit",
-        "test:unit": "jest",
-        "test:coverage": "jest --coverage",
-        "lint": "standard --fix src/ scripts/",
-        "verify": "npm test",
-        "prerelease": "npm run verify",
-        "release": "git tag -d v$npm_package_version; git tag v$npm_package_version && git push --tags && git push && npm run create-release",
-        "documentation": "bash -c '( sed \"/^<!--/q\" src/nodes/config-client.html && node scripts/service2doc.js -s src/services/services.json -r src/nodes/victron-nodes.html -o nodered ) | sponge src/nodes/config-client.html'",
-        "wiki": "bash -c 'node scripts/service2doc.js -s src/services/services.json -r src/nodes/victron-nodes.html -o md | sponge ../node-red-contrib-victron.wiki/Available-nodes.md'"
-    },
-    "pre-commit": [
-        "lint",
-        "test"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/victronenergy/node-red-contrib-victron"
-    },
-    "engines": {
-        "node": ">=14.17.4"
-    },
-    "license": "MIT",
-    "jest": {
-        "testEnvironment": "node",
-        "testMatch": [
-            "**/test/**/*.test.js"
-        ],
-        "collectCoverage": true,
-        "coverageDirectory": "coverage",
-        "coverageReporters": [
-            "text",
-            "lcov"
-        ]
-    }
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ]
+  }
 }


### PR DESCRIPTION
Add [husky](https://typicode.github.io/husky/) to utilize git hooks to run the linter before committing.

Only works if/when developer does an `npm install` after this change.

@dirkjanfaber and I observed various times that, even though we *think* we used the linter, we ended up with diffs that had whitespace changes in unintended locations. Adding linting (and also building derived code via rollup etc, and unit-testing) automatically with each commit should help.