### PR TITLE
fixes a visual issue with the toggle to switch between AND and OR

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # ensure there are no manual changes to ./resources before committing
-git diff-index --quiet HEAD -- ./resources || (echo "manual changes to ./resources, they would get overwritten by 'npm run build'. Abort." && false)
+git diff-index --quiet HEAD -- ./resources/*.js || (echo "manual changes to ./resources, they would get overwritten by 'npm run build'. Abort." && false)
 
 # call lint-staged, see ./package.json for configuration
 npx lint-staged

--- a/resources/victron-styles.css
+++ b/resources/victron-styles.css
@@ -523,6 +523,10 @@
   overflow: hidden;
 }
 
+.victron-form .victron-logic-toggle .victron-logic-option {
+  display: inline-block;
+}
+
 .victron-form .victron-logic-option {
   flex: 1;
   margin: 0;


### PR DESCRIPTION
This fixes a css visual issue with the "AND/OR" toggle when using conditional logic in the Custom Input node.

Further to the above, I had to adjust the husky pre-commit hook: We currently fail the commit, if anything in ./resources is changed; this is too strict, as the css files (and also the svg files) live under ./resources, and we do need to change those there.
