### PR TITLE
fix(virtual): remove default value 0 from energy counter properties

### DIFF
--- a/src/nodes/victron-virtual/device-type/energymeter.js
+++ b/src/nodes/victron-virtual/device-type/energymeter.js
@@ -10,8 +10,8 @@ const ROLE_TO_SERVICE_TYPE = {
 }
 
 const sharedProperties = {
-  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0 },
-  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0 },
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
+  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
   'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
   'Ac/PowerFactor': { type: 'd', format: (v) => v != null ? v.toFixed(2) : '' },
   Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 },

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -863,6 +863,12 @@ describe('energymeter', () => {
         expect(prop.format(null)).toBeDefined()
       }
     })
+
+    it('Ac/Energy/Forward and Ac/Energy/Reverse have no default value to avoid spurious delta on first real write', () => {
+      const props = energymeter.__sharedProperties
+      expect(props['Ac/Energy/Forward'].value).toBeUndefined()
+      expect(props['Ac/Energy/Reverse'].value).toBeUndefined()
+    })
   })
 
   describe('initialize', () => {


### PR DESCRIPTION
`Ac/Energy/Forward` and `Ac/Energy/Reverse` no longer carry value:`0` in sharedProperties. A hard-coded zero caused a large apparent delta when the user first wrote a real energy counter value.