### PR TITLE
fix(conditional): prefer service with most paths when deduplicating condition 2 dropdown

### DIFF
--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -310,7 +310,10 @@
                         allServices[key].services.forEach(function(service) {
                             if (service.service) {
                                 const dedupeKey = service.service + ':' + (service.deviceInstance || '');
-                                serviceMap[dedupeKey] = service;
+                                const existing = serviceMap[dedupeKey];
+                                if (!existing || service.paths.length > existing.paths.length) {
+                                    serviceMap[dedupeKey] = service;
+                                }
                             }
                         });
                     }


### PR DESCRIPTION
Tank sensors appear in both input-tank and input-temperature service lists. The last-write-wins dedup caused input-temperature (only 2 paths) to overwrite input-tank (full path list), hiding /Level from the condition 2 path dropdown.

Easiest test is with a deployed virtual tank sensor and a temperature input sensor and enabling the second condition. Before this patch the _tank sensor_ didn't show the level. 

<img width="485" height="197" alt="image" src="https://github.com/user-attachments/assets/8c787675-8775-4630-ada7-85368fa0b865" />