### PR TITLE
fix: showing output for control nodes

### DIFF
--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -1105,7 +1105,6 @@
                 "onlyChanges": { value: false },
                 "roundValues": { value: "no" },
                 "rateLimit": { value: 0 },
-                outputs: { value: 1 },
                 // Conditional mode properties
                 conditionalMode: { value: false },
                 condition1Operator: { value: ">" },


### PR DESCRIPTION
When pulling a control node on the canvas it initially also shows an output connection. That should not happen and this commit fixes that.

Regression from c5b58f6 (v1.6.59)