### PR TITLE
feat(virtual-switch): add Show in UI option

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -750,6 +750,54 @@
     }
   };
 
+  function renderShowInUICheckboxes (containerId, savedValue, targetInputId) {
+    const localId = `${containerId}-local`;
+    const remoteId = `${containerId}-remote`;
+
+    const savedInt = parseInt(savedValue ?? 1, 10);
+    const localChecked = !!(savedInt & 1) || !!(savedInt & 2);
+    const remoteChecked = !!(savedInt & 1) || !!(savedInt & 4);
+
+    const container = $(`#${containerId}`);
+    container.empty();
+    container.append(`
+    <label style="font-weight:bold;"><i class="fa fa-eye"></i> Show in UI</label>
+    <div class="form-row victron-checkbox">
+      <input type="checkbox" id="${localId}">
+      <label for="${localId}">Local UI
+        <i class="fa fa-info-circle tooltip-icon" data-tooltip="GUI running natively on GX device, MFD and WASM over local LAN"></i>
+      </label>
+    </div>
+    <div class="form-row victron-checkbox">
+      <input type="checkbox" id="${remoteId}">
+      <label for="${remoteId}">Remote UI
+        <i class="fa fa-info-circle tooltip-icon" data-tooltip="VRM remote console and VRM switch pane"></i>
+      </label>
+    </div>
+  `);
+
+    $(`#${localId}`).prop('checked', localChecked);
+    $(`#${remoteId}`).prop('checked', remoteChecked);
+
+    if (targetInputId) {
+      const updateTarget = () => {
+        $(`#${targetInputId}`).val(getShowUIValue(containerId));
+      };
+      $(`#${localId}`).on('change', updateTarget);
+      $(`#${remoteId}`).on('change', updateTarget);
+      updateTarget();
+    }
+  }
+
+  function getShowUIValue (containerId) {
+    const local = $(`#${containerId}-local`).is(':checked');
+    const remote = $(`#${containerId}-remote`).is(':checked');
+    if (local && remote) return 1
+    if (local) return 2
+    if (remote) return 4
+    return 0
+  }
+
   function renderSwitchConfigRow (context) {
     const typeOptions = Object.entries(SWITCH_TYPE_CONFIGS)
       .map(([value, cfg]) => `<option value="${value}">${cfg.label}</option>`)
@@ -968,6 +1016,10 @@
 
     $('#node-input-switch_1_type').on('change', renderTypeConfig);
     renderTypeConfig();
+
+    // Show in UI section (outside renderTypeConfig so it persists across type changes)
+    $('#switch-config-container').append('<div id="switch-show-ui" style="margin-top:10px;"></div>');
+    renderShowInUICheckboxes('switch-show-ui', context.switch_1_show_ui_input);
   }
 
   function renderDropdownLabels (context) {
@@ -1261,6 +1313,8 @@
     updateBatteryVoltageVisibility,
     calculateOutputs,
     updateOutputs,
+    renderShowInUICheckboxes,
+    getShowUIValue,
     initializeTooltips
   };
 

--- a/src/nodes/victron-virtual-browser.js
+++ b/src/nodes/victron-virtual-browser.js
@@ -9,7 +9,9 @@ import {
   fetchSwitchNodeNameAndGroupFromCache,
   updateBatteryVoltageVisibility,
   calculateOutputs,
-  updateOutputs
+  updateOutputs,
+  renderShowInUICheckboxes,
+  getShowUIValue
 } from './victron-virtual-functions.js'
 import { initializeTooltips } from './victron-common.js'
 
@@ -24,5 +26,7 @@ window.__victron = {
   updateBatteryVoltageVisibility,
   calculateOutputs,
   updateOutputs,
+  renderShowInUICheckboxes,
+  getShowUIValue,
   initializeTooltips
 }

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -487,6 +487,54 @@ export const DEVICE_TYPE_DOCS = {
   }
 }
 
+export function renderShowInUICheckboxes (containerId, savedValue, targetInputId) {
+  const localId = `${containerId}-local`
+  const remoteId = `${containerId}-remote`
+
+  const savedInt = parseInt(savedValue ?? 1, 10)
+  const localChecked = !!(savedInt & 1) || !!(savedInt & 2)
+  const remoteChecked = !!(savedInt & 1) || !!(savedInt & 4)
+
+  const container = $(`#${containerId}`)
+  container.empty()
+  container.append(`
+    <label style="font-weight:bold;"><i class="fa fa-eye"></i> Show in UI</label>
+    <div class="form-row victron-checkbox">
+      <input type="checkbox" id="${localId}">
+      <label for="${localId}">Local UI
+        <i class="fa fa-info-circle tooltip-icon" data-tooltip="GUI running natively on GX device, MFD and WASM over local LAN"></i>
+      </label>
+    </div>
+    <div class="form-row victron-checkbox">
+      <input type="checkbox" id="${remoteId}">
+      <label for="${remoteId}">Remote UI
+        <i class="fa fa-info-circle tooltip-icon" data-tooltip="VRM remote console and VRM switch pane"></i>
+      </label>
+    </div>
+  `)
+
+  $(`#${localId}`).prop('checked', localChecked)
+  $(`#${remoteId}`).prop('checked', remoteChecked)
+
+  if (targetInputId) {
+    const updateTarget = () => {
+      $(`#${targetInputId}`).val(getShowUIValue(containerId))
+    }
+    $(`#${localId}`).on('change', updateTarget)
+    $(`#${remoteId}`).on('change', updateTarget)
+    updateTarget()
+  }
+}
+
+export function getShowUIValue (containerId) {
+  const local = $(`#${containerId}-local`).is(':checked')
+  const remote = $(`#${containerId}-remote`).is(':checked')
+  if (local && remote) return 1
+  if (local) return 2
+  if (remote) return 4
+  return 0
+}
+
 export function renderSwitchConfigRow (context) {
   const typeOptions = Object.entries(SWITCH_TYPE_CONFIGS)
     .map(([value, cfg]) => `<option value="${value}">${cfg.label}</option>`)
@@ -705,6 +753,10 @@ export function renderSwitchConfigRow (context) {
 
   $('#node-input-switch_1_type').on('change', renderTypeConfig)
   renderTypeConfig()
+
+  // Show in UI section (outside renderTypeConfig so it persists across type changes)
+  $('#switch-config-container').append('<div id="switch-show-ui" style="margin-top:10px;"></div>')
+  renderShowInUICheckboxes('switch-show-ui', context.switch_1_show_ui_input)
 }
 
 function renderDropdownLabels (context) {

--- a/src/nodes/victron-virtual-switch.html
+++ b/src/nodes/victron-virtual-switch.html
@@ -21,7 +21,8 @@
             switch_1_include_measurement: {value: false, required: false},
             switch_1_rgb_color_wheel: {value: false, required: false},
             switch_1_cct_wheel: {value: false, required: false},
-            switch_1_rgb_white_dimmer: {value: false, required: false}
+            switch_1_rgb_white_dimmer: {value: false, required: false},
+            switch_1_show_ui_input: {value: 1, required: false}
         },
         icon: "victronenergy.svg",
         inputs:1,
@@ -103,7 +104,7 @@
 
         },
         oneditsave: function() {
-            const { validateSwitchConfig, SWITCH_TYPE_CONFIGS, updateOutputs } = window.__victron;
+            const { validateSwitchConfig, SWITCH_TYPE_CONFIGS, updateOutputs, getShowUIValue } = window.__victron;
 
             this.device = 'switch';
 
@@ -159,6 +160,7 @@
                     });
                 });
             }
+            this['switch_1_show_ui_input'] = getShowUIValue('switch-show-ui');
             updateOutputs(this);
         }
     });

--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -75,7 +75,7 @@ function createSwitchProperties (config, ifaceDesc, iface) {
       value: 1,
       min: 0,
       max: 6,
-      persist: true,
+      persist: false,
       format: (v) => {
         if (v === 0) return 'Hidden'
         const parts = []

--- a/test/victron-virtual-functions.switch.test.js
+++ b/test/victron-virtual-functions.switch.test.js
@@ -32,6 +32,8 @@ function createMockElement(customValues = {}) {
     after: jest.fn().mockReturnThis(),
     on: jest.fn().mockReturnThis(),
     off: jest.fn().mockReturnThis(),
+    prop: jest.fn().mockReturnThis(),
+    is: jest.fn().mockReturnValue(customValues.is || false),
     0: mockDOMElement,
     length: customValues.length !== undefined ? customValues.length : 1
   }


### PR DESCRIPTION
Adds a Show in UI section to the virtual switch node edit dialog, controlled by two checkboxes (Local UI / Remote UI) backed by the `Settings/ShowUIControl` bitmask:
  0bxx1 - show in all UIs (both checked -> value 1)
  0bx10 - local UI only (GX device, MFD, LAN WASM)
  0b1x0 - remote UI only (VRM remote console and switch pane)
  0b000 - hidden

Introduces two reusable helpers in victron-virtual-functions.js:
  renderShowInUICheckboxes(containerId, savedValue, targetInputId)
  getShowUIValue(containerId)

These will also be used by the generic input API node.

<img width="471" height="111" alt="image" src="https://github.com/user-attachments/assets/93ac197e-efe3-4f9c-91ab-4d2e354b77b8" />
