### PR TITLE
fix(virtual): use httpAdminRoot prefix for virtual-device-types endpoint

### DIFF
--- a/docs/NODE_EDIT_DIALOG_DESIGN_GUIDE.md
+++ b/docs/NODE_EDIT_DIALOG_DESIGN_GUIDE.md
@@ -80,6 +80,23 @@ window.__victronCommon.initializeTooltips();
 
 See [victron-styles.css](/resources/victron-styles.css) for CSS definitions.
 
+## HTTP Requests from Edit Dialogs
+
+**Never hardcode absolute paths** when calling backend endpoints from `oneditprepare` or other dialog callbacks. Node-RED can be deployed under a non-root subpath (e.g., `/node-red/`), so a hardcoded `/victron/...` URL will 404.
+
+Always prefix with the admin root:
+
+```javascript
+// ❌ WRONG - breaks when Node-RED is not at /
+$.getJSON('/victron/virtual-device-types')
+
+// ✅ CORRECT - works at any subpath
+var baseUrl = (RED.settings.httpNodeRoot || RED.settings.httpAdminRoot || "").replace(/\/$/, "");
+$.getJSON(baseUrl + '/victron/virtual-device-types')
+```
+
+The same pattern applies to any `$.ajax`, `fetch`, or other HTTP call made inside an edit dialog.
+
 ## Dynamic Content
 
 Use CSS classes in JavaScript-generated HTML:

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -140,7 +140,8 @@
                 self.device = 'e-drive';
             }
 
-            $.getJSON('/victron/virtual-device-types')
+            var baseUrl = (RED.settings.httpNodeRoot || RED.settings.httpAdminRoot || "").replace(/\/$/, "");
+            $.getJSON(baseUrl + '/victron/virtual-device-types')
                 .done(function(deviceTypes) {
                     const $select = $('#node-input-device');
                     $select.empty();


### PR DESCRIPTION
Hardcoded /victron/virtual-device-types broke when Node-RED was deployed under a subpath. Now constructs the URL the same way victron-nodes.html does, using RED.settings.httpNodeRoot || RED.settings.httpAdminRoot.

Also documents the correct pattern in NODE_EDIT_DIALOG_DESIGN_GUIDE.md to prevent recurrence.

Closes #440, Closes #443