### PR TITLE
fix: add evcharger session info

### DIFF
--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -2943,6 +2943,18 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Set charge current (manual mode) (A)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/SetCurrent</b><span class="property-mode"> (Mode: both)</span>
 </dd>
+  <dt class="optional">Session charging time (seconds)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Session/Time</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Session charging energy (kWh)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Session/Energy</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Session cost (no currency)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Session/Cost</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Session saved cost (no currency)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Session/SavedCost</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Start/stop charging (manual mode)<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/StartStop</b><span class="property-mode"> (Mode: both)</span>
 <ul>
@@ -3053,6 +3065,18 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional">Set charge current (manual mode) (A)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/SetCurrent</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional">Session charging time (seconds)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Session/Time</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Session charging energy (kWh)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Session/Energy</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Session cost (no currency)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Session/Cost</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Session saved cost (no currency)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Session/SavedCost</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">Start/stop charging (manual mode)<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/StartStop</b><span class="property-mode"> (Mode: both)</span>

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -2187,6 +2187,26 @@
         "mode": "both"
       },
       {
+         "path": "/Session/Time",
+         "type": "integer",
+         "name": "Session charging time (seconds)"
+      },
+      {
+        "path": "/Session/Energy",
+        "type": "integer",
+        "name": "Session charging energy (kWh)"
+      },
+      {
+        "path": "/Session/Cost",
+        "type": "float",
+        "name": "Session cost (no currency)"
+      },
+      {
+        "path": "/Session/SavedCost",
+        "type": "float",
+        "name": "Session saved cost (no currency)"
+      },
+      {
         "path": "/StartStop",
         "type": "enum",
         "name": "Start/stop charging (manual mode)",


### PR DESCRIPTION
Session info paths of the EV charger where missing

Closes issue #404