### PR TITLE
feat(conditional): add hysteresis to conditional input node (#418)

### DIFF
--- a/resources/victron-styles.css
+++ b/resources/victron-styles.css
@@ -417,6 +417,12 @@
   box-sizing: border-box;
 }
 
+.victron-form .victron-condition-section .form-warning,
+.victron-form .victron-condition-section .form-info,
+.victron-form .victron-condition-section .form-tips {
+  width: auto;
+}
+
 .victron-form .victron-condition-header {
   display: flex;
   justify-content: space-between;
@@ -478,7 +484,7 @@
 .victron-form .victron-condition-row input[type="number"],
 .victron-form .victron-condition-row select,
 .victron-form .victron-logic-row .victron-logic-toggle {
-  width: 220px !important;
+  width: 210px !important;
 }
 
 /* Add condition button */

--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -130,6 +130,37 @@
                     <label for="node-input-condition1-threshold">Threshold</label>
                     <input type="number" id="node-input-condition1-threshold" placeholder="e.g., 50" step="any" autocomplete="off" data-lpignore="true">
                 </div>
+
+                <!-- Hysteresis (Advanced) -->
+                <div class="form-row victron-condition-row">
+                    <label>&nbsp;</label>
+                    <button type="button" id="toggle-hysteresis-btn" class="victron-add-condition-btn">
+                        <i class="fa fa-chevron-right" id="hysteresis-chevron"></i> Advanced: Hysteresis
+                    </button>
+                </div>
+                <div id="hysteresis-panel" class="hidden">
+                    <div class="form-tips">
+                        Hysteresis prevents rapid switching near a threshold. Example: turn ON above 80%, turn OFF only when it drops below 70%.
+                    </div>
+                    <div class="form-row victron-condition-row">
+                        <label for="node-input-condition1HysteresisEnabled">
+                            Enable hysteresis
+                            <i class="fa fa-info-circle tooltip-icon" data-tooltip="When enabled, the condition stays TRUE until the value crosses a second (turn-off) threshold, preventing rapid switching near the main threshold."></i>
+                        </label>
+                        <input type="checkbox" id="node-input-condition1HysteresisEnabled">
+                    </div>
+                    <div id="hysteresis-threshold-row" class="form-row victron-condition-row hidden">
+                        <label for="node-input-condition1HysteresisThreshold">
+                            Turn-off threshold
+                            <i class="fa fa-info-circle tooltip-icon" data-tooltip="Value at which the condition switches back to FALSE. Should be on the opposite side of the main threshold (e.g., main > 80, turn-off < 70)."></i>
+                        </label>
+                        <input type="number" id="node-input-condition1HysteresisThreshold" placeholder="e.g., 70" step="any" autocomplete="off" data-lpignore="true">
+                    </div>
+                    <div class="form-warning hidden" id="hysteresis-warning">
+                        <i class="fa fa-exclamation-circle"></i>
+                        <span id="hysteresis-warning-text"></span>
+                    </div>
+                </div>
             </div>
 
             <!-- Second Condition Toggle -->
@@ -422,12 +453,49 @@
                 if (node.logicOperator) $('input[name="logicOperator"][value="' + node.logicOperator + '"]').prop('checked', true);
             }
 
+            // Restore hysteresis state
+            if (node.condition1HysteresisEnabled) {
+                $('#hysteresis-panel').removeClass('hidden').show();
+                $('#hysteresis-chevron').removeClass('fa-chevron-right').addClass('fa-chevron-down');
+                $('#node-input-condition1HysteresisEnabled').prop('checked', true);
+                $('#hysteresis-threshold-row').removeClass('hidden').show();
+                if (node.condition1HysteresisThreshold !== undefined) {
+                    $('#node-input-condition1HysteresisThreshold').val(node.condition1HysteresisThreshold);
+                }
+            }
+
             // Restore output configuration
             if (node.outputTrue !== undefined) $('#node-input-outputTrue').val(node.outputTrue);
             if (node.outputFalse !== undefined) $('#node-input-outputFalse').val(node.outputFalse);
             // outputOnChange is now always enforced to true in the backend for conditional mode
             if (node.debounce !== undefined) $('#node-input-debounce').val(node.debounce);
         }
+
+        // Toggle hysteresis advanced panel
+        $('#toggle-hysteresis-btn').on('click', function() {
+            const $panel = $('#hysteresis-panel');
+            const $chevron = $('#hysteresis-chevron');
+            if ($panel.is(':visible')) {
+                $panel.slideUp(200);
+                $chevron.removeClass('fa-chevron-down').addClass('fa-chevron-right');
+            } else {
+                $panel.removeClass('hidden').slideDown(200);
+                $chevron.removeClass('fa-chevron-right').addClass('fa-chevron-down');
+            }
+        });
+
+        // Show/hide hysteresis threshold field based on checkbox
+        $('#node-input-condition1HysteresisEnabled').on('change', function() {
+            if ($(this).is(':checked')) {
+                $('#hysteresis-threshold-row').removeClass('hidden').slideDown(200);
+            } else {
+                $('#hysteresis-threshold-row').slideUp(200, function() {
+                    $('#hysteresis-threshold-row').addClass('hidden');
+                    $('#node-input-condition1HysteresisThreshold').val('');
+                });
+            }
+            validateHysteresisThreshold();
+        });
 
         // Toggle conditional mode panel
         $conditionalMode.on('change', function() {
@@ -470,6 +538,8 @@
 
         // Threshold validation
         const $thresholdWarning = $('#threshold-warning');
+        const $hysteresisWarning = $('#hysteresis-warning');
+        const $hysteresisWarningText = $('#hysteresis-warning-text');
 
         function validateThreshold() {
             if (!$conditionalMode.is(':checked')) {
@@ -485,23 +555,67 @@
             return true;
         }
 
+        function validateHysteresisThreshold() {
+            const showWarning = function(msg) {
+                $hysteresisWarningText.text(msg);
+                $hysteresisWarning.removeClass('hidden').show();
+                return false;
+            };
+            $hysteresisWarning.hide();
+
+            if (!$conditionalMode.is(':checked')) return true;
+            if (!$('#node-input-condition1HysteresisEnabled').is(':checked')) return true;
+
+            const operator = $('#node-input-condition1-operator').val();
+
+            if (operator === '==' || operator === '!=') {
+                return showWarning('Hysteresis has no effect with == or != operators.');
+            }
+
+            const hysteresisVal = $('#node-input-condition1HysteresisThreshold').val();
+            if (hysteresisVal === '' || hysteresisVal === null || hysteresisVal === undefined) {
+                return showWarning('Turn-off threshold is required when hysteresis is enabled.');
+            }
+
+            const mainThreshold = parseFloat($('#node-input-condition1-threshold').val());
+            const hysteresisThreshold = parseFloat(hysteresisVal);
+
+            if (isNaN(mainThreshold)) return true; // main threshold not yet filled in
+
+            if ((operator === '>' || operator === '>=') && hysteresisThreshold >= mainThreshold) {
+                return showWarning('Turn-off threshold must be lower than the main threshold (e.g., main > 80, turn-off < 70).');
+            }
+            if ((operator === '<' || operator === '<=') && hysteresisThreshold <= mainThreshold) {
+                return showWarning('Turn-off threshold must be higher than the main threshold (e.g., main < 20, turn-off > 30).');
+            }
+
+            return true;
+        }
+
         // Update preview when operator/threshold changes (no data fetch needed)
         $('#node-input-condition1-operator, #node-input-condition1-threshold, ' +
           '#node-input-condition2-operator, #node-input-condition2-threshold, ' +
           'input[name="logicOperator"]').on('change input', function() {
             updateLivePreview();
             validateThreshold();
+            validateHysteresisThreshold();
+        });
+
+        $('#node-input-condition1HysteresisThreshold').on('input change', function() {
+            validateHysteresisThreshold();
         });
 
         // Start preview and fetch initial data when conditional mode is enabled
         $conditionalMode.on('change', function() {
             if ($(this).is(':checked')) {
                 validateThreshold();
+                validateHysteresisThreshold();
                 setTimeout(function() {
                     startLivePreview();
                 }, 100);
             } else {
                 validateThreshold();
+                validateHysteresisThreshold();
             }
         });
 
@@ -969,6 +1083,14 @@
                 node.condition1Operator = $('#node-input-condition1-operator').val();
                 node.condition1Threshold = parseFloat($('#node-input-condition1-threshold').val());
 
+                // Hysteresis
+                node.condition1HysteresisEnabled = $('#node-input-condition1HysteresisEnabled').is(':checked');
+                if (node.condition1HysteresisEnabled) {
+                    node.condition1HysteresisThreshold = parseFloat($('#node-input-condition1HysteresisThreshold').val());
+                } else {
+                    delete node.condition1HysteresisThreshold;
+                }
+
                 // Condition 2
                 node.condition2Enabled = $('#condition-2-panel').is(':visible');
                 if (node.condition2Enabled) {
@@ -1005,6 +1127,8 @@
                 // Clear all conditional mode data if disabled
                 delete node.condition1Operator;
                 delete node.condition1Threshold;
+                delete node.condition1HysteresisEnabled;
+                delete node.condition1HysteresisThreshold;
                 delete node.condition2Enabled;
                 delete node.condition2Service;
                 delete node.condition2Path;
@@ -1109,6 +1233,8 @@
                 conditionalMode: { value: false },
                 condition1Operator: { value: ">" },
                 condition1Threshold: { value: undefined },
+                condition1HysteresisEnabled: { value: false },
+                condition1HysteresisThreshold: { value: undefined },
                 condition2Enabled: { value: false },
                 condition2Service: { value: "" },
                 condition2Path: { value: "" },

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -70,6 +70,8 @@ module.exports = function (RED) {
       this.conditionalMode = nodeDefinition.conditionalMode || false
       this.condition1Operator = nodeDefinition.condition1Operator
       this.condition1Threshold = nodeDefinition.condition1Threshold
+      this.condition1HysteresisEnabled = nodeDefinition.condition1HysteresisEnabled || false
+      this.condition1HysteresisThreshold = nodeDefinition.condition1HysteresisThreshold
       this.condition2Enabled = nodeDefinition.condition2Enabled || false
       this.condition2Service = nodeDefinition.condition2Service
       this.condition2Path = nodeDefinition.condition2Path
@@ -84,6 +86,7 @@ module.exports = function (RED) {
 
       // Conditional mode state
       this.condition1CurrentValue = null
+      this.condition1LastResult = null // Tracks condition 1 result for hysteresis
       this.condition2CurrentValue = null
       this.lastConditionalResult = null
       this.pendingConditionalResult = null // Track what result we're debouncing towards
@@ -213,12 +216,41 @@ module.exports = function (RED) {
           }
         }
 
+        // Returns the inverse operator for hysteresis "turn-off" check
+        const getInverseOperator = (operator) => {
+          const inverseOps = { '>': '<=', '>=': '<', '<': '>=', '<=': '>' }
+          return inverseOps[operator] || null
+        }
+
+        // Evaluates a condition with optional hysteresis using previousResult as state
+        const evaluateConditionWithHysteresis = (currentValue, operator, threshold, hysteresisEnabled, hysteresisThreshold, previousResult) => {
+          if (!hysteresisEnabled) {
+            return evaluateCondition(currentValue, operator, threshold)
+          }
+          const inverseOp = getInverseOperator(operator)
+          if (!inverseOp) {
+            // == and != don't have a meaningful inverse; fall back to normal evaluation
+            return evaluateCondition(currentValue, operator, threshold)
+          }
+          if (previousResult === true) {
+            // Currently ON: stay ON unless value crosses the hysteresis threshold
+            const shouldTurnOff = evaluateCondition(currentValue, inverseOp, hysteresisThreshold)
+            if (shouldTurnOff === null) return null
+            return !shouldTurnOff
+          }
+          // Currently OFF (or unknown on first evaluation): use main threshold to turn ON
+          return evaluateCondition(currentValue, operator, threshold)
+        }
+
         // Evaluate conditions and send conditional output
         this.evaluateAndSendConditional = (topic, primaryValue) => {
-          const result1 = evaluateCondition(
+          const result1 = evaluateConditionWithHysteresis(
             this.condition1CurrentValue,
             this.condition1Operator,
-            this.condition1Threshold
+            this.condition1Threshold,
+            this.condition1HysteresisEnabled,
+            this.condition1HysteresisThreshold,
+            this.condition1LastResult
           )
 
           if (result1 === null) {
@@ -227,6 +259,8 @@ module.exports = function (RED) {
             }
             return
           }
+
+          this.condition1LastResult = result1
 
           let result2 = null
           if (this.condition2Enabled) {
@@ -297,14 +331,17 @@ module.exports = function (RED) {
             : parseOutputValue(this.outputFalse, false)
 
           // Build diagnostic info
-          const info = {
-            condition1: {
-              value: this.condition1CurrentValue,
-              operator: this.condition1Operator,
-              threshold: this.condition1Threshold,
-              result: result1
-            }
+          const condition1Info = {
+            value: this.condition1CurrentValue,
+            operator: this.condition1Operator,
+            threshold: this.condition1Threshold,
+            result: result1,
+            hysteresisEnabled: this.condition1HysteresisEnabled
           }
+          if (this.condition1HysteresisEnabled) {
+            condition1Info.hysteresisThreshold = this.condition1HysteresisThreshold
+          }
+          const info = { condition1: condition1Info }
 
           if (this.condition2Enabled) {
             info.condition2 = {

--- a/test/victron-nodes.conditional.test.js
+++ b/test/victron-nodes.conditional.test.js
@@ -1,14 +1,14 @@
-const victronNodesInitFunction = require('../src/nodes/victron-nodes');
+const victronNodesInitFunction = require('../src/nodes/victron-nodes')
 
 /**
  * Creates a mock global context for Node-RED
  * @returns {Object} Mock global context with set/get methods
  */
-function createMockGlobalContext() {
-    return {
-        set: jest.fn(),
-        get: jest.fn()
-    };
+function createMockGlobalContext () {
+  return {
+    set: jest.fn(),
+    get: jest.fn()
+  }
 }
 
 /**
@@ -19,21 +19,21 @@ function createMockGlobalContext() {
  * @param {Function} options.removeStatusListener - Mock removeStatusListener function
  * @returns {Object} Mock victron-client node
  */
-function createMockVictronClientNode({ subscribe, addStatusListener, removeStatusListener }) {
-    return {
-        addStatusListener,
-        removeStatusListener,
-        client: {
-            subscribe,
-            unsubscribe: jest.fn(),
-            client: {
-                connected: true,
-                getValue: jest.fn(),
-                services: {}
-            }
-        },
-        showValues: true
-    };
+function createMockVictronClientNode ({ subscribe, addStatusListener, removeStatusListener }) {
+  return {
+    addStatusListener,
+    removeStatusListener,
+    client: {
+      subscribe,
+      unsubscribe: jest.fn(),
+      client: {
+        connected: true,
+        getValue: jest.fn(),
+        services: {}
+      }
+    },
+    showValues: true
+  }
 }
 
 /**
@@ -42,553 +42,699 @@ function createMockVictronClientNode({ subscribe, addStatusListener, removeStatu
  * @param {Function} handleStatus - Status handler for validation
  * @returns {Function} createNode function
  */
-function createMockCreateNode(globalContext, handleStatus) {
-    return function(self, config) {
-        Object.assign(self, config);
-        self.node = self;
-        self.on = jest.fn();
-        self.send = jest.fn();
-        self.status = jest.fn((message) => {
-            handleStatus(self, message, self, false);
-        });
-        self.context = jest.fn().mockReturnValue({
-            global: globalContext
-        });
-    };
+function createMockCreateNode (globalContext, handleStatus) {
+  return function (self, config) {
+    Object.assign(self, config)
+    self.node = self
+    self.on = jest.fn()
+    self.send = jest.fn()
+    self.status = jest.fn((message) => {
+      handleStatus(self, message, self, false)
+    })
+    self.context = jest.fn().mockReturnValue({
+      global: globalContext
+    })
+  }
 }
 
 /**
  * Creates the complete mock RED object for testing
  * @returns {Object} Object containing mockRED and helper references
  */
-function createMockRED() {
-    const handleStatus = jest.fn(function(_node, message, _reportingNode, _muteStatusEvent) {
-        if (message.hasOwnProperty('text') && typeof message.text !== 'string') {
-            message.text = message.text.toString();
-        }
-    });
+function createMockRED () {
+  const handleStatus = jest.fn(function (_node, message, _reportingNode, _muteStatusEvent) {
+    if (Object.prototype.hasOwnProperty.call(message, 'text') && typeof message.text !== 'string') {
+      message.text = message.text.toString()
+    }
+  })
 
-    const globalContext = createMockGlobalContext();
-    const subscribe = jest.fn();
-    const addStatusListener = jest.fn();
-    const removeStatusListener = jest.fn();
+  const globalContext = createMockGlobalContext()
+  const subscribe = jest.fn()
+  const addStatusListener = jest.fn()
+  const removeStatusListener = jest.fn()
 
-    const victronClientNode = createMockVictronClientNode({
-        subscribe,
-        addStatusListener,
-        removeStatusListener
-    });
+  const victronClientNode = createMockVictronClientNode({
+    subscribe,
+    addStatusListener,
+    removeStatusListener
+  })
 
-    const getNodeFn = function getNode(id) {
-        if (id === 'victron-client-id') {
-            return victronClientNode;
-        }
-        throw new Error('[mock getNode] Node not found: ' + id);
-    };
+  const getNodeFn = function getNode (id) {
+    if (id === 'victron-client-id') {
+      return victronClientNode
+    }
+    throw new Error('[mock getNode] Node not found: ' + id)
+  }
 
-    const mockRED = {
-        nodes: {
-            registerType: jest.fn(),
-            createNode: createMockCreateNode(globalContext, handleStatus),
-            getNode: getNodeFn
-        }
-    };
+  const mockRED = {
+    nodes: {
+      registerType: jest.fn(),
+      createNode: createMockCreateNode(globalContext, handleStatus),
+      getNode: getNodeFn
+    }
+  }
 
-    return {
-        mockRED,
-        subscribe,
-        addStatusListener,
-        removeStatusListener,
-        globalContext,
-        handleStatus,
-        victronClientNode
-    };
+  return {
+    mockRED,
+    subscribe,
+    addStatusListener,
+    removeStatusListener,
+    globalContext,
+    handleStatus,
+    victronClientNode
+  }
 }
 
 describe('victron-nodes conditional mode', () => {
-    // Mock Node-RED environment
-    let mockRED;
-    let subscribe, addStatusListener, removeStatusListener;
-    let globalContext;
-    let handleStatus;
+  // Mock Node-RED environment
+  let mockRED
+  let subscribe, addStatusListener
 
-    beforeEach(() => {
-        const mocks = createMockRED();
-        mockRED = mocks.mockRED;
-        subscribe = mocks.subscribe;
-        addStatusListener = mocks.addStatusListener;
-        removeStatusListener = mocks.removeStatusListener;
-        globalContext = mocks.globalContext;
-        handleStatus = mocks.handleStatus;
+  beforeEach(() => {
+    const mocks = createMockRED()
+    mockRED = mocks.mockRED
+    subscribe = mocks.subscribe
+    addStatusListener = mocks.addStatusListener
 
-        // Initialize the nodes
-        victronNodesInitFunction(mockRED);
-    });
+    // Initialize the nodes
+    victronNodesInitFunction(mockRED)
+  })
 
-    const getBaseInputNodeDef = () => {
-        // Find the specific 'victron-input-battery' registration to get the defaults
-        const registerCall = mockRED.nodes.registerType.mock.calls.find(call => call[0] === 'victron-input-battery');
-        if (!registerCall) {
-            throw new Error('victron-input-battery node not registered');
-        }
-        return registerCall[1]; // This is the entire node definition object
-    };
+  const getBaseInputNodeDef = () => {
+    // Find the specific 'victron-input-battery' registration to get the defaults
+    const registerCall = mockRED.nodes.registerType.mock.calls.find(call => call[0] === 'victron-input-battery')
+    if (!registerCall) {
+      throw new Error('victron-input-battery node not registered')
+    }
+    return registerCall[1] // This is the entire node definition object
+  }
 
-    // Helper to get a specific output message from a specific node.send call
-    const getMessageFromSendCall = (node, sendCallIndex, outputIndex = 0) => {
-        if (!node.send.mock.calls[sendCallIndex]) return undefined;
-        return node.send.mock.calls[sendCallIndex][0][outputIndex];
-    };
+  // Helper to get a specific output message from a specific node.send call
+  const getMessageFromSendCall = (node, sendCallIndex, outputIndex = 0) => {
+    if (!node.send.mock.calls[sendCallIndex]) return undefined
+    return node.send.mock.calls[sendCallIndex][0][outputIndex]
+  }
 
-    // Helper to get the last status text
-    const getLastStatusText = (node) => {
-        if (!node.status.mock.calls.length) return undefined;
-        const lastCallArgs = node.status.mock.calls[node.status.mock.calls.length - 1][0];
-        return lastCallArgs.text;
-    };
+  // Helper to get the last status text
+  const getLastStatusText = (node) => {
+    if (!node.status.mock.calls.length) return undefined
+    const lastCallArgs = node.status.mock.calls[node.status.mock.calls.length - 1][0]
+    return lastCallArgs.text
+  }
 
-    // Test for basic conditional mode functionality
-    it('should send payload to output 1 and conditional result to output 2 when conditional mode is enabled (single condition - TRUE)', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Conditional Test Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.5,
-            outputTrue: 'Condition Met',
-            outputFalse: 'Condition Not Met',
-            debounce: 0
-        });
+  // Test for basic conditional mode functionality
+  it('should send payload to output 1 and conditional result to output 2 when conditional mode is enabled (single condition - TRUE)', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Conditional Test Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.5,
+      outputTrue: 'Condition Met',
+      outputFalse: 'Condition Not Met',
+      debounce: 0
+    })
 
-        // Simulate a value that makes the condition TRUE
-        subscribe.mock.calls[0][2]({ value: 13.0 }); // Primary value
+    // Simulate a value that makes the condition TRUE
+    subscribe.mock.calls[0][2]({ value: 13.0 }) // Primary value
 
-        expect(node.send).toHaveBeenCalledTimes(2); // One for primary, one for conditional
-        expect(getMessageFromSendCall(node, 0, 0)).toEqual({ // First send call, first output
-            payload: 13.0,
-            topic: 'Conditional Test Node'
-        });
-        expect(getMessageFromSendCall(node, 0, 1)).toBeNull(); // First send call, second output is null
+    expect(node.send).toHaveBeenCalledTimes(2) // One for primary, one for conditional
+    expect(getMessageFromSendCall(node, 0, 0)).toEqual({ // First send call, first output
+      payload: 13.0,
+      topic: 'Conditional Test Node'
+    })
+    expect(getMessageFromSendCall(node, 0, 1)).toBeNull() // First send call, second output is null
 
-        expect(getMessageFromSendCall(node, 1, 0)).toBeNull(); // Second send call, first output is null
-        expect(getMessageFromSendCall(node, 1, 1)).toEqual({ // Second send call, second output
-            payload: 'Condition Met',
-            topic: 'Conditional Test Node',
-            info: expect.any(Object)
-        });
-        expect(getLastStatusText(node)).toBe('13 | true');
-    });
+    expect(getMessageFromSendCall(node, 1, 0)).toBeNull() // Second send call, first output is null
+    expect(getMessageFromSendCall(node, 1, 1)).toEqual({ // Second send call, second output
+      payload: 'Condition Met',
+      topic: 'Conditional Test Node',
+      info: expect.any(Object)
+    })
+    expect(getLastStatusText(node)).toBe('13 | true')
+  })
 
-    it('should send payload to output 1 and conditional result to output 2 when conditional mode is enabled (single condition - FALSE)', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Conditional Test Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.5,
-            outputTrue: 'Condition Met',
-            outputFalse: 'Condition Not Met',
-            debounce: 0
-        });
+  it('should send payload to output 1 and conditional result to output 2 when conditional mode is enabled (single condition - FALSE)', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Conditional Test Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.5,
+      outputTrue: 'Condition Met',
+      outputFalse: 'Condition Not Met',
+      debounce: 0
+    })
 
-        // Simulate a value that makes the condition FALSE
-        subscribe.mock.calls[0][2]({ value: 12.0 }); // Primary value
+    // Simulate a value that makes the condition FALSE
+    subscribe.mock.calls[0][2]({ value: 12.0 }) // Primary value
 
-        expect(node.send).toHaveBeenCalledTimes(2);
-        expect(getMessageFromSendCall(node, 0, 0)).toEqual({
-            payload: 12.0,
-            topic: 'Conditional Test Node'
-        });
-        expect(getMessageFromSendCall(node, 0, 1)).toBeNull();
+    expect(node.send).toHaveBeenCalledTimes(2)
+    expect(getMessageFromSendCall(node, 0, 0)).toEqual({
+      payload: 12.0,
+      topic: 'Conditional Test Node'
+    })
+    expect(getMessageFromSendCall(node, 0, 1)).toBeNull()
 
-        expect(getMessageFromSendCall(node, 1, 0)).toBeNull();
-        expect(getMessageFromSendCall(node, 1, 1)).toEqual({
-            payload: 'Condition Not Met',
-            topic: 'Conditional Test Node',
-            info: expect.any(Object)
-        });
-        expect(getLastStatusText(node)).toBe('12 | false');
-    });
+    expect(getMessageFromSendCall(node, 1, 0)).toBeNull()
+    expect(getMessageFromSendCall(node, 1, 1)).toEqual({
+      payload: 'Condition Not Met',
+      topic: 'Conditional Test Node',
+      info: expect.any(Object)
+    })
+    expect(getLastStatusText(node)).toBe('12 | false')
+  })
 
-    it('should handle null/undefined primary input value gracefully', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Conditional Test Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.5,
-            outputTrue: 'Condition Met',
-            outputFalse: 'Condition Not Met',
-            debounce: 0
-        });
+  it('should handle null/undefined primary input value gracefully', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Conditional Test Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.5,
+      outputTrue: 'Condition Met',
+      outputFalse: 'Condition Not Met',
+      debounce: 0
+    })
 
-        // Simulate a null value for the primary input
-        subscribe.mock.calls[0][2]({ value: null });
+    // Simulate a null value for the primary input
+    subscribe.mock.calls[0][2]({ value: null })
 
-        // Expect primary output to still send null payload
-        expect(node.send).toHaveBeenCalledTimes(1); // Only the primary output send
-        expect(getMessageFromSendCall(node, 0, 0)).toEqual({
-            payload: null,
-            topic: 'Conditional Test Node'
-        });
-        expect(getMessageFromSendCall(node, 0, 1)).toBeNull();
-        // Expect no conditional output yet, status waiting
-        expect(getLastStatusText(node)).toBe('null | waiting');
+    // Expect primary output to still send null payload
+    expect(node.send).toHaveBeenCalledTimes(1) // Only the primary output send
+    expect(getMessageFromSendCall(node, 0, 0)).toEqual({
+      payload: null,
+      topic: 'Conditional Test Node'
+    })
+    expect(getMessageFromSendCall(node, 0, 1)).toBeNull()
+    // Expect no conditional output yet, status waiting
+    expect(getLastStatusText(node)).toBe('null | waiting')
 
-        // Simulate an undefined value for the primary input
-        subscribe.mock.calls[0][2]({ value: undefined });
-        expect(node.send).toHaveBeenCalledTimes(2); // primary output of second input event
-        expect(getMessageFromSendCall(node, 1, 0)).toEqual({
-            payload: undefined,
-            topic: 'Conditional Test Node'
-        });
-        expect(getMessageFromSendCall(node, 1, 1)).toBeNull();
-        expect(getLastStatusText(node)).toBe('undefined | waiting');
-    });
+    // Simulate an undefined value for the primary input
+    subscribe.mock.calls[0][2]({ value: undefined })
+    expect(node.send).toHaveBeenCalledTimes(2) // primary output of second input event
+    expect(getMessageFromSendCall(node, 1, 0)).toEqual({
+      payload: undefined,
+      topic: 'Conditional Test Node'
+    })
+    expect(getMessageFromSendCall(node, 1, 1)).toBeNull()
+    expect(getLastStatusText(node)).toBe('undefined | waiting')
+  })
 
-    // Test two conditions (AND)
-    it('should evaluate two conditions with AND logic (TRUE && TRUE)', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Dual Conditional Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.0,
-            condition2Enabled: true,
-            condition2Service: 'com.victronenergy.solarcharger',
-            condition2Path: '/Dc/0/Current',
-            condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
-            condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
-            condition2Operator: '<',
-            condition2Threshold: 5.0,
-            logicOperator: 'AND',
-            outputTrue: 'Both True',
-            outputFalse: 'Not Both True',
-            debounce: 0
-        });
+  // Test two conditions (AND)
+  it('should evaluate two conditions with AND logic (TRUE && TRUE)', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Dual Conditional Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.0,
+      condition2Enabled: true,
+      condition2Service: 'com.victronenergy.solarcharger',
+      condition2Path: '/Dc/0/Current',
+      condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
+      condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
+      condition2Operator: '<',
+      condition2Threshold: 5.0,
+      logicOperator: 'AND',
+      outputTrue: 'Both True',
+      outputFalse: 'Not Both True',
+      debounce: 0
+    })
 
-        // Simulate primary input
-        subscribe.mock.calls[0][2]({ value: 12.8 }); // Condition 1 TRUE
+    // Simulate primary input
+    subscribe.mock.calls[0][2]({ value: 12.8 }) // Condition 1 TRUE
 
-        // Simulate secondary input
-        subscribe.mock.calls[1][2]({ value: 3.0 }); // Condition 2 TRUE
+    // Simulate secondary input
+    subscribe.mock.calls[1][2]({ value: 3.0 }) // Condition 2 TRUE
 
-        expect(node.send).toHaveBeenCalledTimes(2); // Primary, then conditional
-        expect(getMessageFromSendCall(node, 0, 0)).toEqual({ payload: 12.8, topic: 'Dual Conditional Node' }); // First send call, primary output
-        expect(getMessageFromSendCall(node, 1, 1).payload).toBe('Both True'); // Second send call, conditional output
-        expect(getLastStatusText(node)).toBe('12.8 | true');
-    });
+    expect(node.send).toHaveBeenCalledTimes(2) // Primary, then conditional
+    expect(getMessageFromSendCall(node, 0, 0)).toEqual({ payload: 12.8, topic: 'Dual Conditional Node' }) // First send call, primary output
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('Both True') // Second send call, conditional output
+    expect(getLastStatusText(node)).toBe('12.8 | true')
+  })
 
-    it('should evaluate two conditions with AND logic (TRUE && FALSE)', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Dual Conditional Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.0,
-            condition2Enabled: true,
-            condition2Service: 'com.victronenergy.solarcharger',
-            condition2Path: '/Dc/0/Current',
-            condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
-            condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
-            condition2Operator: '<',
-            condition2Threshold: 5.0,
-            logicOperator: 'AND',
-            outputTrue: 'Both True',
-            outputFalse: 'Not Both True',
-            debounce: 0
-        });
+  it('should evaluate two conditions with AND logic (TRUE && FALSE)', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Dual Conditional Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.0,
+      condition2Enabled: true,
+      condition2Service: 'com.victronenergy.solarcharger',
+      condition2Path: '/Dc/0/Current',
+      condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
+      condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
+      condition2Operator: '<',
+      condition2Threshold: 5.0,
+      logicOperator: 'AND',
+      outputTrue: 'Both True',
+      outputFalse: 'Not Both True',
+      debounce: 0
+    })
 
-        // Simulate primary input
-        subscribe.mock.calls[0][2]({ value: 12.8 }); // Condition 1 TRUE
+    // Simulate primary input
+    subscribe.mock.calls[0][2]({ value: 12.8 }) // Condition 1 TRUE
 
-        // Simulate secondary input
-        subscribe.mock.calls[1][2]({ value: 6.0 }); // Condition 2 FALSE
+    // Simulate secondary input
+    subscribe.mock.calls[1][2]({ value: 6.0 }) // Condition 2 FALSE
 
-        expect(node.send).toHaveBeenCalledTimes(2);
-        expect(getMessageFromSendCall(node, 0, 0)).toEqual({ payload: 12.8, topic: 'Dual Conditional Node' });
-        expect(getMessageFromSendCall(node, 1, 1).payload).toBe('Not Both True');
-        expect(getLastStatusText(node)).toBe('12.8 | false');
-    });
+    expect(node.send).toHaveBeenCalledTimes(2)
+    expect(getMessageFromSendCall(node, 0, 0)).toEqual({ payload: 12.8, topic: 'Dual Conditional Node' })
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('Not Both True')
+    expect(getLastStatusText(node)).toBe('12.8 | false')
+  })
 
-    it('should evaluate two conditions with OR logic (TRUE || FALSE)', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Dual Conditional Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.0,
-            condition2Enabled: true,
-            condition2Service: 'com.victronenergy.solarcharger',
-            condition2Path: '/Dc/0/Current',
-            condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
-            condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
-            condition2Operator: '<',
-            condition2Threshold: 5.0,
-            logicOperator: 'OR',
-            outputTrue: 'At Least One True',
-            outputFalse: 'Neither True',
-            debounce: 0
-        });
+  it('should evaluate two conditions with OR logic (TRUE || FALSE)', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Dual Conditional Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.0,
+      condition2Enabled: true,
+      condition2Service: 'com.victronenergy.solarcharger',
+      condition2Path: '/Dc/0/Current',
+      condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
+      condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
+      condition2Operator: '<',
+      condition2Threshold: 5.0,
+      logicOperator: 'OR',
+      outputTrue: 'At Least One True',
+      outputFalse: 'Neither True',
+      debounce: 0
+    })
 
-        // Simulate primary input
-        subscribe.mock.calls[0][2]({ value: 12.8 }); // Condition 1 TRUE
+    // Simulate primary input
+    subscribe.mock.calls[0][2]({ value: 12.8 }) // Condition 1 TRUE
 
-        // Simulate secondary input
-        subscribe.mock.calls[1][2]({ value: 6.0 }); // Condition 2 FALSE
+    // Simulate secondary input
+    subscribe.mock.calls[1][2]({ value: 6.0 }) // Condition 2 FALSE
 
-        expect(node.send).toHaveBeenCalledTimes(2);
-        expect(getMessageFromSendCall(node, 0, 0)).toEqual({ payload: 12.8, topic: 'Dual Conditional Node' });
-        expect(getMessageFromSendCall(node, 1, 1).payload).toBe('At Least One True');
-        expect(getLastStatusText(node)).toBe('12.8 | true');
-    });
+    expect(node.send).toHaveBeenCalledTimes(2)
+    expect(getMessageFromSendCall(node, 0, 0)).toEqual({ payload: 12.8, topic: 'Dual Conditional Node' })
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('At Least One True')
+    expect(getLastStatusText(node)).toBe('12.8 | true')
+  })
 
-    it('should evaluate two conditions with OR logic (FALSE || FALSE)', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Dual Conditional Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.0,
-            condition2Enabled: true,
-            condition2Service: 'com.victronenergy.solarcharger',
-            condition2Path: '/Dc/0/Current',
-            condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
-            condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
-            condition2Operator: '<',
-            condition2Threshold: 5.0,
-            logicOperator: 'OR',
-            outputTrue: 'At Least One True',
-            outputFalse: 'Neither True',
-            debounce: 0
-        });
+  it('should evaluate two conditions with OR logic (FALSE || FALSE)', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Dual Conditional Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.0,
+      condition2Enabled: true,
+      condition2Service: 'com.victronenergy.solarcharger',
+      condition2Path: '/Dc/0/Current',
+      condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
+      condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
+      condition2Operator: '<',
+      condition2Threshold: 5.0,
+      logicOperator: 'OR',
+      outputTrue: 'At Least One True',
+      outputFalse: 'Neither True',
+      debounce: 0
+    })
 
-        // Simulate primary input
-        subscribe.mock.calls[0][2]({ value: 11.0 }); // Condition 1 FALSE
+    // Simulate primary input
+    subscribe.mock.calls[0][2]({ value: 11.0 }) // Condition 1 FALSE
 
-        // Simulate secondary input
-        subscribe.mock.calls[1][2]({ value: 6.0 }); // Condition 2 FALSE
+    // Simulate secondary input
+    subscribe.mock.calls[1][2]({ value: 6.0 }) // Condition 2 FALSE
 
-        expect(node.send).toHaveBeenCalledTimes(2);
-        expect(getMessageFromSendCall(node, 0, 0)).toEqual({ payload: 11.0, topic: 'Dual Conditional Node' });
-        expect(getMessageFromSendCall(node, 1, 1).payload).toBe('Neither True');
-        expect(getLastStatusText(node)).toBe('11 | false');
-    });
+    expect(node.send).toHaveBeenCalledTimes(2)
+    expect(getMessageFromSendCall(node, 0, 0)).toEqual({ payload: 11.0, topic: 'Dual Conditional Node' })
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('Neither True')
+    expect(getLastStatusText(node)).toBe('11 | false')
+  })
 
-    // Test debounce
-    it('should debounce conditional output', (done) => {
-        jest.useFakeTimers(); // Enable fake timers
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Debounced Conditional Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.0,
-            outputTrue: 'True Value',
-            outputFalse: 'False Value',
-            debounce: 100 // 100ms debounce
-        });
+  // Test debounce
+  it('should debounce conditional output', (done) => {
+    jest.useFakeTimers() // Enable fake timers
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Debounced Conditional Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.0,
+      outputTrue: 'True Value',
+      outputFalse: 'False Value',
+      debounce: 100 // 100ms debounce
+    })
 
-        subscribe.mock.calls[0][2]({ value: 13.0 }); // TRUE
-        expect(node.send).toHaveBeenCalledTimes(1); // One call to send primary output
-        expect(getMessageFromSendCall(node, 0, 0)).toEqual({
-            payload: 13.0,
-            topic: 'Debounced Conditional Node'
-        });
-        expect(getMessageFromSendCall(node, 0, 1)).toBeNull(); // Conditional output should be debounced
-        expect(getLastStatusText(node)).toBe('13 | pending'); // Status shows pending during debounce
+    subscribe.mock.calls[0][2]({ value: 13.0 }) // TRUE
+    expect(node.send).toHaveBeenCalledTimes(1) // One call to send primary output
+    expect(getMessageFromSendCall(node, 0, 0)).toEqual({
+      payload: 13.0,
+      topic: 'Debounced Conditional Node'
+    })
+    expect(getMessageFromSendCall(node, 0, 1)).toBeNull() // Conditional output should be debounced
+    expect(getLastStatusText(node)).toBe('13 | pending') // Status shows pending during debounce
 
-        subscribe.mock.calls[0][2]({ value: 11.0 }); // FALSE (within debounce period)
-        expect(node.send).toHaveBeenCalledTimes(2); // primary output for the second input
-        expect(getMessageFromSendCall(node, 1, 0)).toEqual({
-            payload: 11.0,
-            topic: 'Debounced Conditional Node'
-        });
-        expect(getMessageFromSendCall(node, 1, 1)).toBeNull(); // Conditional output still debounced
-        expect(getLastStatusText(node)).toBe('11 | pending'); // Status shows pending during debounce
+    subscribe.mock.calls[0][2]({ value: 11.0 }) // FALSE (within debounce period)
+    expect(node.send).toHaveBeenCalledTimes(2) // primary output for the second input
+    expect(getMessageFromSendCall(node, 1, 0)).toEqual({
+      payload: 11.0,
+      topic: 'Debounced Conditional Node'
+    })
+    expect(getMessageFromSendCall(node, 1, 1)).toBeNull() // Conditional output still debounced
+    expect(getLastStatusText(node)).toBe('11 | pending') // Status shows pending during debounce
 
-        jest.advanceTimersByTime(50); // Advance halfway
-        expect(node.send).toHaveBeenCalledTimes(2); // No new conditional output
+    jest.advanceTimersByTime(50) // Advance halfway
+    expect(node.send).toHaveBeenCalledTimes(2) // No new conditional output
 
-        subscribe.mock.calls[0][2]({ value: 14.0 }); // TRUE (reset debounce)
-        expect(node.send).toHaveBeenCalledTimes(3); // primary output for the third input
-        expect(getMessageFromSendCall(node, 2, 0)).toEqual({
-            payload: 14.0,
-            topic: 'Debounced Conditional Node'
-        });
-        expect(getMessageFromSendCall(node, 2, 1)).toBeNull(); // Conditional output still debounced
-        expect(getLastStatusText(node)).toBe('14 | pending'); // Status shows pending during debounce
+    subscribe.mock.calls[0][2]({ value: 14.0 }) // TRUE (reset debounce)
+    expect(node.send).toHaveBeenCalledTimes(3) // primary output for the third input
+    expect(getMessageFromSendCall(node, 2, 0)).toEqual({
+      payload: 14.0,
+      topic: 'Debounced Conditional Node'
+    })
+    expect(getMessageFromSendCall(node, 2, 1)).toBeNull() // Conditional output still debounced
+    expect(getLastStatusText(node)).toBe('14 | pending') // Status shows pending during debounce
 
-        jest.advanceTimersByTime(100); // Advance past debounce period
+    jest.advanceTimersByTime(100) // Advance past debounce period
 
-        expect(node.send).toHaveBeenCalledTimes(4); // Now conditional output should be sent
-        expect(getMessageFromSendCall(node, 3, 1).payload).toBe('True Value');
-        expect(getLastStatusText(node)).toBe('14 | true'); // Status shows confirmed after debounce completes
+    expect(node.send).toHaveBeenCalledTimes(4) // Now conditional output should be sent
+    expect(getMessageFromSendCall(node, 3, 1).payload).toBe('True Value')
+    expect(getLastStatusText(node)).toBe('14 | true') // Status shows confirmed after debounce completes
 
-        jest.useRealTimers(); // Disable fake timers
-        done();
-    });
+    jest.useRealTimers() // Disable fake timers
+    done()
+  })
 
-    // Test outputTrue/outputFalse parsing
-    it('should parse outputTrue/outputFalse as JSON objects if valid', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'JSON Output Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.0,
-            outputTrue: '{"status":"ok", "value": true}',
-            outputFalse: '{"status":"error", "value": false}',
-            debounce: 0
-        });
+  // Test outputTrue/outputFalse parsing
+  it('should parse outputTrue/outputFalse as JSON objects if valid', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'JSON Output Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.0,
+      outputTrue: '{"status":"ok", "value": true}',
+      outputFalse: '{"status":"error", "value": false}',
+      debounce: 0
+    })
 
-        // First input makes condition TRUE
-        subscribe.mock.calls[0][2]({ value: 13.0 });
-        expect(node.send).toHaveBeenCalledTimes(2); // Primary + Conditional
-        expect(getMessageFromSendCall(node, 1, 1).payload).toEqual({ status: 'ok', value: true });
+    // First input makes condition TRUE
+    subscribe.mock.calls[0][2]({ value: 13.0 })
+    expect(node.send).toHaveBeenCalledTimes(2) // Primary + Conditional
+    expect(getMessageFromSendCall(node, 1, 1).payload).toEqual({ status: 'ok', value: true })
 
-        // Second input makes condition FALSE
-        subscribe.mock.calls[0][2]({ value: 11.0 });
-        expect(node.send).toHaveBeenCalledTimes(4); // Another Primary + Conditional
-        expect(getMessageFromSendCall(node, 3, 1).payload).toEqual({ status: 'error', value: false });
-    });
+    // Second input makes condition FALSE
+    subscribe.mock.calls[0][2]({ value: 11.0 })
+    expect(node.send).toHaveBeenCalledTimes(4) // Another Primary + Conditional
+    expect(getMessageFromSendCall(node, 3, 1).payload).toEqual({ status: 'error', value: false })
+  })
 
-    it('should use outputTrue/outputFalse as literal strings if not valid JSON', () => {
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Literal Output Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.0,
-            outputTrue: 'true_string',
-            outputFalse: 'false_string',
-            debounce: 0
-        });
+  it('should use outputTrue/outputFalse as literal strings if not valid JSON', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Literal Output Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.0,
+      outputTrue: 'true_string',
+      outputFalse: 'false_string',
+      debounce: 0
+    })
 
-        // First input makes condition TRUE
-        subscribe.mock.calls[0][2]({ value: 13.0 });
-        expect(node.send).toHaveBeenCalledTimes(2); // Primary + Conditional
-        expect(getMessageFromSendCall(node, 1, 1).payload).toBe('true_string');
+    // First input makes condition TRUE
+    subscribe.mock.calls[0][2]({ value: 13.0 })
+    expect(node.send).toHaveBeenCalledTimes(2) // Primary + Conditional
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('true_string')
 
-        // Second input makes condition FALSE
-        subscribe.mock.calls[0][2]({ value: 11.0 });
-        expect(node.send).toHaveBeenCalledTimes(4); // Another Primary + Conditional
-        expect(getMessageFromSendCall(node, 3, 1).payload).toBe('false_string');
-    });
+    // Second input makes condition FALSE
+    subscribe.mock.calls[0][2]({ value: 11.0 })
+    expect(node.send).toHaveBeenCalledTimes(4) // Another Primary + Conditional
+    expect(getMessageFromSendCall(node, 3, 1).payload).toBe('false_string')
+  })
 
-    it('should register two outputs and correct labels when conditional mode is enabled', () => {
-        const registerTypeSpy = jest.spyOn(mockRED.nodes, 'registerType');
-        victronNodesInitFunction(mockRED); // Re-initialize to capture registerType calls
+  it('should register two outputs and correct labels when conditional mode is enabled', () => {
+    const registerTypeSpy = jest.spyOn(mockRED.nodes, 'registerType')
+    victronNodesInitFunction(mockRED) // Re-initialize to capture registerType calls
 
-        const inputNodeCalls = registerTypeSpy.mock.calls.filter(call => call[0].startsWith('victron-input'));
+    const inputNodeCalls = registerTypeSpy.mock.calls.filter(call => call[0].startsWith('victron-input'))
 
-        // Find the registration for a generic input node (e.g., 'victron-input-battery')
-        const batteryInputRegistration = inputNodeCalls.find(call => call[0] === 'victron-input-battery');
-        expect(batteryInputRegistration).toBeDefined();
+    // Find the registration for a generic input node (e.g., 'victron-input-battery')
+    const batteryInputRegistration = inputNodeCalls.find(call => call[0] === 'victron-input-battery')
+    expect(batteryInputRegistration).toBeDefined()
 
-        // outputLabels is now in the third argument (options object) per Node-RED standard pattern
-        const nodeOptions = batteryInputRegistration[2];
-        expect(nodeOptions).toBeDefined();
-        expect(nodeOptions.outputLabels).toBeDefined();
+    // outputLabels is now in the third argument (options object) per Node-RED standard pattern
+    const nodeOptions = batteryInputRegistration[2]
+    expect(nodeOptions).toBeDefined()
+    expect(nodeOptions.outputLabels).toBeDefined()
 
-        // Simulate conditional mode enabled
-        const conditionalNodeInstance = { conditionalMode: true };
-        let outputLabels = nodeOptions.outputLabels.call(conditionalNodeInstance, 0);
-        expect(outputLabels).toBe('value');
-        outputLabels = nodeOptions.outputLabels.call(conditionalNodeInstance, 1);
-        expect(outputLabels).toBe('conditional');
+    // Simulate conditional mode enabled
+    const conditionalNodeInstance = { conditionalMode: true }
+    let outputLabels = nodeOptions.outputLabels.call(conditionalNodeInstance, 0)
+    expect(outputLabels).toBe('value')
+    outputLabels = nodeOptions.outputLabels.call(conditionalNodeInstance, 1)
+    expect(outputLabels).toBe('conditional')
 
-        // Simulate conditional mode disabled
-        const regularNodeInstance = { conditionalMode: false };
-        outputLabels = nodeOptions.outputLabels.call(regularNodeInstance, 0);
-        expect(outputLabels).toBeUndefined();
-    });
+    // Simulate conditional mode disabled
+    const regularNodeInstance = { conditionalMode: false }
+    outputLabels = nodeOptions.outputLabels.call(regularNodeInstance, 0)
+    expect(outputLabels).toBeUndefined()
+  })
 
-    it('should unsubscribe from primary and secondary subscriptions and clear debounce timer on close', (done) => {
-        // Make subscribe return mock subscription IDs so the cleanup code is triggered
-        subscribe.mockReturnValueOnce('subscription-1').mockReturnValueOnce('subscription-2');
-        // Make addStatusListener return mock handler IDs so the cleanup code removes both listeners
-        addStatusListener.mockReturnValueOnce('handler-1').mockReturnValueOnce('handler-2');
+  it('should unsubscribe from primary and secondary subscriptions and clear debounce timer on close', (done) => {
+    // Make subscribe return mock subscription IDs so the cleanup code is triggered
+    subscribe.mockReturnValueOnce('subscription-1').mockReturnValueOnce('subscription-2')
+    // Make addStatusListener return mock handler IDs so the cleanup code removes both listeners
+    addStatusListener.mockReturnValueOnce('handler-1').mockReturnValueOnce('handler-2')
 
-        const unsubscribeSpy = jest.spyOn(mockRED.nodes.getNode('victron-client-id').client, 'unsubscribe');
-        const removeStatusListenerSpy = jest.spyOn(mockRED.nodes.getNode('victron-client-id'), 'removeStatusListener');
+    const unsubscribeSpy = jest.spyOn(mockRED.nodes.getNode('victron-client-id').client, 'unsubscribe')
+    const removeStatusListenerSpy = jest.spyOn(mockRED.nodes.getNode('victron-client-id'), 'removeStatusListener')
 
-        const NodeDef = getBaseInputNodeDef();
-        const node = new NodeDef({
-            name: 'Cleanup Test Node',
-            service: 'com.victronenergy.battery',
-            path: '/Dc/0/Voltage',
-            serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
-            pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
-            conditionalMode: true,
-            condition1Operator: '>',
-            condition1Threshold: 12.5,
-            condition2Enabled: true, // Enable second condition to trigger its subscription
-            condition2Service: 'com.victronenergy.solarcharger',
-            condition2Path: '/Dc/0/Current',
-            condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
-            condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
-            condition2Operator: '<',
-            condition2Threshold: 5.0,
-            debounce: 100
-        });
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      name: 'Cleanup Test Node',
+      service: 'com.victronenergy.battery',
+      path: '/Dc/0/Voltage',
+      serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+      pathObj: { name: 'Voltage', path: '/Dc/0/Voltage', type: 'float' },
+      conditionalMode: true,
+      condition1Operator: '>',
+      condition1Threshold: 12.5,
+      condition2Enabled: true, // Enable second condition to trigger its subscription
+      condition2Service: 'com.victronenergy.solarcharger',
+      condition2Path: '/Dc/0/Current',
+      condition2ServiceObj: { name: 'Solar Charger', service: 'com.victronenergy.solarcharger' },
+      condition2PathObj: { name: 'Current', path: '/Dc/0/Current', type: 'float' },
+      condition2Operator: '<',
+      condition2Threshold: 5.0,
+      debounce: 100
+    })
 
-        // Trigger subscriptions and debounce timer setup
-        subscribe.mock.calls[0][2]({ value: 13.0 }); // Primary
-        subscribe.mock.calls[1][2]({ value: 3.0 }); // Secondary
+    // Trigger subscriptions and debounce timer setup
+    subscribe.mock.calls[0][2]({ value: 13.0 }) // Primary
+    subscribe.mock.calls[1][2]({ value: 3.0 }) // Secondary
 
-        // Call the 'close' handler with proper 'this' context
-        const closeHandler = node.on.mock.calls.find(call => call[0] === 'close')[1];
-        closeHandler.call(node, done);
+    // Call the 'close' handler with proper 'this' context
+    const closeHandler = node.on.mock.calls.find(call => call[0] === 'close')[1]
+    closeHandler.call(node, done)
 
-        // Expect both subscriptions to be unsubscribed
-        expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
+    // Expect both subscriptions to be unsubscribed
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(2)
 
-        // Expect status listeners to be removed (primary + secondary)
-        expect(removeStatusListenerSpy).toHaveBeenCalledTimes(2);
+    // Expect status listeners to be removed (primary + secondary)
+    expect(removeStatusListenerSpy).toHaveBeenCalledTimes(2)
 
-        // Ensure debounce timer is cleared
-        expect(node.debounceTimer).toBeNull();
-    });
+    // Ensure debounce timer is cleared
+    expect(node.debounceTimer).toBeNull()
+  })
+})
 
-});
+describe('victron-nodes conditional mode - hysteresis', () => {
+  let mockRED
+  let subscribe
+
+  beforeEach(() => {
+    const mocks = createMockRED()
+    mockRED = mocks.mockRED
+    subscribe = mocks.subscribe
+    victronNodesInitFunction(mockRED)
+  })
+
+  const getBaseInputNodeDef = () => {
+    const registerCall = mockRED.nodes.registerType.mock.calls.find(call => call[0] === 'victron-input-battery')
+    if (!registerCall) throw new Error('victron-input-battery node not registered')
+    return registerCall[1]
+  }
+
+  const getMessageFromSendCall = (node, sendCallIndex, outputIndex = 0) => {
+    if (!node.send.mock.calls[sendCallIndex]) return undefined
+    return node.send.mock.calls[sendCallIndex][0][outputIndex]
+  }
+
+  const baseHysteresisConfig = {
+    name: 'Hysteresis Test Node',
+    service: 'com.victronenergy.battery',
+    path: '/Soc',
+    serviceObj: { name: 'Battery', service: 'com.victronenergy.battery' },
+    pathObj: { name: 'State of charge', path: '/Soc', type: 'float' },
+    conditionalMode: true,
+    condition1Operator: '>',
+    condition1Threshold: 80,
+    condition1HysteresisEnabled: true,
+    condition1HysteresisThreshold: 70,
+    outputTrue: 'ON',
+    outputFalse: 'OFF',
+    debounce: 0
+  }
+
+  it('should stay TRUE when value is between hysteresis and main threshold', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({ ...baseHysteresisConfig })
+
+    subscribe.mock.calls[0][2]({ value: 85 }) // TRUE: 85 > 80
+    expect(node.send).toHaveBeenCalledTimes(2)
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('ON')
+
+    subscribe.mock.calls[0][2]({ value: 75 }) // 75 > 70 so still in ON zone
+    expect(node.send).toHaveBeenCalledTimes(3) // Only primary, no conditional
+    expect(getMessageFromSendCall(node, 2, 1)).toBeNull()
+  })
+
+  it('should go FALSE when value drops below hysteresis threshold', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({ ...baseHysteresisConfig })
+
+    subscribe.mock.calls[0][2]({ value: 85 }) // TRUE
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('ON')
+
+    subscribe.mock.calls[0][2]({ value: 65 }) // 65 <= 70 -> goes FALSE
+    expect(node.send).toHaveBeenCalledTimes(4)
+    expect(getMessageFromSendCall(node, 3, 1).payload).toBe('OFF')
+  })
+
+  it('should stay FALSE when value rises to between hysteresis and main threshold', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({ ...baseHysteresisConfig })
+
+    subscribe.mock.calls[0][2]({ value: 65 }) // FALSE: 65 < 80
+    expect(node.send).toHaveBeenCalledTimes(2)
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('OFF')
+
+    subscribe.mock.calls[0][2]({ value: 75 }) // 75 < 80, not yet at main threshold
+    expect(node.send).toHaveBeenCalledTimes(3) // Only primary, no conditional
+    expect(getMessageFromSendCall(node, 2, 1)).toBeNull()
+  })
+
+  it('should go TRUE again after crossing main threshold', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({ ...baseHysteresisConfig })
+
+    subscribe.mock.calls[0][2]({ value: 85 }) // TRUE
+    subscribe.mock.calls[0][2]({ value: 65 }) // FALSE (crosses hysteresis threshold)
+    subscribe.mock.calls[0][2]({ value: 85 }) // TRUE again (crosses main threshold)
+
+    expect(node.send).toHaveBeenCalledTimes(6)
+    expect(getMessageFromSendCall(node, 5, 1).payload).toBe('ON')
+  })
+
+  it('should work with < operator (hysteresis inverse is >=)', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      ...baseHysteresisConfig,
+      condition1Operator: '<',
+      condition1Threshold: 20,
+      condition1HysteresisThreshold: 30
+    })
+
+    subscribe.mock.calls[0][2]({ value: 15 }) // TRUE: 15 < 20
+    expect(node.send).toHaveBeenCalledTimes(2)
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('ON')
+
+    subscribe.mock.calls[0][2]({ value: 25 }) // 25 < 30, still in ON zone
+    expect(node.send).toHaveBeenCalledTimes(3) // Only primary
+    expect(getMessageFromSendCall(node, 2, 1)).toBeNull()
+
+    subscribe.mock.calls[0][2]({ value: 35 }) // 35 >= 30 -> goes FALSE
+    expect(node.send).toHaveBeenCalledTimes(5)
+    expect(getMessageFromSendCall(node, 4, 1).payload).toBe('OFF')
+  })
+
+  it('should behave normally when hysteresis is disabled', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      ...baseHysteresisConfig,
+      condition1HysteresisEnabled: false
+    })
+
+    subscribe.mock.calls[0][2]({ value: 85 }) // TRUE: 85 > 80
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('ON')
+
+    subscribe.mock.calls[0][2]({ value: 75 }) // FALSE without hysteresis: 75 < 80
+    expect(node.send).toHaveBeenCalledTimes(4)
+    expect(getMessageFromSendCall(node, 3, 1).payload).toBe('OFF')
+  })
+
+  it('should fall back to normal evaluation for == operator (unsupported with hysteresis)', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({
+      ...baseHysteresisConfig,
+      condition1Operator: '==',
+      condition1Threshold: 80
+    })
+
+    subscribe.mock.calls[0][2]({ value: 80 }) // TRUE: 80 == 80
+    expect(getMessageFromSendCall(node, 1, 1).payload).toBe('ON')
+
+    subscribe.mock.calls[0][2]({ value: 75 }) // FALSE: 75 != 80 (hysteresis ignored for ==)
+    expect(node.send).toHaveBeenCalledTimes(4)
+    expect(getMessageFromSendCall(node, 3, 1).payload).toBe('OFF')
+  })
+
+  it('should include hysteresis config in conditional output info', () => {
+    const NodeDef = getBaseInputNodeDef()
+    const node = new NodeDef({ ...baseHysteresisConfig })
+
+    subscribe.mock.calls[0][2]({ value: 85 }) // TRUE
+    const conditionalMsg = getMessageFromSendCall(node, 1, 1)
+    expect(conditionalMsg.info.condition1.hysteresisEnabled).toBe(true)
+    expect(conditionalMsg.info.condition1.hysteresisThreshold).toBe(70)
+  })
+})


### PR DESCRIPTION
Adds hysteresis support to prevent rapid switching near a threshold. When enabled, the condition stays TRUE until the value crosses a separate turn-off threshold (e.g. turn ON above 80%, turn OFF below 70%).

- Backend: evaluateConditionWithHysteresis uses inverse operator against the turn-off threshold when the previous result was TRUE
- UI: collapsible Advanced section under Condition 1 with enable checkbox, turn-off threshold input, and live validation
- Validation: warns when threshold is empty, on wrong side, or operator is == / != (unsupported)
- CSS: fix info/warning/tip boxes overflowing victron-condition-section; reduce condition row input width by 10px to add clearance from border