### PR TITLE
fix(virtual-switch): allow leading-slash Auto key to exit manual mode

### DIFF
--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -682,7 +682,7 @@ function shouldApplyPayloadToDBus (config, iface, payload) {
   const mode = config.switch_1_passthrough_mode ?? 'always'
   if (mode === 'always') return true
 
-  if (payload && payload['SwitchableOutput/output_1/Auto'] === 1) return true
+  if (payload && (payload['SwitchableOutput/output_1/Auto'] === 1 || payload['/SwitchableOutput/output_1/Auto'] === 1)) return true
 
   const autoValue = iface ? iface['SwitchableOutput/output_1/Auto'] : null
   const isAuto = autoValue === 1

--- a/test/virtual-switch.test.js
+++ b/test/virtual-switch.test.js
@@ -411,6 +411,12 @@ describe('shouldApplyPayloadToDBus', () => {
       expect(shouldApplyPayloadToDBus(config, makeIface(0), payload)).toBe(true)
     })
 
+    test('allows payload with leading-slash key that sets Auto=1 when in manual mode', () => {
+      const config = { switch_1_type: String(SWITCH_TYPE_MAP.THREE_STATE), switch_1_passthrough_mode: 'auto_only' }
+      const payload = { ['/' + autoKey]: 1 }
+      expect(shouldApplyPayloadToDBus(config, makeIface(0), payload)).toBe(true)
+    })
+
     test('defaults to always when mode is not set (backward compat for existing nodes)', () => {
       const config = { switch_1_type: String(SWITCH_TYPE_MAP.THREE_STATE) }
       expect(shouldApplyPayloadToDBus(config, makeIface(0))).toBe(true)


### PR DESCRIPTION
`shouldApplyPayloadToDBus` only checked `'SwitchableOutput/output_1/Auto'` (no leading slash), but users send d-bus paths with a leading slash. A payload of `{"/SwitchableOutput/output_1/Auto": 1}` was blocked with _"Ignored: switch in manual mode"_ even though its intent is to restore auto mode.