### PR TITLE
fix(virtual): add /State path to switch and indicator nodes

### DIFF
--- a/src/services/virtual-indicator.js
+++ b/src/services/virtual-indicator.js
@@ -99,6 +99,8 @@ function createIndicatorProperties (config, ifaceDesc, iface) {
     }
   })
 
+  ifaceDesc.properties.State = { type: 'i' }
+  iface.State = 0x100
   ifaceDesc.properties.CustomName = { type: 's', persist: true }
   ifaceDesc.properties.DeviceInstance = { type: 'i' }
   ifaceDesc.properties.Serial = { type: 's', persist: true }

--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -96,6 +96,8 @@ function createSwitchProperties (config, ifaceDesc, iface) {
     persist: true
   }
 
+  ifaceDesc.properties.State = { type: 'i' }
+  iface.State = 0x100
   ifaceDesc.properties.DeviceInstance = { type: 'i' }
   ifaceDesc.properties.Serial = { type: 's', persist: true }
 

--- a/test/victron-virtual-indicator.test.js
+++ b/test/victron-virtual-indicator.test.js
@@ -42,6 +42,13 @@ describe('createIndicatorProperties', () => {
       expect(iface['GenericInput/0/Settings/Group']).toBe('Indicators')
     })
 
+    test('sets top-level State to 0x100 (Running)', () => {
+      const { ifaceDesc, iface } = makeIfaceAndDesc()
+      createIndicatorProperties({}, ifaceDesc, iface)
+      expect(iface['State']).toBe(0x100)
+      expect(ifaceDesc.properties['State']).toBeDefined()
+    })
+
     test('sets Settings/ShowUIInput to 1 by default', () => {
       const { ifaceDesc, iface } = makeIfaceAndDesc()
       createIndicatorProperties({}, ifaceDesc, iface)

--- a/test/virtual-switch.test.js
+++ b/test/virtual-switch.test.js
@@ -259,6 +259,16 @@ describe('handleSwitchOutputs', () => {
   })
 })
 
+describe('createSwitchProperties - State', () => {
+  test('sets top-level State to 0x100 (Running)', () => {
+    const ifaceDesc = { properties: {} }
+    const iface = {}
+    createSwitchProperties({ switch_1_type: SWITCH_TYPE_MAP.TOGGLE }, ifaceDesc, iface)
+    expect(iface['State']).toBe(0x100)
+    expect(ifaceDesc.properties['State']).toBeDefined()
+  })
+})
+
 describe('createSwitchProperties - ShowUIControl', () => {
   const showUIKey = 'SwitchableOutput/output_1/Settings/ShowUIControl'
 


### PR DESCRIPTION
Add State = 0x100 (Running) to createSwitchProperties and createIndicatorProperties. Note: iface.State uses dot notation because the standard linter auto-converts bracket notation for simple keys.

Closes #472.

(note that I had accidentally pushed (and reverted) this into master before). 