### PR TITLE
fix(virtual-switch): allow array of strings for dropdown Labels

### DIFF
--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1135,8 +1135,8 @@ export function validateVirtualDevicePayload (payload) {
     if (typeof value === 'number') return false
     if (typeof value === 'boolean') return false
     if (Array.isArray(value)) {
-      // Arrays are valid (for LightControls), but should contain only numbers
-      return !value.every(item => typeof item === 'number')
+      // Arrays are valid (for LightControls and Labels), but must be homogeneous (all numbers or all strings)
+      return !(value.every(item => typeof item === 'number') || value.every(item => typeof item === 'string'))
     }
     return true
   })
@@ -1145,7 +1145,7 @@ export function validateVirtualDevicePayload (payload) {
     const invalidKeys = invalidEntries.map(([key]) => key).join(', ')
     return {
       valid: false,
-      error: `Invalid value types for keys: ${invalidKeys}. Expected: string, number, boolean, null, or array of numbers.`,
+      error: `Invalid value types for keys: ${invalidKeys}. Expected: string, number, boolean, null, array of numbers, or array of strings.`,
       invalidKeys: invalidEntries.map(([key]) => key)
     }
   }

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -352,8 +352,8 @@ function validateVirtualDevicePayload (payload) {
     if (typeof value === 'number') return false
     if (typeof value === 'boolean') return false
     if (Array.isArray(value)) {
-      // Arrays are valid (for LightControls), but should contain only numbers
-      return !value.every(item => typeof item === 'number')
+      // Arrays are valid (for LightControls and Labels), but must be homogeneous (all numbers or all strings)
+      return !(value.every(item => typeof item === 'number') || value.every(item => typeof item === 'string'))
     }
     return true
   })
@@ -362,7 +362,7 @@ function validateVirtualDevicePayload (payload) {
     const invalidKeys = invalidEntries.map(([key]) => key).join(', ')
     return {
       valid: false,
-      error: `Invalid value types for keys: ${invalidKeys}. Expected: string, number, boolean, null, or array of numbers.`,
+      error: `Invalid value types for keys: ${invalidKeys}. Expected: string, number, boolean, null, array of numbers, or array of strings.`,
       invalidKeys: invalidEntries.map(([key]) => key)
     }
   }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -127,6 +127,14 @@ describe('utils', () => {
       expect(result.valid).toBe(true)
     })
 
+    it('accepts array of strings (for dropdown Labels)', () => {
+      const payload = {
+        'SwitchableOutput/output_1/Settings/Labels': ['Label 1', 'Label 2', 'Label 3']
+      }
+      const result = validateVirtualDevicePayload(payload)
+      expect(result.valid).toBe(true)
+    })
+
     it('accepts mixed valid types including arrays', () => {
       const payload = {
         Soc: 75,
@@ -268,7 +276,7 @@ describe('utils', () => {
       }
       const result = validateVirtualDevicePayload(payload)
       expect(result.error).toContain('BadObject')
-      expect(result.error).toContain('Expected: string, number, boolean, null, or array of numbers')
+      expect(result.error).toContain('Expected: string, number, boolean, null, array of numbers, or array of strings')
     })
 
   })


### PR DESCRIPTION
The validateVirtualDevicePayload function only accepted arrays of numbers, rejecting the string array required by the dropdown virtual switch Labels field.

Allow homogeneous arrays of strings in addition to arrays of numbers, so users can set /SwitchableOutput/output_1/Settings/Labels without hitting the "Invalid value types" error.

Closes #429