### PR TITLE
fix: allow writing to com.victronenergy.system in output nodes

### DIFF
--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -878,12 +878,6 @@
 
             // in case any services are available, populate the service and path dropdowns
             if (data.length !== 0) {
-                if (isCustomNode && isOutputNode) {
-                    data = data.filter(function (s) {
-                        return s.service !== 'com.victronenergy.system/0';
-                    });
-                }
-
                 populateSelect(serviceElem, data);
 
                 function containsDuplicates(array) {


### PR DESCRIPTION
Regression introduced in https://github.com/victronenergy/node-red-contrib-victron/commit/a8fbd769d5ff3c622c84ed540ea626fbf308cad0 (v1.6.33): the system service was incorrectly filtered from the output node service list. It is writable for a limited set of paths and should be available as an output target.

Note that only the custom output node and the relay node actually support writing to paths on the system service.