### PR TITLE
fix(system): filter null D-Bus values from input/output node dropdowns

### DIFF
--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -59,7 +59,8 @@ class SystemConfiguration {
               )) &&
               (expandedPathObj.mode === 'both' ||
               (isOutput && expandedPathObj.mode === 'output') ||
-              (!isOutput && (expandedPathObj.mode === 'input' || !expandedPathObj.mode)))
+              (!isOutput && (expandedPathObj.mode === 'input' || !expandedPathObj.mode))) &&
+              cachedPaths[expandedPathObj.path] !== null
             )
 
             return pathAcc.concat(filtered)

--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -52,16 +52,15 @@ class SystemConfiguration {
             const expanded = utils.expandWildcardPaths(pathObj, cachedPaths, dbusService)
 
             const filtered = expanded.filter(expandedPathObj =>
-              (!isOutput || (
-                (expandedPathObj.path !== '/Mode' || _.get(cachedPaths, '/ModeIsAdjustable', 1)) &&
-                (expandedPathObj.path !== '/Ac/In/1/CurrentLimit' || _.get(cachedPaths, '/Ac/In/1/CurrentLimitIsAdjustable', 1)) &&
-                (expandedPathObj.path !== '/Ac/In/2/CurrentLimit' || _.get(cachedPaths, '/Ac/In/2/CurrentLimitIsAdjustable', 1))
-              )) &&
               (expandedPathObj.mode === 'both' ||
               (isOutput && expandedPathObj.mode === 'output') ||
-              (!isOutput && (expandedPathObj.mode === 'input' || !expandedPathObj.mode))) &&
-              cachedPaths[expandedPathObj.path] !== null
-            )
+              (!isOutput && (expandedPathObj.mode === 'input' || !expandedPathObj.mode)))
+            ).map(expandedPathObj => {
+              if (cachedPaths[expandedPathObj.path] === null) {
+                return { ...expandedPathObj, name: `${expandedPathObj.name} - (null)` }
+              }
+              return expandedPathObj
+            })
 
             return pathAcc.concat(filtered)
           }, [])

--- a/test/victron-system.test.js
+++ b/test/victron-system.test.js
@@ -44,6 +44,101 @@ describe('Alternator /Mode control (Orion XS in Charger mode)', () => {
   })
 })
 
+describe('getNodeServices null value filtering', () => {
+  let systemConfig
+  let originalServices
+
+  beforeEach(() => {
+    originalServices = utils.SERVICES
+    systemConfig = new SystemConfiguration()
+  })
+
+  afterEach(() => {
+    utils.SERVICES = originalServices
+  })
+
+  test('excludes paths with null D-Bus values from input node dropdown', () => {
+    utils.SERVICES = {
+      multi: {
+        multi: [
+          { path: '/Ac/In/1/CurrentLimit', type: 'float', name: 'AC Input 1 Current Limit', mode: 'both' },
+          { path: '/Ac/In/2/CurrentLimit', type: 'float', name: 'AC Input 2 Current Limit', mode: 'both' },
+          { path: '/Ac/Out/P', type: 'float', name: 'AC Output Power', mode: 'input' }
+        ]
+      }
+    }
+
+    systemConfig.cache = {
+      'com.victronenergy.multi.socketcan_vecan0_vi2_uc738825': {
+        '/Ac/In/1/CurrentLimit': 16,
+        '/Ac/In/2/CurrentLimit': null,
+        '/Ac/Out/P': 500,
+        '/DeviceInstance': 0
+      }
+    }
+
+    const result = systemConfig.getNodeServices('input-multi')
+    const paths = result.services[0].paths
+
+    expect(paths.find(p => p.path === '/Ac/In/1/CurrentLimit')).toBeDefined()
+    expect(paths.find(p => p.path === '/Ac/In/2/CurrentLimit')).toBeUndefined()
+    expect(paths.find(p => p.path === '/Ac/Out/P')).toBeDefined()
+  })
+
+  test('excludes paths with null D-Bus values from output node dropdown', () => {
+    utils.SERVICES = {
+      multi: {
+        multi: [
+          { path: '/Ac/In/1/CurrentLimit', type: 'float', name: 'AC Input 1 Current Limit', mode: 'both' },
+          { path: '/Ac/In/2/CurrentLimit', type: 'float', name: 'AC Input 2 Current Limit', mode: 'both' }
+        ]
+      }
+    }
+
+    systemConfig.cache = {
+      'com.victronenergy.multi.socketcan_vecan0_vi2_uc738825': {
+        '/Ac/In/1/CurrentLimit': 16,
+        '/Ac/In/2/CurrentLimit': null,
+        '/Ac/In/1/CurrentLimitIsAdjustable': 1,
+        '/Ac/In/2/CurrentLimitIsAdjustable': 1,
+        '/DeviceInstance': 0
+      }
+    }
+
+    const result = systemConfig.getNodeServices('output-multi')
+    const paths = result.services[0].paths
+
+    expect(paths.find(p => p.path === '/Ac/In/1/CurrentLimit')).toBeDefined()
+    expect(paths.find(p => p.path === '/Ac/In/2/CurrentLimit')).toBeUndefined()
+  })
+})
+
+describe('getCachedServices null value handling (custom nodes)', () => {
+  let systemConfig
+
+  beforeEach(() => {
+    systemConfig = new SystemConfiguration()
+    systemConfig.cache = {
+      'com.victronenergy.multi.socketcan_vecan0_vi2_uc738825': {
+        '/Ac/In/1/CurrentLimit': 16,
+        '/Ac/In/2/CurrentLimit': null,
+        '/Ac/Out/P': 500,
+        '/DeviceInstance': 0
+      }
+    }
+  })
+
+  test('custom nodes still show paths with null D-Bus values', () => {
+    const result = systemConfig.getCachedServices()
+    const service = result.services[0]
+    const paths = service.paths
+
+    expect(paths.find(p => p.path === '/Ac/In/1/CurrentLimit')).toBeDefined()
+    expect(paths.find(p => p.path === '/Ac/In/2/CurrentLimit')).toBeDefined()
+    expect(paths.find(p => p.path === '/Ac/Out/P')).toBeDefined()
+  })
+})
+
 describe('SystemConfiguration path sorting', () => {
   let systemConfig
   let originalServices

--- a/test/victron-system.test.js
+++ b/test/victron-system.test.js
@@ -44,7 +44,7 @@ describe('Alternator /Mode control (Orion XS in Charger mode)', () => {
   })
 })
 
-describe('getNodeServices null value filtering', () => {
+describe('getNodeServices null value handling', () => {
   let systemConfig
   let originalServices
 
@@ -57,7 +57,7 @@ describe('getNodeServices null value filtering', () => {
     utils.SERVICES = originalServices
   })
 
-  test('excludes paths with null D-Bus values from input node dropdown', () => {
+  test('includes paths with null D-Bus values in input node dropdown, labeled with - (null)', () => {
     utils.SERVICES = {
       multi: {
         multi: [
@@ -81,11 +81,13 @@ describe('getNodeServices null value filtering', () => {
     const paths = result.services[0].paths
 
     expect(paths.find(p => p.path === '/Ac/In/1/CurrentLimit')).toBeDefined()
-    expect(paths.find(p => p.path === '/Ac/In/2/CurrentLimit')).toBeUndefined()
+    const nullPath = paths.find(p => p.path === '/Ac/In/2/CurrentLimit')
+    expect(nullPath).toBeDefined()
+    expect(nullPath.name).toBe('AC Input 2 Current Limit - (null)')
     expect(paths.find(p => p.path === '/Ac/Out/P')).toBeDefined()
   })
 
-  test('excludes paths with null D-Bus values from output node dropdown', () => {
+  test('includes paths with null D-Bus values in output node dropdown, labeled with - (null)', () => {
     utils.SERVICES = {
       multi: {
         multi: [
@@ -109,7 +111,9 @@ describe('getNodeServices null value filtering', () => {
     const paths = result.services[0].paths
 
     expect(paths.find(p => p.path === '/Ac/In/1/CurrentLimit')).toBeDefined()
-    expect(paths.find(p => p.path === '/Ac/In/2/CurrentLimit')).toBeUndefined()
+    const nullPath = paths.find(p => p.path === '/Ac/In/2/CurrentLimit')
+    expect(nullPath).toBeDefined()
+    expect(nullPath.name).toBe('AC Input 2 Current Limit - (null)')
   })
 })
 


### PR DESCRIPTION
Paths whose cached D-Bus value is null (the empty variant []) are not applicable to the current device configuration and should not appear in the measurement dropdown of regular input/output nodes.

Custom nodes (getCachedServices) are intentionally unaffected and continue to expose null-valued paths.

Fixes a bug reported by @warwickchapman 