### PR TITLE
fix(notification): Accept string numbers for notification type

### DIFF
--- a/src/nodes/victron-inject-functions.js
+++ b/src/nodes/victron-inject-functions.js
@@ -59,7 +59,12 @@ function validateNotificationInput (payload, type, title) {
       info: 2
     }
     const typeLower = type.toLowerCase()
-    if (typeLower in typeMap) {
+
+    // Check if the string is a number between 0 and 2
+    const parsedType = parseInt(type, 10)
+    if (!isNaN(parsedType) && parsedType >= 0 && parsedType <= 2) {
+      typeNum = parsedType
+    } else if (typeLower in typeMap) {
       typeNum = typeMap[typeLower]
     } else {
       return {

--- a/test/victron-inject-functions.test.js
+++ b/test/victron-inject-functions.test.js
@@ -68,6 +68,15 @@ describe('victron-inject-functions', () => {
         expect(result.message).toBe('Test message')
       })
 
+      it.each(['0', '1', '2'])('should accept valid payload with type as string "%s"', (typeString) => {
+        const typeNum = parseInt(typeString, 10);
+        const result = validateNotificationInput('Test message', typeString, 'Test Title');
+        expect(result.valid).toBe(true);
+        expect(result.type).toBe(typeNum);
+        expect(result.title).toBe('Test Title');
+        expect(result.message).toBe('Test message');
+      });
+
       it('should accept valid payload with type as "warning"', () => {
         const result = validateNotificationInput('Warning message', 'warning', 'Warning Title')
         expect(result.valid).toBe(true)


### PR DESCRIPTION
Refactor validateNotificationInput to correctly parse string representations of 0, 1, and 2 as valid notification types. Updated unit tests to use a parameterized test for these cases.