### PR TITLE
feat(virtual): auto-update LastEvContact on any EV property change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.7.8",
       "license": "MIT",
       "dependencies": {
-        "dbus-victron-virtual": "^0.1.33",
+        "dbus-native-victron": "^0.4.5",
+        "dbus-victron-virtual": "^0.1.34",
         "debug": "^4.4.0",
         "lodash": "^4.17.21",
         "promise-retry": "^2.0.1"
@@ -64,6 +65,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1910,6 +1912,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2350,9 +2353,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2393,6 +2396,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2857,16 +2861,15 @@
       }
     },
     "node_modules/dbus-native-victron": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/dbus-native-victron/-/dbus-native-victron-0.4.8.tgz",
-      "integrity": "sha512-hJVAXaYlf3lFL1Qx87XnYBFAbX+FbyCPKQgV7ATu8qHlC2pb1P5m4rX63WeX+VPUcOrmLvhN/+oenw49Z8fVWg==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/dbus-native-victron/-/dbus-native-victron-0.4.9.tgz",
+      "integrity": "sha512-75wAb1ndDvYv6FE0yAf92L93J9wx7yrYGklLSoqW2abW+FW8SbGwNpGo4ufnkF5/cu3KjVHzznmfzYdR3OrzvQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.3.6",
         "event-stream": "^4.0.0",
         "hexy": "^0.2.10",
         "long": "^4.0.0",
-        "put": "0.0.6",
         "safe-buffer": "^5.1.1",
         "xml2js": "^0.6.2"
       },
@@ -2895,12 +2898,12 @@
       }
     },
     "node_modules/dbus-victron-virtual": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/dbus-victron-virtual/-/dbus-victron-virtual-0.1.33.tgz",
-      "integrity": "sha512-wFXEEXnxNntPmQSL8al2ecKQjl2vp+hMhliziUociQ2OLy0pf3eOeEUHKfIL9oZN5Qergibisg8B8G1w0BbYvg==",
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/dbus-victron-virtual/-/dbus-victron-virtual-0.1.34.tgz",
+      "integrity": "sha512-XeeRwFHdUf4Wa2dwCL0/ZDKDLlDYzqo/QWYZLkmAIZ2Tj4jowAeM0Eqzns91rf2n5bAdV0DsS54AEiH7lYICoQ==",
       "license": "MIT",
       "dependencies": {
-        "dbus-native-victron": "^0.4.8",
+        "dbus-native-victron": "^0.4.9",
         "debug": "^4.3.7"
       }
     },
@@ -3305,6 +3308,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3474,6 +3478,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3518,6 +3523,7 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -3557,6 +3563,7 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3573,6 +3580,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -6107,9 +6115,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6421,9 +6429,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
       "license": "MIT",
       "optional": true
     },
@@ -6805,6 +6813,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7115,15 +7124,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/put": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/put/-/put-0.0.6.tgz",
-      "integrity": "sha512-w0szIZ2NkqznMFqxYPRETCIi+q/S8UKis9F4yOl6/N9NDCZmbjZZT85aI4FgJf3vIPrzMPX60+odCLOaYxNWWw==",
-      "license": "MIT/X11",
-      "engines": {
-        "node": ">=0.3.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7379,6 +7379,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7518,9 +7519,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -7939,6 +7940,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8896,9 +8898,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Custom Node-RED Nodes for Victron Energy",
   "version": "1.7.8",
   "dependencies": {
-    "dbus-victron-virtual": "^0.1.33",
+    "dbus-native-victron": "^0.4.5",
+    "dbus-victron-virtual": "^0.1.34",
     "debug": "^4.4.0",
     "lodash": "^4.17.21",
     "promise-retry": "^2.0.1"

--- a/src/nodes/victron-virtual/device-type/ev.js
+++ b/src/nodes/victron-virtual/device-type/ev.js
@@ -52,4 +52,11 @@ function initialize (config, _ifaceDesc, iface, _node) {
   return 'Virtual EV'
 }
 
-module.exports = { properties, initialize, label: 'Electric Vehicle' }
+function onPropertiesChanged ({ changes /* , instance */ }) {
+  if (!changes.LastEvContact) {
+    changes.LastEvContact = Math.floor(Date.now() / 1000)
+  }
+  return changes
+}
+
+module.exports = { properties, initialize, onPropertiesChanged, label: 'Electric Vehicle' }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -227,26 +227,21 @@ module.exports = function (RED) {
     }
 
     function handleInput (msg, done) {
-      // S2 signal messages are internal control - never pass through to any output
-      if (msg.payload && msg.payload.s2Signal !== undefined) {
-        // Fall through to s2Signal handler below
-      } else {
-        // Send passthrough message FIRST, before any validation
-        const userSetConnected = msg.connected !== undefined
-        if (!userSetConnected) {
-          msg.connected = node.presenceConnected
-        }
-        const outputs = [msg]
-        // Fill remaining outputs with null
-        for (let i = 1; i < config.outputs; i++) {
-          outputs.push(null)
-        }
-        node.send(outputs)
+      // Send passthrough message FIRST, before any validation
+      const userSetConnected = msg.connected !== undefined
+      if (!userSetConnected) {
+        msg.connected = node.presenceConnected
+      }
+      const outputs = [msg]
+      // Fill remaining outputs with null
+      for (let i = 1; i < config.outputs; i++) {
+        outputs.push(null)
+      }
+      node.send(outputs)
 
-        if (userSetConnected) {
-          node.setPresence(!!msg.connected, done)
-          return
-        }
+      if (userSetConnected) {
+        node.setPresence(!!msg.connected, done)
+        return
       }
 
       // Now do validation with more helpful messages
@@ -308,6 +303,7 @@ module.exports = function (RED) {
       }
 
       if (msg.payload.s2Signal !== undefined) {
+        console.warn('About to send s2Signal', msg.payload)
         switch (msg.payload.s2Signal) {
           case 'Message':
             if (!msg.payload.message) {
@@ -321,31 +317,6 @@ module.exports = function (RED) {
             }
             node.emitS2Signal(msg.payload.s2Signal, [msg.payload.reason])
             return successAndDone('Sent s2Signal "Disconnect"', done)
-          case 'PowerMeasurementStart': {
-            node._s2PowerMeasurementActive = true
-            node._s2PowerMeasurementCemId = msg.cemId
-            // Emit current values immediately so the CEM doesn't wait for the first change
-            const measurementProps = node.ifaceDesc && node.ifaceDesc.__s2PowerMeasurementProps
-            if (measurementProps && node.iface) {
-              for (const [propName, commodityQuantity] of Object.entries(measurementProps)) {
-                const propValue = node.iface[propName]
-                if (propValue !== null && propValue !== undefined) {
-                  node.send([null, {
-                    payload: {
-                      command: 'PowerMeasurement',
-                      cemId: node._s2PowerMeasurementCemId,
-                      values: [{ commodity_quantity: commodityQuantity, value: propValue }]
-                    }
-                  }])
-                }
-              }
-            }
-            return successAndDone('Power measurement started', done)
-          }
-          case 'PowerMeasurementStop':
-            node._s2PowerMeasurementActive = false
-            node._s2PowerMeasurementCemId = null
-            return successAndDone('Power measurement stopped', done)
           default:
             return failAndDone(`s2Signal "${msg.payload.s2Signal}" not implemented`, done)
         }
@@ -437,6 +408,7 @@ module.exports = function (RED) {
 
       const actualDeviceType = getActualDeviceType(config.device, config.generator_type)
       const dbusServiceType = deviceModules[config.device]?.getServiceType?.(config) ?? actualDeviceType
+      const onPropertiesChanged = deviceModules[config.device]?.onPropertiesChanged
 
       const serviceName = `com.victronenergy.${dbusServiceType}.virtual_${self.id}`
       const interfaceName = serviceName
@@ -737,6 +709,7 @@ module.exports = function (RED) {
         // TODO: S2: Should we rename this?
         // We need to add a emitCallbackS2 for S2-related property changes
         // to be able to react to imocoming connection requests and messages.
+
         function emitCallback (event, data) {
           // we could use node.context().set('bla', 42) to set (and get) state, but state disappears on redeploy
           // for global context: node.context().global.set('bla', 43)
@@ -758,20 +731,6 @@ module.exports = function (RED) {
           if (config.device === 'switch') {
             handleSwitchOutputs(config, node, propName, propValue)
           }
-
-          // S2 power measurement: emit when the changed property is a declared power measurement property
-          if (node._s2PowerMeasurementActive &&
-              ifaceDesc.__s2PowerMeasurementProps &&
-              ifaceDesc.__s2PowerMeasurementProps[propName] !== undefined &&
-              propValue !== null && propValue !== undefined) {
-            node.send([null, {
-              payload: {
-                command: 'PowerMeasurement',
-                cemId: node._s2PowerMeasurementCemId,
-                values: [{ commodity_quantity: ifaceDesc.__s2PowerMeasurementProps[propName], value: propValue }]
-              }
-            }])
-          }
         }
 
         // Then we can add the required Victron interfaces, and receive some functions to use
@@ -780,7 +739,7 @@ module.exports = function (RED) {
           getValue,
           setValuesLocally,
           emitS2Signal
-        } = addVictronInterfaces(usedBus, ifaceDesc, iface, /* add_defaults */ true, emitCallback)
+        } = addVictronInterfaces(usedBus, ifaceDesc, iface, /* add_defaults */ true, emitCallback, onPropertiesChanged)
 
         node.setValuesLocally = setValuesLocally
         node.emitS2Signal = emitS2Signal

--- a/test/victron-virtual-ev.test.js
+++ b/test/victron-virtual-ev.test.js
@@ -1,0 +1,42 @@
+// test/victron-virtual-ev.test.js
+/* eslint-env jest */
+const ev = require('../src/nodes/victron-virtual/device-type/ev')
+
+describe('ev device module', () => {
+  test('exports required contract', () => {
+    expect(typeof ev.properties).toBe('object')
+    expect(typeof ev.initialize).toBe('function')
+    expect(typeof ev.onPropertiesChanged).toBe('function')
+  })
+
+  describe('onPropertiesChanged', () => {
+    test('returns changes with LastEvContact timestamp when a property changes', () => {
+      const before = Math.floor(Date.now() / 1000)
+      const result = ev.onPropertiesChanged({ changes: { Soc: 75 } })
+      const after = Math.floor(Date.now() / 1000)
+      expect(result).toHaveProperty('LastEvContact')
+      expect(result.LastEvContact).toBeGreaterThanOrEqual(before)
+      expect(result.LastEvContact).toBeLessThanOrEqual(after)
+    })
+
+    test('does not override LastEvContact when explicitly set by caller', () => {
+      const externalContactTime = Math.floor(Date.now() / 1000) - 3600 // 1 hour ago
+      const result = ev.onPropertiesChanged({ changes: { LastEvContact: externalContactTime } })
+      expect(result.LastEvContact).toBe(externalContactTime)
+    })
+
+    test('updates LastEvContact for any non-LastEvContact property', () => {
+      const props = ['Soc', 'TargetSoc', 'ChargingState', 'Ac/Power', 'BatteryCapacity', 'AtSite', 'Connected']
+      for (const prop of props) {
+        const result = ev.onPropertiesChanged({ changes: { [prop]: 1 } })
+        expect(result).toHaveProperty('LastEvContact')
+        expect(typeof result.LastEvContact).toBe('number')
+      }
+    })
+
+    test('does not include msg in result', () => {
+      const result = ev.onPropertiesChanged({ changes: { Soc: 50 } })
+      expect(result).not.toHaveProperty('msg')
+    })
+  })
+})


### PR DESCRIPTION
Adds o`nPropertyChanged` to the ev device module so that any incoming property update automatically sets `LastEvContact` to the current Unix timestamp. Uses the `skipOnPropertyChanged` guard (same pattern as #403) to prevent recursive emitCallback calls.