### PR TITLE
feat(virtual-switch): show customname, group and type in node label

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1459,11 +1459,26 @@
     $('#node-input-outputs').val(outputs);
   }
 
+  /**
+   * Returns the Node-RED palette label for a virtual node.
+   * Priority: name -> customname + group + typeName -> fallback + typeName
+   * @param {{ name?: string, customname?: string, group?: string, typeName?: string, fallback?: string }} opts
+   * @returns {string}
+   */
+  function getVirtualNodeLabel ({ name, customname, group, typeName, fallback = 'Virtual' } = {}) {
+    if (name) return name
+    const parts = [customname || fallback];
+    if (group) parts.push('(' + group + ')');
+    if (typeName) parts.push('[' + typeName + ']');
+    return parts.join(' ')
+  }
+
   // src/nodes/victron-virtual-browser.js
 
   window.__victron = {
     checkGeneratorType,
     SWITCH_TYPE_CONFIGS,
+    INDICATOR_TYPE_LABELS,
     renderSwitchConfigRow,
     updateSwitchConfig,
     checkSelectedVirtualDevice,
@@ -1475,7 +1490,8 @@
     renderIndicatorDocBox,
     renderShowInUICheckboxes,
     getShowUIValue,
-    initializeTooltips
+    initializeTooltips,
+    getVirtualNodeLabel
   };
 
 })();

--- a/src/nodes/victron-virtual-browser.js
+++ b/src/nodes/victron-virtual-browser.js
@@ -2,23 +2,7 @@
 import {
   checkGeneratorType,
   SWITCH_TYPE_CONFIGS,
-  renderSwitchConfigRow,
-  updateSwitchConfig,
-  checkSelectedVirtualDevice,
-  validateSwitchConfig,
-  fetchSwitchNodeNameAndGroupFromCache,
-  updateBatteryVoltageVisibility,
-  calculateOutputs,
-  updateOutputs,
-  renderIndicatorDocBox,
-  renderShowInUICheckboxes,
-  getShowUIValue
-} from './victron-virtual-functions.js'
-import { initializeTooltips } from './victron-common.js'
-
-window.__victron = {
-  checkGeneratorType,
-  SWITCH_TYPE_CONFIGS,
+  INDICATOR_TYPE_LABELS,
   renderSwitchConfigRow,
   updateSwitchConfig,
   checkSelectedVirtualDevice,
@@ -30,5 +14,25 @@ window.__victron = {
   renderIndicatorDocBox,
   renderShowInUICheckboxes,
   getShowUIValue,
-  initializeTooltips
+  getVirtualNodeLabel
+} from './victron-virtual-functions.js'
+import { initializeTooltips } from './victron-common.js'
+
+window.__victron = {
+  checkGeneratorType,
+  SWITCH_TYPE_CONFIGS,
+  INDICATOR_TYPE_LABELS,
+  renderSwitchConfigRow,
+  updateSwitchConfig,
+  checkSelectedVirtualDevice,
+  validateSwitchConfig,
+  fetchSwitchNodeNameAndGroupFromCache,
+  updateBatteryVoltageVisibility,
+  calculateOutputs,
+  updateOutputs,
+  renderIndicatorDocBox,
+  renderShowInUICheckboxes,
+  getShowUIValue,
+  initializeTooltips,
+  getVirtualNodeLabel
 }

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1315,3 +1315,17 @@ export function formatLightControls (value, switchType) {
 
   return String(value) || ''
 }
+
+/**
+ * Returns the Node-RED palette label for a virtual node.
+ * Priority: name -> customname + group + typeName -> fallback + typeName
+ * @param {{ name?: string, customname?: string, group?: string, typeName?: string, fallback?: string }} opts
+ * @returns {string}
+ */
+export function getVirtualNodeLabel ({ name, customname, group, typeName, fallback = 'Virtual' } = {}) {
+  if (name) return name
+  const parts = [customname || fallback]
+  if (group) parts.push('(' + group + ')')
+  if (typeName) parts.push('[' + typeName + ']')
+  return parts.join(' ')
+}

--- a/src/nodes/victron-virtual-indicator.html
+++ b/src/nodes/victron-virtual-indicator.html
@@ -23,7 +23,13 @@
         inputs: 1,
         outputs: 1,
         label: function () {
-            return this.name || this.customname || 'Virtual Indicator'
+            return window.__victron.getVirtualNodeLabel({
+                name: this.name,
+                customname: this.customname,
+                group: this.group,
+                typeName: window.__victron.INDICATOR_TYPE_LABELS[this.indicator_type],
+                fallback: 'Virtual Indicator'
+            })
         },
         outputLabels: ['Passthrough'],
         oneditprepare: function () {

--- a/src/nodes/victron-virtual-switch.html
+++ b/src/nodes/victron-virtual-switch.html
@@ -28,7 +28,14 @@
         inputs:1,
         outputs:2,
         label: function() {
-            return this.name || "Virtual Switch"
+            const cfg = window.__victron.SWITCH_TYPE_CONFIGS[parseInt(this.switch_1_type, 10)]
+            return window.__victron.getVirtualNodeLabel({
+                name: this.name,
+                customname: this.switch_1_customname,
+                group: this.switch_1_group,
+                typeName: cfg ? cfg.label : 'Switch',
+                fallback: 'Virtual Switch'
+            })
         },
         outputLabels: function(index) {
             const switchType = this.switch_1_type

--- a/test/victron-virtual-switch-label.test.js
+++ b/test/victron-virtual-switch-label.test.js
@@ -1,0 +1,129 @@
+// test/victron-virtual-switch-label.test.js
+/* eslint-env jest */
+
+const {
+  getVirtualNodeLabel,
+  SWITCH_TYPE_CONFIGS,
+  INDICATOR_TYPE_LABELS
+} = require('./fixtures/victron-virtual-functions.cjs')
+
+describe('getVirtualNodeLabel', () => {
+  test('returns name when set, ignoring all other fields', () => {
+    expect(getVirtualNodeLabel({
+      name: 'My Label',
+      customname: 'Custom',
+      group: 'Group',
+      typeName: 'Toggle',
+      fallback: 'Virtual Switch'
+    })).toBe('My Label')
+  })
+
+  test('shows customname, group and typeName when name is empty', () => {
+    expect(getVirtualNodeLabel({
+      name: '',
+      customname: 'Fan',
+      group: 'Ventilation',
+      typeName: 'Toggle',
+      fallback: 'Virtual Switch'
+    })).toBe('Fan (Ventilation) [Toggle]')
+  })
+
+  test('omits group brackets when group is empty', () => {
+    expect(getVirtualNodeLabel({
+      name: '',
+      customname: 'Fan',
+      group: '',
+      typeName: 'Toggle',
+      fallback: 'Virtual Switch'
+    })).toBe('Fan [Toggle]')
+  })
+
+  test('omits type brackets when typeName is empty', () => {
+    expect(getVirtualNodeLabel({
+      name: '',
+      customname: 'My Indicator',
+      group: 'Sensors'
+    })).toBe('My Indicator (Sensors)')
+  })
+
+  test('uses fallback when customname is empty', () => {
+    expect(getVirtualNodeLabel({
+      name: '',
+      customname: '',
+      group: '',
+      typeName: 'Toggle',
+      fallback: 'Virtual Switch'
+    })).toBe('Virtual Switch [Toggle]')
+  })
+
+  test('defaults fallback to "Virtual" when not provided', () => {
+    expect(getVirtualNodeLabel({ name: '', customname: '', group: '' })).toBe('Virtual')
+  })
+})
+
+describe('virtual switch label via SWITCH_TYPE_CONFIGS', () => {
+  function switchLabel (node) {
+    const cfg = SWITCH_TYPE_CONFIGS[parseInt(node.switch_1_type, 10)]
+    return getVirtualNodeLabel({
+      name: node.name,
+      customname: node.switch_1_customname,
+      group: node.switch_1_group,
+      typeName: cfg ? cfg.label : 'Switch',
+      fallback: 'Virtual Switch'
+    })
+  }
+
+  test('shows customname, group and type for a toggle switch', () => {
+    expect(switchLabel({ name: '', switch_1_customname: 'Fan', switch_1_group: 'Ventilation', switch_1_type: 1 }))
+      .toBe('Fan (Ventilation) [Toggle]')
+  })
+
+  test('shows correct type for all switch types', () => {
+    const cases = [
+      [0, 'Momentary'],
+      [1, 'Toggle'],
+      [2, 'Dimmable'],
+      [3, 'Temperature setpoint'],
+      [4, 'Stepped switch'],
+      [6, 'Dropdown'],
+      [7, 'Basic slider'],
+      [8, 'Numeric input'],
+      [9, 'Three-state switch'],
+      [10, 'Bilge pump control']
+    ]
+    cases.forEach(([type, expectedTypeName]) => {
+      expect(switchLabel({ name: '', switch_1_customname: 'S', switch_1_group: '', switch_1_type: type }))
+        .toBe(`S [${expectedTypeName}]`)
+    })
+  })
+})
+
+describe('virtual indicator label via INDICATOR_TYPE_LABELS', () => {
+  function indicatorLabel (node) {
+    return getVirtualNodeLabel({
+      name: node.name,
+      customname: node.customname,
+      group: node.group,
+      typeName: INDICATOR_TYPE_LABELS[node.indicator_type],
+      fallback: 'Virtual Indicator'
+    })
+  }
+
+  test('shows customname, group and indicator type', () => {
+    expect(indicatorLabel({ name: '', customname: 'Solar', group: 'Energy', indicator_type: 1 }))
+      .toBe('Solar (Energy) [Value]')
+  })
+
+  test('shows correct type for all indicator types', () => {
+    const cases = [
+      [0, 'Discrete'],
+      [1, 'Value'],
+      [2, 'Value with range'],
+      [3, 'Temperature']
+    ]
+    cases.forEach(([type, expectedTypeName]) => {
+      expect(indicatorLabel({ name: '', customname: 'I', group: '', indicator_type: type }))
+        .toBe(`I [${expectedTypeName}]`)
+    })
+  })
+})


### PR DESCRIPTION
When the Name field is left empty, the virtual switch and indicator nodes now fall back to a label built from the configured custom name, group and switch/indicator type (e.g. "Fan (Ventilation) [Toggle]") instead of a plain "Virtual Switch" / "Virtual Indicator" string.

Shared getVirtualNodeLabel() added to victron-virtual-functions.js and exposed on window.__victron so both nodes use the same logic. INDICATOR_TYPE_LABELS also added to window.__victron for indicator type name lookup.

Closes #464