### PR TITLE
fix(virtual-switch): apply switch_1_show_ui_input config to ShowUIControl

### DIFF
--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -133,6 +133,9 @@ function createSwitchProperties (config, ifaceDesc, iface) {
   const groupKey = 'SwitchableOutput/output_1/Settings/Group'
   iface[groupKey] = config.switch_1_group || ''
 
+  const showUIControlKey = 'SwitchableOutput/output_1/Settings/ShowUIControl'
+  iface[showUIControlKey] = Number(config.switch_1_show_ui_input ?? 1)
+
   // Type-specific properties
   if (switchType === 2) {
     // DIMMABLE switch

--- a/test/virtual-switch.test.js
+++ b/test/virtual-switch.test.js
@@ -1,5 +1,5 @@
 // test/virtual-switch.test.js
-const { updateSwitchStatus, emitInitialSwitchOutputs, handleSwitchOutputs } = require('../src/services/virtual-switch')
+const { updateSwitchStatus, emitInitialSwitchOutputs, handleSwitchOutputs, createSwitchProperties } = require('../src/services/virtual-switch')
 const { SWITCH_TYPE_MAP } = require('../src/nodes/victron-virtual-constants')
 
 function makeNode (ifaceOverrides = {}, ifaceDescOverrides = {}) {
@@ -256,5 +256,32 @@ describe('handleSwitchOutputs', () => {
       null,
       { payload: 21.5, topic: 'Test switch/temperature', source_path: '/SwitchableOutput/output_1/Dimming' }
     ])
+  })
+})
+
+describe('createSwitchProperties - ShowUIControl', () => {
+  const showUIKey = 'SwitchableOutput/output_1/Settings/ShowUIControl'
+
+  function run (config) {
+    const ifaceDesc = { properties: {} }
+    const iface = {}
+    createSwitchProperties({ switch_1_type: SWITCH_TYPE_MAP.TOGGLE, ...config }, ifaceDesc, iface)
+    return iface[showUIKey]
+  }
+
+  test('defaults to 1 when switch_1_show_ui_input is not set', () => {
+    expect(run({})).toBe(1)
+  })
+
+  test('uses switch_1_show_ui_input value 0 (hidden)', () => {
+    expect(run({ switch_1_show_ui_input: 0 })).toBe(0)
+  })
+
+  test('uses switch_1_show_ui_input value 2 (local UI only)', () => {
+    expect(run({ switch_1_show_ui_input: 2 })).toBe(2)
+  })
+
+  test('uses switch_1_show_ui_input value 4 (remote UI only)', () => {
+    expect(run({ switch_1_show_ui_input: 4 })).toBe(4)
   })
 })


### PR DESCRIPTION
The `ShowUIControl` iface property was always set to the hardcoded default value of `1` because the baseProperties loop never reads config values. Applied the same override pattern used for CustomName and Group.

So this is makes a6d7df22f8c7dcb8730866f05975169118b3e672 actually work.