### PR TITLE
fix(virtual-switch): Add DeviceInstance and Serial to interface descr…

### DIFF
--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -70,6 +70,9 @@ function createSwitchProperties (config, ifaceDesc, iface) {
     persist: true
   }
 
+  ifaceDesc.properties.DeviceInstance = { type: 'i' }
+  ifaceDesc.properties.Serial = { type: 's', persist: true }
+
   // Add base properties for all switch types
   baseProperties.forEach(({ name, type, value, format, persist, immediate, min, max }) => {
     const switchableOutputPropertyKey = `SwitchableOutput/output_1/${name}`


### PR DESCRIPTION
…iption

The DeviceInstance and Serial paths were not being exposed on D-Bus because they were missing from ifaceDesc.properties. The values were set on iface but without the property definitions in the interface description.

Solves issue #372