### PR TITLE
fix(ev): correct ChargingState enum values per VRM D-Bus spec

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -550,7 +550,7 @@
         <ul>
           <li><code>/Soc</code> &mdash; State of charge as a percentage (0-100%).</li>
           <li><code>/TargetSoc</code> &mdash; Target state of charge as a percentage (0-100%).</li>
-          <li><code>/ChargingState</code> &mdash; Charging state: <code>0</code> = Disconnected, <code>1</code> = Connected, <code>2</code> = Charging, <code>3</code> = Charged, <code>5</code> = Inverting, <code>6</code> = Error, <code>7</code> = Unknown.</li>
+          <li><code>/ChargingState</code> &mdash; Charging state: <code>0</code> = Not charging, <code>1</code> = Low power mode, <code>3</code> = Charging, <code>256</code> = Discharging, <code>259</code> = Scheduled charging. Also supported: <code>244</code> = Sustain, <code>245</code> = Wake up, <code>250</code> = Blocked, <code>255</code> = Unavailable.</li>
           <li><code>/Ac/Power</code> &mdash; AC power in watts. Positive = charging, negative = discharging (V2G/V2H).</li>
           <li><code>/Odometer</code> &mdash; Odometer reading in km.</li>
           <li><code>/RangeToGo</code> &mdash; Estimated driving range in km.</li>

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -287,7 +287,7 @@ export const DEVICE_TYPE_DOCS = {
         <ul>
           <li><code>/Soc</code> &mdash; State of charge as a percentage (0-100%).</li>
           <li><code>/TargetSoc</code> &mdash; Target state of charge as a percentage (0-100%).</li>
-          <li><code>/ChargingState</code> &mdash; Charging state: <code>0</code> = Disconnected, <code>1</code> = Connected, <code>2</code> = Charging, <code>3</code> = Charged, <code>5</code> = Inverting, <code>6</code> = Error, <code>7</code> = Unknown.</li>
+          <li><code>/ChargingState</code> &mdash; Charging state: <code>0</code> = Not charging, <code>1</code> = Low power mode, <code>3</code> = Charging, <code>256</code> = Discharging, <code>259</code> = Scheduled charging. Also supported: <code>244</code> = Sustain, <code>245</code> = Wake up, <code>250</code> = Blocked, <code>255</code> = Unavailable.</li>
           <li><code>/Ac/Power</code> &mdash; AC power in watts. Positive = charging, negative = discharging (V2G/V2H).</li>
           <li><code>/Odometer</code> &mdash; Odometer reading in km.</li>
           <li><code>/RangeToGo</code> &mdash; Estimated driving range in km.</li>

--- a/src/nodes/victron-virtual/device-type/ev.js
+++ b/src/nodes/victron-virtual/device-type/ev.js
@@ -5,13 +5,15 @@ const properties = {
   ChargingState: {
     type: 'i',
     format: (v) => ({
-      0: 'Disconnected',
-      1: 'Connected',
-      2: 'Charging',
-      3: 'Charged',
-      5: 'Inverting',
-      6: 'Error',
-      7: 'Unknown'
+      0: 'Not charging',
+      1: 'Low power mode',
+      3: 'Charging',
+      244: 'Sustain',
+      245: 'Wake up',
+      250: 'Blocked',
+      255: 'Unavailable',
+      256: 'Discharging',
+      259: 'Scheduled charging'
     }[v] || 'unknown')
   },
   BatteryCapacity: { type: 'd', format: (v) => v != null ? v.toFixed(0) + 'kWh' : '', persist: true },

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -242,13 +242,16 @@ describe('ev', () => {
 
     const chargingStateFmt = ev.properties.ChargingState.format
     test.each([
-      [0, 'Disconnected'],
-      [1, 'Connected'],
-      [2, 'Charging'],
-      [3, 'Charged'],
-      [5, 'Inverting'],
-      [6, 'Error'],
-      [7, 'Unknown'],
+      [0, 'Not charging'],
+      [1, 'Low power mode'],
+      [3, 'Charging'],
+      [244, 'Sustain'],
+      [245, 'Wake up'],
+      [250, 'Blocked'],
+      [255, 'Unavailable'],
+      [256, 'Discharging'],
+      [259, 'Scheduled charging'],
+      [2, 'unknown'],
       [99, 'unknown']
     ])('ChargingState %i -> %s', (v, expected) => {
       expect(chargingStateFmt(v)).toBe(expected)

--- a/test/victron-virtual-ev.test.js
+++ b/test/victron-virtual-ev.test.js
@@ -9,6 +9,33 @@ describe('ev device module', () => {
     expect(typeof ev.onPropertiesChanged).toBe('function')
   })
 
+  describe('ChargingState format', () => {
+    const fmt = ev.properties.ChargingState.format
+
+    test.each([
+      [0, 'Not charging'],
+      [1, 'Low power mode'],
+      [3, 'Charging'],
+      [244, 'Sustain'],
+      [245, 'Wake up'],
+      [250, 'Blocked'],
+      [255, 'Unavailable'],
+      [256, 'Discharging'],
+      [259, 'Scheduled charging']
+    ])('value %i formats to "%s"', (value, expected) => {
+      expect(fmt(value)).toBe(expected)
+    })
+
+    test('unknown value returns "unknown"', () => {
+      expect(fmt(2)).toBe('unknown')
+      expect(fmt(99)).toBe('unknown')
+    })
+
+    test('null returns "unknown"', () => {
+      expect(fmt(null)).toBe('unknown')
+    })
+  })
+
   describe('onPropertiesChanged', () => {
     test('returns changes with LastEvContact timestamp when a property changes', () => {
       const before = Math.floor(Date.now() / 1000)


### PR DESCRIPTION
Previous values (0=Disconnected, 1=Connected, 2=Charging, 3=Charged, 5=Inverting, 6=Error, 7=Unknown) did not match the actual [Venus OS D-Bus spec](https://github.com/victronenergy/venus/wiki/dbus#ev). Correct values are: 0=Not charging, 1=Low power mode, 3=Charging, 244=Sustain, 245=Wake up, 250=Blocked, 255=Unavailable, 256=Discharging, 259=Scheduled charging.

Update tests and node UI documentation accordingly.