### PR TITLE
feat(virtual): add DC load virtual device

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -517,6 +517,30 @@
   `,
       img: null
     },
+    dcload: {
+      label: 'DC Load',
+      text: `
+    ${INPUT_DOCS}
+    <div>
+      <div><strong>Most relevant paths:</strong>
+        <ul>
+          <li><code>/Dc/0/Voltage</code> &mdash; DC load voltage in volts.</li>
+          <li><code>/Dc/0/Current</code> &mdash; DC load current in amperes.</li>
+          <li><code>/Dc/0/Power</code> &mdash; DC load power in watts.</li>
+        </ul>
+        <p>For more information on available paths, see the <a href="https://github.com/victronenergy/venus/wiki/dbus" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS dbus specification</a>.</p>
+      </div>
+    </div>
+    <div>
+      <div><strong>Output:</strong>
+        <ol>
+          <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
+        </ol>
+      </div>
+    </div>
+  `,
+      img: null
+    },
     ev: {
       label: 'Electric Vehicle',
       text: `

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -254,6 +254,30 @@ export const DEVICE_TYPE_DOCS = {
   `,
     img: null
   },
+  dcload: {
+    label: 'DC Load',
+    text: `
+    ${INPUT_DOCS}
+    <div>
+      <div><strong>Most relevant paths:</strong>
+        <ul>
+          <li><code>/Dc/0/Voltage</code> &mdash; DC load voltage in volts.</li>
+          <li><code>/Dc/0/Current</code> &mdash; DC load current in amperes.</li>
+          <li><code>/Dc/0/Power</code> &mdash; DC load power in watts.</li>
+        </ul>
+        <p>For more information on available paths, see the <a href="https://github.com/victronenergy/venus/wiki/dbus" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS dbus specification</a>.</p>
+      </div>
+    </div>
+    <div>
+      <div><strong>Output:</strong>
+        <ol>
+          <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
+        </ol>
+      </div>
+    </div>
+  `,
+    img: null
+  },
   ev: {
     label: 'Electric Vehicle',
     text: `

--- a/src/nodes/victron-virtual/device-type/dcload.js
+++ b/src/nodes/victron-virtual/device-type/dcload.js
@@ -1,0 +1,17 @@
+const properties = {
+  'Dc/0/Current': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '', immediate: true },
+  'Dc/0/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '', immediate: true },
+  'Dc/0/Voltage': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '', immediate: true },
+  'Settings/MonitorMode': { type: 'i', value: 1 }
+}
+
+function initialize (config, ifaceDesc, iface, node) {
+  if (config.default_values) {
+    iface['Dc/0/Current'] = 0
+    iface['Dc/0/Power'] = 0
+    iface['Dc/0/Voltage'] = 0
+  }
+  return 'Virtual DC load'
+}
+
+module.exports = { properties, initialize, label: 'DC Load' }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -16,6 +16,7 @@ const { makeSetPresence } = require('./helpers')
 
 const acloadModule = require('./device-type/acload')
 const batteryModule = require('./device-type/battery')
+const dcloadModule = require('./device-type/dcload')
 const evModule = require('./device-type/ev')
 const generatorModule = require('./device-type/generator')
 const gpsModule = require('./device-type/gps')
@@ -42,6 +43,7 @@ process.on('unhandledRejection', (reason, promise) => {
 const properties = {
   acload: acloadModule.properties,
   battery: batteryModule.properties,
+  dcload: dcloadModule.properties,
   ev: evModule.properties,
   temperature: temperatureModule.properties,
   genset: generatorModule.properties.genset,
@@ -59,6 +61,7 @@ const properties = {
 const deviceModules = {
   acload: acloadModule,
   battery: batteryModule,
+  dcload: dcloadModule,
   ev: evModule,
   generator: generatorModule,
   gps: gpsModule,
@@ -75,6 +78,7 @@ const deviceModules = {
 const DEVICE_TYPES = [
   { value: 'acload', label: 'AC Load' },
   { value: 'battery', label: 'Battery' },
+  { value: 'dcload', label: 'DC Load' },
   { value: 'e-drive', label: 'E-drive' },
   { value: 'ev', label: 'Electric Vehicle' },
   { value: 'generator', label: 'Generator' },

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -3,6 +3,7 @@
 
 const acload = require('../src/nodes/victron-virtual/device-type/acload')
 const battery = require('../src/nodes/victron-virtual/device-type/battery')
+const dcload = require('../src/nodes/victron-virtual/device-type/dcload')
 const ev = require('../src/nodes/victron-virtual/device-type/ev')
 const generator = require('../src/nodes/victron-virtual/device-type/generator')
 const gps = require('../src/nodes/victron-virtual/device-type/gps')
@@ -130,6 +131,52 @@ describe('battery', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       const result = battery.initialize({ battery_capacity: 25 }, ifaceDesc, iface, node)
       expect(result).toBe('Virtual 25Ah battery')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// dcload
+// ---------------------------------------------------------------------------
+
+describe('dcload', () => {
+  describe('properties', () => {
+    test('has required DC paths', () => {
+      expect(dcload.properties['Dc/0/Current']).toBeDefined()
+      expect(dcload.properties['Dc/0/Power']).toBeDefined()
+      expect(dcload.properties['Dc/0/Voltage']).toBeDefined()
+    })
+
+    test('Settings/MonitorMode has value 1', () => {
+      expect(dcload.properties['Settings/MonitorMode'].value).toBe(1)
+    })
+
+    test('DC paths have immediate: true', () => {
+      expect(dcload.properties['Dc/0/Current'].immediate).toBe(true)
+      expect(dcload.properties['Dc/0/Power'].immediate).toBe(true)
+      expect(dcload.properties['Dc/0/Voltage'].immediate).toBe(true)
+    })
+  })
+
+  describe('initialize', () => {
+    test('sets default values when enabled', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      dcload.initialize({ default_values: true }, ifaceDesc, iface, node)
+      expect(iface['Dc/0/Current']).toBe(0)
+      expect(iface['Dc/0/Power']).toBe(0)
+      expect(iface['Dc/0/Voltage']).toBe(0)
+    })
+
+    test('does not set default values when disabled', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      dcload.initialize({ default_values: false }, ifaceDesc, iface, node)
+      expect(iface['Dc/0/Current']).toBeUndefined()
+    })
+
+    test('returns label string', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      const result = dcload.initialize({}, ifaceDesc, iface, node)
+      expect(result).toBe('Virtual DC load')
     })
   })
 })


### PR DESCRIPTION
Implements com.victronenergy.dcload virtual device with Dc/0/Current, Dc/0/Power, Dc/0/Voltage and a fixed Settings/MonitorMode of 1.

Closes #415