### PR TITLE
feat(virtual-switch): add Settings/Adjustable path set to read-only

### DIFF
--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -85,7 +85,9 @@ function createSwitchProperties (config, ifaceDesc, iface) {
         if (v & 0b100) parts.push('Remote UIs')
         return parts.length > 0 ? parts.join(' + ') : 'Hidden'
       }
-    }
+    },
+    // 0 = all settings (CustomName, Group) are read-only in the GUI; they are stored in the flow, not the UI
+    { name: 'Settings/Adjustable', type: 'i', value: 0, format: (v) => v === 0 ? 'Read-only' : 'Writable' }
   ]
 
   const switchType = Number(config.switch_1_type ?? 1)

--- a/test/virtual-switch.test.js
+++ b/test/virtual-switch.test.js
@@ -296,6 +296,30 @@ describe('createSwitchProperties - ShowUIControl', () => {
   })
 })
 
+describe('createSwitchProperties - Adjustable', () => {
+  const adjustableKey = 'SwitchableOutput/output_1/Settings/Adjustable'
+
+  test('sets Adjustable to 0 for all switch types (settings are read-only in GUI)', () => {
+    for (const switchType of Object.values(SWITCH_TYPE_MAP)) {
+      const ifaceDesc = { properties: {} }
+      const iface = {}
+      createSwitchProperties({ switch_1_type: switchType }, ifaceDesc, iface)
+      expect(iface[adjustableKey]).toBe(0)
+      expect(ifaceDesc.properties[adjustableKey]).toBeDefined()
+      expect(ifaceDesc.properties[adjustableKey].type).toBe('i')
+    }
+  })
+
+  test('formats Adjustable 0 as Read-only and non-zero as Writable', () => {
+    const ifaceDesc = { properties: {} }
+    const iface = {}
+    createSwitchProperties({ switch_1_type: SWITCH_TYPE_MAP.TOGGLE }, ifaceDesc, iface)
+    const { format } = ifaceDesc.properties[adjustableKey]
+    expect(format(0)).toBe('Read-only')
+    expect(format(1)).toBe('Writable')
+  })
+})
+
 describe('expandSwitchPayload', () => {
   test('plain number for toggle uses State path', () => {
     expect(expandSwitchPayload(1, SWITCH_TYPE_MAP.TOGGLE)).toEqual({ 'SwitchableOutput/output_1/State': 1 })


### PR DESCRIPTION
Adds `SwitchableOutput/output_1/Settings/Adjustable = 0` to all virtual switches. gui-v2 uses this path to hide edit fields for _CustomName_ and _Group_, since those values are stored in the Node-RED flow and cannot be saved from the GUI.

Relates to victronenergy/gui-v2#2790.