### PR TITLE
feat(virtual): add device presence control via msg.connected

### DIFF
--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -69,7 +69,9 @@
             include_humidity: { value: false },
             include_pressure: { value: false },
             include_temp_battery: { value: false },
-            temp_battery_voltage: { value: 3.3 }
+            temp_battery_voltage: { value: 3.3 },
+            // presence
+            start_disconnected: { value: false, required: false }
         },
         icon: "victronenergy.svg",
         inputs:1,
@@ -155,11 +157,6 @@
                         $('#node-input-device')
                             .prop('disabled', true)
                             .attr('title', 'Device type cannot be changed after deployment.');
-                    }
-                    if (self.id && self.changed === false && self.device === 'generator') {
-                        $('#node-input-generator_type')
-                            .prop('disabled', true)
-                            .attr('title', 'Generator type (AC/DC) cannot be changed after deployment.');
                     }
 
                     $('#node-input-device').on('change', (v) => {
@@ -513,6 +510,14 @@
             </div>
         </div>
 
+        <div class="form-row victron-checkbox">
+            <input type="checkbox" id="node-input-start_disconnected">
+            <label for="node-input-start_disconnected">
+                Start disconnected
+                <i class="fa fa-info-circle tooltip-icon" data-tooltip="When checked, the device will not appear on the system until it receives msg.connected = true"></i>
+            </label>
+        </div>
+
         <div id="switch-docs-container"></div>
 
         <div class="form-row community-link-container">
@@ -596,6 +601,27 @@ update all specified properties and show the number of updated values in its sta
 
 If you want to set a single value, you can either use this way to send that single
 path + value combination (recommended) or use the _Custom Control_ node.
+
+### Device presence
+
+When the real-world device goes offline, the virtual device keeps broadcasting its last known values. To make the rest of the system aware that the device is gone, you can explicitly disconnect it from the dbus by sending `msg.connected = false`. The device will disappear from VRM and the GX display until you reconnect it with `msg.connected = true`.
+
+```javascript
+// Take the device offline
+msg.connected = false;
+return msg;
+
+// Bring it back online
+msg.connected = true;
+return msg;
+
+```
+
+When `msg.connected` is set, no payload processing takes place - the message is used solely for presence control. For normal value updates, omit `msg.connected`.
+
+Every output message from the node carries `msg.connected` indicating the current presence state (`true` when visible on the system, `false` when offline). The node status shows a grey ring when the device is intentionally offline.
+
+The _Start disconnected_ option in the edit dialog causes the device to remain invisible after deployment until it receives `msg.connected = true`. This is useful when the flow controls visibility based on whether data is actually being received.
 
 ### AC Load
 
@@ -703,6 +729,8 @@ humidity, pressure and battery voltage.
 ## Device Visibility
 
 Depending on the created device, it might not appear immediately on the GX device or VRM portal. You will need to write some values to it first. Alternatively, you could use _Initialize with default values_ to make it appear on the GX device directly. Please note that those default values may not be appropriate for your specific situation, but it can help to get you started.
+
+Use _Start disconnected_ if you want the device to remain invisible until your flow explicitly connects it with `msg.connected = true`. This is the recommended approach when the virtual device represents a real-world device whose availability is not guaranteed at startup.
 
 Also note that it might take a short while before the service on the dbus is actually created. So best practice is to wait a second before injecting data into the virtual device.
 

--- a/src/nodes/victron-virtual/helpers.js
+++ b/src/nodes/victron-virtual/helpers.js
@@ -1,0 +1,33 @@
+/**
+ * Creates a setPresence function for a virtual device node.
+ * @param {object} node - The Node-RED node (must have bus, serviceName, presenceConnected, status)
+ * @param {string} text - Device display label
+ * @param {object} iface - Device interface (must have DeviceInstance)
+ * @returns {Function} setPresence(connected, onDone)
+ */
+function makeSetPresence (node, text, iface) {
+  return function setPresence (connected, onDone) {
+    const statusText = `${text} (${iface.DeviceInstance})`
+    if (connected && !node.presenceConnected) {
+      node.bus.requestName(node.serviceName, 0x4, (err, retCode) => {
+        if (!err && (retCode === 1 || retCode === 3)) {
+          node.presenceConnected = true
+          node.status({ fill: 'green', shape: 'dot', text: statusText })
+        }
+        onDone()
+      })
+    } else if (!connected && node.presenceConnected) {
+      node.bus.releaseName(node.serviceName, (err) => {
+        if (!err) {
+          node.presenceConnected = false
+          node.status({ fill: 'grey', shape: 'ring', text: `${statusText} - offline` })
+        }
+        onDone()
+      })
+    } else {
+      onDone()
+    }
+  }
+}
+
+module.exports = { makeSetPresence }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -12,6 +12,7 @@ const {
 const { validateVirtualDevicePayload, validateLightControls, debounce } = require('../../services/utils')
 const { handleSwitchOutputs } = require('../../services/virtual-switch')
 const { filterInactiveVirtualDevices } = require('../../services/virtual-device-cleanup')
+const { makeSetPresence } = require('./helpers')
 
 const acloadModule = require('./device-type/acload')
 const batteryModule = require('./device-type/battery')
@@ -188,6 +189,7 @@ module.exports = function (RED) {
     }
 
     node.retryOnConnectionEnd = true
+    node.presenceConnected = false
     node.pendingCallsToSetValuesLocally = []
 
     const debouncedSetters = new Map()
@@ -216,12 +218,21 @@ module.exports = function (RED) {
 
     function handleInput (msg, done) {
       // Send passthrough message FIRST, before any validation
+      const userSetConnected = msg.connected !== undefined
+      if (!userSetConnected) {
+        msg.connected = node.presenceConnected
+      }
       const outputs = [msg]
       // Fill remaining outputs with null
       for (let i = 1; i < config.outputs; i++) {
         outputs.push(null)
       }
       node.send(outputs)
+
+      if (userSetConnected) {
+        node.setPresence(!!msg.connected, done)
+        return
+      }
 
       // Now do validation with more helpful messages
       if (!msg || !msg.payload) {
@@ -658,6 +669,12 @@ module.exports = function (RED) {
               node.warn(`Service name "${serviceName}" for ${config.device} already exists on the bus, this may result in undesired behavior.`)
             }
             node.serviceName = serviceName
+            if (config.start_disconnected) {
+              node.bus.releaseName(node.serviceName, () => {
+                node.presenceConnected = false
+                node.status({ fill: 'grey', shape: 'ring', text: `${text} (${iface.DeviceInstance}) — offline` })
+              })
+            }
           } else {
             /* Other return codes means various errors, check here
             (https://dbus.freedesktop.org/doc/api/html/group__DBusShared.html#ga37a9bc7c6eb11d212bf8d5e5ff3b50f9) for more
@@ -710,6 +727,8 @@ module.exports = function (RED) {
         node.setValuesLocally = setValuesLocally
         node.emitS2Signal = emitS2Signal
 
+        node.setPresence = makeSetPresence(node, text, iface)
+
         // If there are pending calls, process them now
         node.pendingCallsToSetValuesLocally.forEach(([msg, done]) => {
           try {
@@ -723,6 +742,7 @@ module.exports = function (RED) {
 
         node.removeSettings = removeSettings
 
+        node.presenceConnected = true
         node.status({
           fill: 'green',
           shape: 'dot',

--- a/test/victron-virtual-presence.test.js
+++ b/test/victron-virtual-presence.test.js
@@ -1,0 +1,120 @@
+/* eslint-env jest */
+
+const { makeSetPresence } = require('../src/nodes/victron-virtual/helpers')
+
+describe('makeSetPresence', () => {
+  function createMockNode (presenceConnected = true) {
+    return {
+      presenceConnected,
+      serviceName: 'com.victronenergy.battery.virtual_test',
+      status: jest.fn(),
+      bus: {
+        requestName: jest.fn(),
+        releaseName: jest.fn()
+      }
+    }
+  }
+
+  const text = 'Virtual battery'
+  const iface = { DeviceInstance: 100 }
+
+  describe('disconnect', () => {
+    test('releases the DBus name when connected', () => {
+      const node = createMockNode(true)
+      node.bus.releaseName.mockImplementation((_name, cb) => cb(null))
+      const done = jest.fn()
+
+      makeSetPresence(node, text, iface)(false, done)
+
+      expect(node.bus.releaseName).toHaveBeenCalledWith(node.serviceName, expect.any(Function))
+      expect(node.presenceConnected).toBe(false)
+      expect(node.status).toHaveBeenCalledWith({ fill: 'grey', shape: 'ring', text: 'Virtual battery (100) - offline' })
+      expect(done).toHaveBeenCalled()
+    })
+
+    test('does not change state when releaseName errors', () => {
+      const node = createMockNode(true)
+      node.bus.releaseName.mockImplementation((_name, cb) => cb(new Error('bus error')))
+      const done = jest.fn()
+
+      makeSetPresence(node, text, iface)(false, done)
+
+      expect(node.presenceConnected).toBe(true)
+      expect(node.status).not.toHaveBeenCalled()
+      expect(done).toHaveBeenCalled()
+    })
+
+    test('is a no-op when already disconnected', () => {
+      const node = createMockNode(false)
+      const done = jest.fn()
+
+      makeSetPresence(node, text, iface)(false, done)
+
+      expect(node.bus.releaseName).not.toHaveBeenCalled()
+      expect(node.status).not.toHaveBeenCalled()
+      expect(done).toHaveBeenCalled()
+    })
+  })
+
+  describe('connect', () => {
+    test('requests the DBus name when disconnected', () => {
+      const node = createMockNode(false)
+      node.bus.requestName.mockImplementation((_name, _flags, cb) => cb(null, 1))
+      const done = jest.fn()
+
+      makeSetPresence(node, text, iface)(true, done)
+
+      expect(node.bus.requestName).toHaveBeenCalledWith(node.serviceName, 0x4, expect.any(Function))
+      expect(node.presenceConnected).toBe(true)
+      expect(node.status).toHaveBeenCalledWith({ fill: 'green', shape: 'dot', text: 'Virtual battery (100)' })
+      expect(done).toHaveBeenCalled()
+    })
+
+    test('also accepts retCode 3 (name already owned)', () => {
+      const node = createMockNode(false)
+      node.bus.requestName.mockImplementation((_name, _flags, cb) => cb(null, 3))
+      const done = jest.fn()
+
+      makeSetPresence(node, text, iface)(true, done)
+
+      expect(node.presenceConnected).toBe(true)
+      expect(node.status).toHaveBeenCalledWith({ fill: 'green', shape: 'dot', text: 'Virtual battery (100)' })
+      expect(done).toHaveBeenCalled()
+    })
+
+    test('does not change state when requestName errors', () => {
+      const node = createMockNode(false)
+      node.bus.requestName.mockImplementation((_name, _flags, cb) => cb(new Error('bus error'), null))
+      const done = jest.fn()
+
+      makeSetPresence(node, text, iface)(true, done)
+
+      expect(node.presenceConnected).toBe(false)
+      expect(node.status).not.toHaveBeenCalled()
+      expect(done).toHaveBeenCalled()
+    })
+
+    test('does not change state when requestName returns unexpected retCode', () => {
+      const node = createMockNode(false)
+      node.bus.requestName.mockImplementation((_name, _flags, cb) => cb(null, 2))
+      const done = jest.fn()
+
+      makeSetPresence(node, text, iface)(true, done)
+
+      expect(node.presenceConnected).toBe(false)
+      expect(node.status).not.toHaveBeenCalled()
+      expect(done).toHaveBeenCalled()
+    })
+
+    test('is a no-op when already connected', () => {
+      const node = createMockNode(true)
+      const done = jest.fn()
+
+      makeSetPresence(node, text, iface)(true, done)
+
+      expect(node.bus.requestName).not.toHaveBeenCalled()
+      expect(node.status).not.toHaveBeenCalled()
+      expect(done).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Allows controlling virtual device D-Bus presence via `msg.connected`:

- `msg.connected = true` brings the device online (requests D-Bus name)
- `msg.connected = false` takes it offline (releases D-Bus name)
- A new `Start disconnected` option in the edit dialog keeps the device invisible until it receives `msg.connected = true`
- Every output message is stamped with `msg.connected` reflecting the current presence state

Supersedes #389.