### PR TITLE
feat(virtual): add split phase option to virtual AC-load

### DIFF
--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -181,7 +181,7 @@
             if (this.device === 'acload') {
                 // Ensure number of phases is valid
                 this.acload_nrofphases = parseInt(this.acload_nrofphases) || 1;
-                if (![1, 3].includes(this.acload_nrofphases)) {
+                if (![1, 2, 3].includes(this.acload_nrofphases)) {
                     this.acload_nrofphases = 1;
                 }
             }
@@ -289,6 +289,7 @@
             <label for="node-input-acload_nrofphases"><i class="fa fa-plug"></i> Number of phases</label>
             <select id="node-input-acload_nrofphases">
                 <option value="1">1 phase</option>
+                <option value="2">Split phase</option>
                 <option value="3">3 phase</option>
             </select>
         </div>


### PR DESCRIPTION
Adds a "Split phase" (2L) option to the AC-load number-of-phases selector, commonly used in US installations. The backend loop already generates L1/L2 paths for NrOfPhases=2  - this was purely a UI restriction.

Closes #388