### PR TITLE
fix(settings): restore MaxChargeVoltage to settings node

### DIFF
--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -5649,6 +5649,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>2 - Genset</li>
   <li>3 - Shore</li>
 </ul></dd>
+  <dt class="optional">Limit managed battery voltage (V DC)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeVoltage</b><span class="property-mode"> (Mode: both)</span>
+</dd>
   <dt class="optional">System name<span class="property-type">string</span></dt>
   <dd>Dbus path: <b>/Settings/SystemSetup/SystemName</b><span class="property-mode"> (Mode: both)</span>
 </dd>
@@ -5748,6 +5751,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>2 - Genset</li>
   <li>3 - Shore</li>
 </ul></dd>
+  <dt class="optional">Limit managed battery voltage (V DC)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeVoltage</b><span class="property-mode"> (Mode: both)</span>
+</dd>
   <dt class="optional">System name<span class="property-type">string</span></dt>
   <dd>Dbus path: <b>/Settings/SystemSetup/SystemName</b><span class="property-mode"> (Mode: both)</span>
 </dd>

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -4051,6 +4051,12 @@
         "mode": "both"
       },
       {
+        "path": "/Settings/SystemSetup/MaxChargeVoltage",
+        "type": "float",
+        "name": "Limit managed battery voltage (V DC)",
+        "mode": "both"
+      },
+      {
         "path": "/Settings/SystemSetup/SystemName",
         "type": "string",
         "name": "System name",


### PR DESCRIPTION
The path /Settings/SystemSetup/MaxChargeVoltage was accidentally removed from the settings node in 9a0a8241 ("Shrink services.json file size"). Restore it under its original name "Limit managed battery voltage (V DC)".

It is probably best to backport this to 3.7x too.