### PR TITLE
feat(virtual): add virtual pulse meter device type

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -743,6 +743,31 @@
     </div>
   `,
       img: null
+    },
+    pulsemeter: {
+      label: 'Pulse meter',
+      text: `
+    ${INPUT_DOCS}
+    <div>
+      <div><strong>Most relevant paths:</strong>
+        <ul>
+          <li><code>/Count</code> &mdash; Cumulative pulse count (integer). The raw counter value from the pulse source.</li>
+          <li><code>/Aggregate</code> &mdash; Measured aggregate value in m&sup3; (float). Set this directly in dumb mode, or let it be computed automatically from Count when auto-compute is enabled.</li>
+        </ul>
+        <p>When <em>Auto-compute Aggregate</em> is enabled, Aggregate is derived as <code>Count &times; multiplier</code> whenever Count changes. For example, with multiplier <code>0.001</code> each pulse represents 1 litre (1000 pulses = 1 m&sup3;).</p>
+        <p>For more information on available paths, see the <a href="https://github.com/victronenergy/venus/wiki/dbus" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS dbus specification</a>.</p>
+      </div>
+    </div>
+    <div>
+      <div><strong>Output:</strong>
+        <ol>
+          <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
+          <li><code>Aggregate</code> &mdash; Emits <tt>msg.payload</tt> with the current Aggregate value whenever it changes</li>
+        </ol>
+      </div>
+    </div>
+  `,
+      img: null
     }
   };
 
@@ -1057,7 +1082,7 @@
   function checkSelectedVirtualDevice (context) {
     [
       'acload', 'battery', 'generator', 'gps', 'grid', 'e-drive',
-      'pvinverter', 'switch', 'tank', 'temperature'
+      'pulsemeter', 'pvinverter', 'switch', 'tank', 'temperature'
     ].forEach(x => { $('.input-' + x).hide(); });
 
     const selected = $('select#node-input-device').val();
@@ -1088,6 +1113,13 @@
         $('#tank_battery-voltage-row').toggle($(this).is(':checked'));
       });
       $('#tank_battery-voltage-row').toggle($('#node-input-include_tank_battery').is(':checked'));
+    }
+
+    if (selected === 'pulsemeter') {
+      $('#node-input-auto_aggregate').off('change').on('change', function () {
+        $('#pulsemeter-multiplier-row').toggle($(this).is(':checked'));
+      });
+      $('#pulsemeter-multiplier-row').toggle($('#node-input-auto_aggregate').is(':checked'));
     }
 
     if (selected === 'generator') {
@@ -1209,7 +1241,8 @@
         return 2 // passthrough + signals
       }
       return 1
-    }
+    },
+    pulsemeter: () => 2
   };
 
   /**

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -481,6 +481,31 @@ export const DEVICE_TYPE_DOCS = {
     </div>
   `,
     img: null
+  },
+  pulsemeter: {
+    label: 'Pulse meter',
+    text: `
+    ${INPUT_DOCS}
+    <div>
+      <div><strong>Most relevant paths:</strong>
+        <ul>
+          <li><code>/Count</code> &mdash; Cumulative pulse count (integer). The raw counter value from the pulse source.</li>
+          <li><code>/Aggregate</code> &mdash; Measured aggregate value in m&sup3; (float). Set this directly in dumb mode, or let it be computed automatically from Count when auto-compute is enabled.</li>
+        </ul>
+        <p>When <em>Auto-compute Aggregate</em> is enabled, Aggregate is derived as <code>Count &times; multiplier</code> whenever Count changes. For example, with multiplier <code>0.001</code> each pulse represents 1 litre (1000 pulses = 1 m&sup3;).</p>
+        <p>For more information on available paths, see the <a href="https://github.com/victronenergy/venus/wiki/dbus" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS dbus specification</a>.</p>
+      </div>
+    </div>
+    <div>
+      <div><strong>Output:</strong>
+        <ol>
+          <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
+          <li><code>Aggregate</code> &mdash; Emits <tt>msg.payload</tt> with the current Aggregate value whenever it changes</li>
+        </ol>
+      </div>
+    </div>
+  `,
+    img: null
   }
 }
 
@@ -795,7 +820,7 @@ export function updateBatteryVoltageVisibility () {
 export function checkSelectedVirtualDevice (context) {
   [
     'acload', 'battery', 'generator', 'gps', 'grid', 'e-drive',
-    'pvinverter', 'switch', 'tank', 'temperature'
+    'pulsemeter', 'pvinverter', 'switch', 'tank', 'temperature'
   ].forEach(x => { $('.input-' + x).hide() })
 
   const selected = $('select#node-input-device').val()
@@ -826,6 +851,13 @@ export function checkSelectedVirtualDevice (context) {
       $('#tank_battery-voltage-row').toggle($(this).is(':checked'))
     })
     $('#tank_battery-voltage-row').toggle($('#node-input-include_tank_battery').is(':checked'))
+  }
+
+  if (selected === 'pulsemeter') {
+    $('#node-input-auto_aggregate').off('change').on('change', function () {
+      $('#pulsemeter-multiplier-row').toggle($(this).is(':checked'))
+    })
+    $('#pulsemeter-multiplier-row').toggle($('#node-input-auto_aggregate').is(':checked'))
   }
 
   if (selected === 'generator') {
@@ -947,7 +979,8 @@ const DEVICE_TYPE_TO_NUM_OUTPUTS = {
       return 2 // passthrough + signals
     }
     return 1
-  }
+  },
+  pulsemeter: () => 2
 }
 
 /**
@@ -992,7 +1025,9 @@ export function getOutputLabels (context = {}) {
   const labels = []
   labels.push('Passthrough')
 
-  if (context.device === 'switch') {
+  if (context.device === 'pulsemeter') {
+    labels.push('Aggregate')
+  } else if (context.device === 'switch') {
     const switchType = Number(context.switch_1_type || 1)
     const outputCount = SWITCH_OUTPUT_CONFIG[switchType] || 2
 

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -64,6 +64,9 @@
                     return !isNaN(num) && num > 0;
                 }
             },
+            // pulsemeter
+            auto_aggregate: { value: false },
+            pulsemeter_multiplier: { value: 0.001, required: false },
             // temperature
             temperature_type: {value: 2, required: false},
             include_humidity: { value: false },
@@ -79,6 +82,9 @@
         },
         outputLabels: function(index) {
             // Inline logic since window.getOutputLabels may not be loaded yet
+            if (this.device === 'pulsemeter') {
+                return index === 0 ? 'Passthrough' : 'Aggregate'
+            }
             if (!this.device || this.device !== 'switch') {
                 return index === 0 ? 'Passthrough' : 'Output ' + (index + 1)
             }
@@ -410,6 +416,21 @@
             <div class="form-row" id="tank_battery-voltage-row" class="hidden-row">
                 <label for="node-input-tank_battery_voltage"><i class="fa fa-battery-full"></i> Battery Voltage (V)</label>
                 <input type="number" id="node-input-tank_battery_voltage" value="3.3" step="0.1" min="0">
+            </div>
+        </div>
+
+        <div class="input-pulsemeter">
+            <div class="form-row victron-checkbox">
+                <input type="checkbox" id="node-input-auto_aggregate">
+                <label for="node-input-auto_aggregate">Auto-compute Aggregate from Count</label>
+            </div>
+            <div class="form-row" id="pulsemeter-multiplier-row">
+                <label for="node-input-pulsemeter_multiplier">
+                    <i class="fa fa-tag"></i> Multiplier
+                    <i class="fa fa-info-circle tooltip-icon"
+                       data-tooltip="Aggregate = Count x multiplier. E.g. 0.001 for 1 pulse = 1 litre (Aggregate is in m3)."></i>
+                </label>
+                <input type="number" id="node-input-pulsemeter_multiplier" step="any" min="0">
             </div>
         </div>
 

--- a/src/nodes/victron-virtual/device-type/pulsemeter.js
+++ b/src/nodes/victron-virtual/device-type/pulsemeter.js
@@ -1,0 +1,31 @@
+const properties = {
+  Count: { type: 'i', format: (v) => v != null ? String(v) : '', persist: true, immediate: true },
+  Aggregate: { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'm³' : '', persist: true, immediate: true }
+}
+
+function onPropertyChanged (propName, propValue, iface, config) {
+  if (config.auto_aggregate && propName === 'Count' && propValue != null) {
+    const multiplier = Number(config.pulsemeter_multiplier)
+    if (!isNaN(multiplier) && multiplier > 0) {
+      const aggregate = propValue * multiplier
+      return {
+        setValues: { Aggregate: aggregate },
+        outputIndex: 1,
+        msg: { payload: aggregate, topic: '/Aggregate', source_path: '/Aggregate' }
+      }
+    }
+  }
+
+  if (propName === 'Aggregate' && propValue != null) {
+    return {
+      outputIndex: 1,
+      msg: { payload: propValue, topic: '/Aggregate', source_path: '/Aggregate' }
+    }
+  }
+}
+
+function initialize (config, ifaceDesc, iface, node) {
+  return 'Virtual pulse meter'
+}
+
+module.exports = { properties, initialize, onPropertyChanged, label: 'Pulse meter' }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -20,6 +20,7 @@ const gpsModule = require('./device-type/gps')
 const gridModule = require('./device-type/grid')
 const meteoModule = require('./device-type/meteo')
 const motordriveModule = require('./device-type/motordrive')
+const pulsemeterModule = require('./device-type/pulsemeter')
 const pvinverterModule = require('./device-type/pvinverter')
 const switchModule = require('./device-type/switch')
 const tankModule = require('./device-type/tank')
@@ -44,6 +45,7 @@ const properties = {
   genset: generatorModule.properties.genset,
   dcgenset: generatorModule.properties.dcgenset,
   grid: gridModule.properties,
+  pulsemeter: pulsemeterModule.properties,
   pvinverter: pvinverterModule.properties,
   meteo: meteoModule.properties,
   motordrive: motordriveModule.properties,
@@ -62,6 +64,7 @@ const deviceModules = {
   meteo: meteoModule,
   motordrive: motordriveModule,
   'e-drive': motordriveModule,
+  pulsemeter: pulsemeterModule,
   pvinverter: pvinverterModule,
   switch: switchModule,
   tank: tankModule,
@@ -76,6 +79,7 @@ const DEVICE_TYPES = [
   { value: 'gps', label: 'GPS' },
   { value: 'grid', label: 'Grid meter' },
   { value: 'meteo', label: 'Meteo' },
+  { value: 'pulsemeter', label: 'Pulse meter' },
   { value: 'pvinverter', label: 'PV inverter' },
   { value: 'switch', label: 'Switch (deprecated)' },
   { value: 'tank', label: 'Tank sensor' },
@@ -626,6 +630,11 @@ module.exports = function (RED) {
         // TODO: S2: Should we rename this?
         // We need to add a emitCallbackS2 for S2-related property changes
         // to be able to react to imocoming connection requests and messages.
+
+        // Track properties set as derived values so emitCallback skips re-processing them.
+        // This prevents infinite recursion when onPropertyChanged calls setValuesLocally.
+        const skipOnPropertyChanged = new Set()
+
         function emitCallback (event, data) {
           // we could use node.context().set('bla', 42) to set (and get) state, but state disappears on redeploy
           // for global context: node.context().global.set('bla', 43)
@@ -646,6 +655,32 @@ module.exports = function (RED) {
           // Legacy support: Handle outputs for existing Virtual Device (switch) nodes
           if (config.device === 'switch') {
             handleSwitchOutputs(config, node, propName, propValue)
+          }
+
+          // Skip onPropertyChanged for properties set as derived values (e.g. auto-computed Aggregate)
+          if (skipOnPropertyChanged.has(propName)) {
+            skipOnPropertyChanged.delete(propName)
+            return
+          }
+
+          // Allow device modules to react to property changes and compute derived values
+          const deviceModule = deviceModules[config.device]
+          if (deviceModule && typeof deviceModule.onPropertyChanged === 'function' && node.setValuesLocally) {
+            const result = deviceModule.onPropertyChanged(propName, propValue, iface, config)
+            if (result != null) {
+              // Set derived values (e.g. auto-compute Aggregate from Count).
+              // Mark them first so their emitCallback does not re-trigger onPropertyChanged.
+              if (result.setValues) {
+                Object.keys(result.setValues).forEach(k => skipOnPropertyChanged.add(k))
+                node.setValuesLocally(result.setValues)
+              }
+              // Send output message
+              if (result.msg != null) {
+                const outputs = new Array(config.outputs).fill(null)
+                outputs[result.outputIndex] = result.msg
+                node.send(outputs)
+              }
+            }
           }
         }
 

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -8,6 +8,7 @@ const gps = require('../src/nodes/victron-virtual/device-type/gps')
 const grid = require('../src/nodes/victron-virtual/device-type/grid')
 const meteo = require('../src/nodes/victron-virtual/device-type/meteo')
 const motordrive = require('../src/nodes/victron-virtual/device-type/motordrive')
+const pulsemeter = require('../src/nodes/victron-virtual/device-type/pulsemeter')
 const pvinverter = require('../src/nodes/victron-virtual/device-type/pvinverter')
 const switchMod = require('../src/nodes/victron-virtual/device-type/switch')
 const tank = require('../src/nodes/victron-virtual/device-type/tank')
@@ -398,6 +399,49 @@ describe('motordrive', () => {
       [99, 'unknown']
     ])('Motor/Direction %i → %s', (v, expected) => {
       expect(fmt(v)).toBe(expected)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// pulsemeter
+// ---------------------------------------------------------------------------
+
+describe('pulsemeter', () => {
+  describe('initialize', () => {
+    test('returns status text', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      const result = pulsemeter.initialize({}, ifaceDesc, iface, node)
+      expect(result).toBe('Virtual pulse meter')
+    })
+
+    test('does not modify ifaceDesc or iface', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      pulsemeter.initialize({}, ifaceDesc, iface, node)
+      expect(Object.keys(ifaceDesc.properties)).toHaveLength(0)
+      expect(Object.keys(iface)).toHaveLength(0)
+    })
+  })
+
+  describe('format', () => {
+    const countFmt = pulsemeter.properties.Count.format
+    const aggregateFmt = pulsemeter.properties.Aggregate.format
+
+    test.each([
+      [0, '0'],
+      [1000, '1000'],
+      [null, '']
+    ])('Count %s -> %s', (v, expected) => {
+      expect(countFmt(v)).toBe(expected)
+    })
+
+    test.each([
+      [1.0, '1.000m³'],
+      [0.5, '0.500m³'],
+      [1234.5678, '1234.568m³'],
+      [null, '']
+    ])('Aggregate %s -> %s', (v, expected) => {
+      expect(aggregateFmt(v)).toBe(expected)
     })
   })
 })

--- a/test/victron-virtual-outputs.test.js
+++ b/test/victron-virtual-outputs.test.js
@@ -1,4 +1,5 @@
 // test/victron-virtual-outputs.test.js
+/* eslint-env jest */
 const { calculateOutputs, getOutputLabels } = require('./fixtures/victron-virtual-functions.cjs')
 const { SWITCH_TYPE_MAP, SWITCH_OUTPUT_CONFIG } = require('../src/nodes/victron-virtual-constants')
 
@@ -14,6 +15,10 @@ describe('calculateOutputs', () => {
 
     test('meteo has 1 output (passthrough only)', () => {
       expect(calculateOutputs('meteo', {})).toBe(1)
+    })
+
+    test('pulsemeter has 2 outputs (passthrough + aggregate)', () => {
+      expect(calculateOutputs('pulsemeter', {})).toBe(2)
     })
 
     test('unknown device defaults to 1 output', () => {
@@ -129,6 +134,10 @@ describe('getOutputLabels', () => {
 
     test('gps has only passthrough label', () => {
       expect(getOutputLabels('gps', {})).toEqual(['Passthrough'])
+    })
+
+    test('pulsemeter has passthrough and aggregate labels', () => {
+      expect(getOutputLabels({ device: 'pulsemeter' })).toEqual(['Passthrough', 'Aggregate'])
     })
   })
 

--- a/test/victron-virtual-pulsemeter.test.js
+++ b/test/victron-virtual-pulsemeter.test.js
@@ -1,0 +1,73 @@
+// test/victron-virtual-pulsemeter.test.js
+/* eslint-env jest */
+const pulsemeter = require('../src/nodes/victron-virtual/device-type/pulsemeter')
+
+describe('pulsemeter device module', () => {
+  test('exports required contract', () => {
+    expect(typeof pulsemeter.properties).toBe('object')
+    expect(typeof pulsemeter.initialize).toBe('function')
+    expect(typeof pulsemeter.onPropertyChanged).toBe('function')
+  })
+
+  describe('onPropertyChanged - dumb mode', () => {
+    test('does not return setValues when auto_aggregate is false', () => {
+      const result = pulsemeter.onPropertyChanged('Count', 500, {}, { auto_aggregate: false, pulsemeter_multiplier: 0.001 })
+      expect(result).toBeUndefined()
+    })
+
+    test('does not react to non-Count property changes', () => {
+      const result = pulsemeter.onPropertyChanged('Aggregate', 1.0, {}, { auto_aggregate: true, pulsemeter_multiplier: 0.001 })
+      // Aggregate changes always produce output (not setValues)
+      expect(result).not.toHaveProperty('setValues')
+    })
+  })
+
+  describe('onPropertyChanged - smart mode', () => {
+    test('computes Aggregate from Count x multiplier', () => {
+      const result = pulsemeter.onPropertyChanged('Count', 1000, {}, { auto_aggregate: true, pulsemeter_multiplier: 0.001 })
+      expect(result.setValues.Aggregate).toBeCloseTo(1.0)
+    })
+
+    test('returns output message with computed Aggregate', () => {
+      const result = pulsemeter.onPropertyChanged('Count', 1000, {}, { auto_aggregate: true, pulsemeter_multiplier: 0.001 })
+      expect(result.outputIndex).toBe(1)
+      expect(result.msg.payload).toBeCloseTo(1.0)
+      expect(result.msg.topic).toBe('/Aggregate')
+    })
+
+    test('does not compute if Count is null', () => {
+      const result = pulsemeter.onPropertyChanged('Count', null, {}, { auto_aggregate: true, pulsemeter_multiplier: 0.001 })
+      expect(result).toBeUndefined()
+    })
+
+    test('does not compute if multiplier is zero', () => {
+      const result = pulsemeter.onPropertyChanged('Count', 100, {}, { auto_aggregate: true, pulsemeter_multiplier: 0 })
+      expect(result).toBeUndefined()
+    })
+
+    test('does not compute if multiplier is invalid', () => {
+      const result = pulsemeter.onPropertyChanged('Count', 100, {}, { auto_aggregate: true, pulsemeter_multiplier: 'bad' })
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('onPropertyChanged - output message', () => {
+    test('returns output message when Aggregate changes', () => {
+      const result = pulsemeter.onPropertyChanged('Aggregate', 1.5, {}, { auto_aggregate: false })
+      expect(result).toEqual({
+        outputIndex: 1,
+        msg: { payload: 1.5, topic: '/Aggregate', source_path: '/Aggregate' }
+      })
+    })
+
+    test('returns undefined for Count changes in dumb mode (no direct output)', () => {
+      const result = pulsemeter.onPropertyChanged('Count', 1000, {}, { auto_aggregate: false })
+      expect(result).toBeUndefined()
+    })
+
+    test('does not return output message when Aggregate is null', () => {
+      const result = pulsemeter.onPropertyChanged('Aggregate', null, {}, { auto_aggregate: false })
+      expect(result).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- New `pulsemeter` virtual device exposing `/Count` and `/Aggregate` on D-Bus
- Optional auto-compute: `Aggregate = Count × multiplier` when Count changes (default: 0.001 m³/pulse)
- 2 output ports: Passthrough and Aggregate (emits on every value change)
- Config dialog, full docs, and 100% test coverage on the new module

Closes #382

## Testing

Open the dialog and click Done to activate the 2nd output port. With auto-compute disabled, inject `{ Count: 1000, Aggregate: 1.0 }` and verify both values appear on D-Bus. With auto-compute enabled (multiplier 0.001), inject `{ Count: 1000 }` and verify `/Aggregate` = 1.0 on D-Bus and on output port 1. Also verify that changing `/Count` directly via D-Bus updates `/Aggregate` and emits on port 1.