### PR TITLE
stop persisting CustomName and Group for virtual switches

### DIFF
--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -33,8 +33,8 @@ function createSwitchProperties (config, ifaceDesc, iface) {
     { name: 'Name', type: 's', persist: true },
 
     // we need value to be '' for Group and CustomName, compare logic below where we set iface[switchableOutputPropertyKey]
-    { name: 'Settings/Group', type: 's', value: '', persist: true },
-    { name: 'Settings/CustomName', type: 's', value: '', persist: true },
+    { name: 'Settings/Group', type: 's', value: '', persist: false },
+    { name: 'Settings/CustomName', type: 's', value: '', persist: false },
 
     {
       name: 'Settings/Type',


### PR DESCRIPTION
This resolves 'source of truth' issues when changing in multiple locations (dbus vs flow vs persisted file vs gui v2). Plan is to also stop editing those via gui v2, then the source of truth for those properties is the node-red flow only.