### PR TITLE
fix(nodes): skip migration and guard null deviceInstance for services without deviceinstance

### DIFF
--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -1,6 +1,7 @@
 module.exports = function (RED) {
   const debug = require('debug')('node-red-contrib-victron:victron-nodes')
   const utils = require('../services/utils.js')
+  const { serviceNamesWithoutDeviceInstance } = require('../services/dbus-listener.js')
 
   const migrateSubscriptions = (x) => {
     // Check if client is fully initialized
@@ -18,7 +19,7 @@ module.exports = function (RED) {
         }
       }
     }
-    if (typeof x.deviceInstance !== 'undefined' && x.deviceInstance.toString().match(/^\d+$/)) {
+    if (x.deviceInstance != null && x.deviceInstance.toString().match(/^\d+$/)) {
       const dbusInterface = x.service.split('.').splice(0, 3).join('.') + ('/' + x.deviceInstance).replace(/\/$/, '')
       // var dbusInterface = x.service
       const newsub = dbusInterface + ':' + x.path
@@ -99,7 +100,7 @@ module.exports = function (RED) {
 
       if (this.service && this.path) {
         // The following is for migration purposes
-        if (!this.service.match(/\/\d+$/)) {
+        if (!this.service.match(/\/\d+$/) && !serviceNamesWithoutDeviceInstance.includes(this.service)) {
           this.deviceInstance = this.service.replace(/^.*\.(\d+)$/, '$1')
           this.service = this.service.replace(/\.\d+$/, '')
           // Only call getValue if the client is initialized and connected

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -460,3 +460,4 @@ class VictronDbusListener {
 }
 
 module.exports = VictronDbusListener
+module.exports.serviceNamesWithoutDeviceInstance = serviceNamesWithoutDeviceInstance

--- a/test/victron-nodes.test.js
+++ b/test/victron-nodes.test.js
@@ -1,4 +1,90 @@
 const victronNodesInitFunction = require('../src/nodes/victron-nodes');
+const { serviceNamesWithoutDeviceInstance } = require('../src/services/dbus-listener');
+
+function buildMockRED({ services = {}, connected = true } = {}) {
+  const subscribe = jest.fn();
+  const mockRED = {
+    nodes: {
+      registerType: jest.fn(),
+      createNode: function (self, config) {
+        self.name = config.name;
+        self.serviceObj = config.serviceObj;
+        self.pathObj = config.pathObj;
+        self.on = jest.fn();
+        self.send = jest.fn();
+        self.context = jest.fn().mockReturnValue({ global: { set: jest.fn() } });
+        self.status = jest.fn();
+      },
+      getNode: function (id) {
+        if (id === 'victron-client-id') {
+          return {
+            addStatusListener: jest.fn(),
+            client: {
+              subscribe,
+              subscriptions: {},
+              system: { cache: {} },
+              onStatusUpdate: jest.fn(),
+              client: { connected, getValue: jest.fn(), services }
+            },
+            showValues: true
+          };
+        }
+        throw new Error('[mock getNode] Node not found: ' + id);
+      }
+    }
+  };
+  victronNodesInitFunction(mockRED);
+  const BaseInputNode = mockRED.nodes.registerType.mock.calls[0][1];
+  return { mockRED, BaseInputNode, subscribe };
+}
+
+describe('victron-nodes migration', () => {
+  it('skips migration for services in serviceNamesWithoutDeviceInstance', () => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    const { BaseInputNode } = buildMockRED();
+
+    new BaseInputNode({
+      name: 'Test',
+      service: 'com.victronenergy.settings',
+      path: '/Settings/Foo',
+      serviceObj: { name: 'Settings' },
+      pathObj: { name: 'Foo' }
+    });
+
+    const migrationTimers = setTimeoutSpy.mock.calls.filter(
+      ([fn]) => fn.name === 'migrateSubscriptions'
+    );
+    expect(migrationTimers).toHaveLength(0);
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('does not crash when deviceInstance is null in the services cache', () => {
+    jest.useFakeTimers();
+    try {
+      const { BaseInputNode } = buildMockRED({
+        services: {
+          'com.victronenergy.battery': { name: 'com.victronenergy.battery', deviceInstance: null }
+        }
+      });
+
+      new BaseInputNode({
+        name: 'Test',
+        service: 'com.victronenergy.battery.512',
+        path: '/Soc',
+        serviceObj: { name: 'Battery' },
+        pathObj: { name: 'SoC' }
+      });
+
+      expect(() => jest.runAllTimers()).not.toThrow();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('serviceNamesWithoutDeviceInstance contains com.victronenergy.settings', () => {
+    expect(serviceNamesWithoutDeviceInstance).toContain('com.victronenergy.settings');
+  });
+});
 
 describe('victron-nodes', () => {
   it('allows me to instantiate a node and set values', () => {


### PR DESCRIPTION
Services like `com.victronenergy.settings` have no device instance and were never meant to go through the legacy service name migration path. Because they lack a trailing `/N` in their name, the migration guard `(!match(/\/\d+$/))` incorrectly treated them as old-format names, entered the migration loop, then retrieved a null deviceInstance from the cache - crashing on null.toString().

Two fixes:
- Guard the migration entry point with `serviceNamesWithoutDeviceInstance` so singleton services are excluded upfront and never enter the retry loop.
- Change the deviceInstance null-check from `'typeof !== undefined'` to `'!= null'` so a null value is also excluded, preventing the crash for any service whose deviceInstance turns out to be null.

`serviceNamesWithoutDeviceInstance` is exported from `dbus-listener.js` rather than duplicated or moved to `utils.js`, because it already lives there alongside the related `initServiceDenylist` and `initServiceAllowlistRegexes`. Keeping all three service filter lists in one place makes it easier to maintain them together.

Reported by users on 1.7.7: _TypeError: Cannot read properties of null (reading 'toString') at Timeout.migrateSubscriptions._