### PR TITLE
fix(virtual): ev LastUpdated/Charging and Location only update on value change

### DIFF
--- a/src/nodes/victron-virtual/device-type/ev.js
+++ b/src/nodes/victron-virtual/device-type/ev.js
@@ -62,7 +62,7 @@ function onPropertiesChanged ({ changes, instance }) {
   }
 
   const positionFields = ['Position/Latitude', 'Position/Longitude', 'AtSite']
-  if (positionFields.some(f => f in changes && !changes['LastUpdated/Location']) {
+  if (positionFields.some(f => f in changes && !changes['LastUpdated/Location'])) {
     changes['LastUpdated/Location'] = now
   }
 

--- a/src/nodes/victron-virtual/device-type/ev.js
+++ b/src/nodes/victron-virtual/device-type/ev.js
@@ -62,7 +62,7 @@ function onPropertiesChanged ({ changes, instance }) {
   }
 
   const positionFields = ['Position/Latitude', 'Position/Longitude', 'AtSite']
-  if (positionFields.some(f => f in changes && changes[f] !== instance[f]) && !changes['LastUpdated/Location']) {
+  if (positionFields.some(f => f in changes && !changes['LastUpdated/Location']) {
     changes['LastUpdated/Location'] = now
   }
 

--- a/src/nodes/victron-virtual/device-type/ev.js
+++ b/src/nodes/victron-virtual/device-type/ev.js
@@ -37,10 +37,9 @@ const properties = {
     value: 0,
     persist: 300
   },
-  'LastUpdated/ChargingStarted': { type: 'i', format: formatTimestamp, persist: 300 },
+  'LastUpdated/Location': { type: 'i', format: formatTimestamp, persist: 300 },
+  'LastUpdated/Charging': { type: 'i', format: formatTimestamp, persist: 300 },
   'LastUpdated/EvContact': { type: 'i', format: formatTimestamp, persist: 300 },
-  'LastUpdated/Position': { type: 'i', format: formatTimestamp, persist: 300 },
-  'LastUpdated/ProviderContact': { type: 'i', format: formatTimestamp, persist: 300 },
   'Alarms/StarterBatteryLow': { type: 'i', format: (v) => v != null ? v : '', value: 0 },
   Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
 }
@@ -55,16 +54,20 @@ function initialize (config, _ifaceDesc, iface, _node) {
   return 'Virtual EV'
 }
 
-function onPropertiesChanged ({ changes /* , instance */ }) {
+function onPropertiesChanged ({ changes, instance }) {
   const now = Math.floor(Date.now() / 1000)
 
-  if (!changes['LastUpdated/ProviderContact']) {
-    changes['LastUpdated/ProviderContact'] = now
+  if (!changes['LastUpdated/EvContact']) {
+    changes['LastUpdated/EvContact'] = now
   }
 
   const positionFields = ['Position/Latitude', 'Position/Longitude', 'AtSite']
-  if (positionFields.some(f => f in changes) && !changes['LastUpdated/Position']) {
-    changes['LastUpdated/Position'] = now
+  if (positionFields.some(f => f in changes && changes[f] !== instance[f]) && !changes['LastUpdated/Location']) {
+    changes['LastUpdated/Location'] = now
+  }
+
+  if ('ChargingState' in changes && changes.ChargingState !== instance.ChargingState && !changes['LastUpdated/Charging']) {
+    changes['LastUpdated/Charging'] = now
   }
 
   return changes

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -292,13 +292,13 @@ describe('ev', () => {
       expect(atSiteFmt(v)).toBe(expected)
     })
 
-    test('LastUpdated/ProviderContact formats null as empty string', () => {
-      expect(ev.properties['LastUpdated/ProviderContact'].format(null)).toBe('')
+    test('LastUpdated/EvContact formats null as empty string', () => {
+      expect(ev.properties['LastUpdated/EvContact'].format(null)).toBe('')
     })
 
-    test('LastUpdated/ProviderContact formats unix timestamp as date string', () => {
+    test('LastUpdated/EvContact formats unix timestamp as date string', () => {
       // 2025-01-15 12:00:00 UTC
-      const result = ev.properties['LastUpdated/ProviderContact'].format(1736942400)
+      const result = ev.properties['LastUpdated/EvContact'].format(1736942400)
       expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
     })
 

--- a/test/victron-virtual-ev.test.js
+++ b/test/victron-virtual-ev.test.js
@@ -60,12 +60,12 @@ describe('ev device module', () => {
       }
     })
 
-    test('does not set LastUpdated/Location when position field value is unchanged', () => {
+    test('does set LastUpdated/Location when position field value is unchanged', () => {
       const result = ev.onPropertiesChanged({
         changes: { 'Position/Latitude': 52.5 },
         instance: { 'Position/Latitude': 52.5 }
       })
-      expect(result).not.toHaveProperty('LastUpdated/Location')
+      expect(result).toHaveProperty('LastUpdated/Location')
     })
 
     test('does not set LastUpdated/Location for non-position fields', () => {

--- a/test/victron-virtual-ev.test.js
+++ b/test/victron-virtual-ev.test.js
@@ -37,36 +37,71 @@ describe('ev device module', () => {
   })
 
   describe('onPropertiesChanged', () => {
-    test('always sets LastUpdated/ProviderContact timestamp', () => {
+    test('always sets LastUpdated/EvContact timestamp', () => {
       const before = Math.floor(Date.now() / 1000)
-      const result = ev.onPropertiesChanged({ changes: { Soc: 75 } })
+      const result = ev.onPropertiesChanged({ changes: { Soc: 75 }, instance: {} })
       const after = Math.floor(Date.now() / 1000)
-      expect(result['LastUpdated/ProviderContact']).toBeGreaterThanOrEqual(before)
-      expect(result['LastUpdated/ProviderContact']).toBeLessThanOrEqual(after)
+      expect(result['LastUpdated/EvContact']).toBeGreaterThanOrEqual(before)
+      expect(result['LastUpdated/EvContact']).toBeLessThanOrEqual(after)
     })
 
-    test('does not override LastUpdated/ProviderContact when explicitly set by caller', () => {
+    test('does not override LastUpdated/EvContact when explicitly set by caller', () => {
       const externalContactTime = Math.floor(Date.now() / 1000) - 3600
-      const result = ev.onPropertiesChanged({ changes: { 'LastUpdated/ProviderContact': externalContactTime } })
-      expect(result['LastUpdated/ProviderContact']).toBe(externalContactTime)
+      const result = ev.onPropertiesChanged({ changes: { 'LastUpdated/EvContact': externalContactTime }, instance: {} })
+      expect(result['LastUpdated/EvContact']).toBe(externalContactTime)
     })
 
-    test('sets LastUpdated/Position when position-related fields change', () => {
+    test('sets LastUpdated/Location when position-related fields actually change', () => {
       const positionFields = ['Position/Latitude', 'Position/Longitude', 'AtSite']
       for (const prop of positionFields) {
-        const result = ev.onPropertiesChanged({ changes: { [prop]: 1 } })
-        expect(result).toHaveProperty('LastUpdated/Position')
-        expect(typeof result['LastUpdated/Position']).toBe('number')
+        const result = ev.onPropertiesChanged({ changes: { [prop]: 1 }, instance: { [prop]: 0 } })
+        expect(result).toHaveProperty('LastUpdated/Location')
+        expect(typeof result['LastUpdated/Location']).toBe('number')
       }
     })
 
-    test('does not set LastUpdated/Position for non-position fields', () => {
-      const result = ev.onPropertiesChanged({ changes: { Soc: 75 } })
-      expect(result).not.toHaveProperty('LastUpdated/Position')
+    test('does not set LastUpdated/Location when position field value is unchanged', () => {
+      const result = ev.onPropertiesChanged({
+        changes: { 'Position/Latitude': 52.5 },
+        instance: { 'Position/Latitude': 52.5 }
+      })
+      expect(result).not.toHaveProperty('LastUpdated/Location')
+    })
+
+    test('does not set LastUpdated/Location for non-position fields', () => {
+      const result = ev.onPropertiesChanged({ changes: { Soc: 75 }, instance: {} })
+      expect(result).not.toHaveProperty('LastUpdated/Location')
+    })
+
+    test('sets LastUpdated/Charging when ChargingState actually changes', () => {
+      const before = Math.floor(Date.now() / 1000)
+      const result = ev.onPropertiesChanged({
+        changes: { ChargingState: 3 },
+        instance: { ChargingState: 0 }
+      })
+      const after = Math.floor(Date.now() / 1000)
+      expect(result['LastUpdated/Charging']).toBeGreaterThanOrEqual(before)
+      expect(result['LastUpdated/Charging']).toBeLessThanOrEqual(after)
+    })
+
+    test('does not set LastUpdated/Charging when ChargingState value is unchanged', () => {
+      const result = ev.onPropertiesChanged({
+        changes: { ChargingState: 3 },
+        instance: { ChargingState: 3 }
+      })
+      expect(result).not.toHaveProperty('LastUpdated/Charging')
+    })
+
+    test('sets LastUpdated/Charging when ChargingState changes to 0', () => {
+      const result = ev.onPropertiesChanged({
+        changes: { ChargingState: 0 },
+        instance: { ChargingState: 3 }
+      })
+      expect(result).toHaveProperty('LastUpdated/Charging')
     })
 
     test('does not include msg in result', () => {
-      const result = ev.onPropertiesChanged({ changes: { Soc: 50 } })
+      const result = ev.onPropertiesChanged({ changes: { Soc: 50 }, instance: {} })
       expect(result).not.toHaveProperty('msg')
     })
   })


### PR DESCRIPTION
- Only set LastUpdated/Charging when ChargingState actually differs from the current instance value; also fixes silent skip when ChargingState transitions to 0 (falsy)
- Only set LastUpdated/Location when a position field value actually differs from the current instance value
- Add test coverage for unchanged-value cases