### PR TITLE
fix: restore sync node registration to prevent grey nodes on startup

### DIFF
--- a/src/nodes/victron-event.html
+++ b/src/nodes/victron-event.html
@@ -1,5 +1,4 @@
 <link rel="stylesheet" href="resources/@victronenergy/node-red-contrib-victron/victron-styles.css">
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-common.js"></script>
 
 <script type="text/javascript">
     RED.nodes.registerType('victron-event', {
@@ -27,6 +26,13 @@
             }
         }
     });
+
+    if (!document.querySelector('script[data-victron-common]')) {
+        var _scr = document.createElement('script');
+        _scr.setAttribute('data-victron-common', '');
+        _scr.src = 'resources/@victronenergy/node-red-contrib-victron/victron-common.js';
+        document.head.appendChild(_scr);
+    }
 </script>
 
 <script type="text/html" data-template-name="victron-event">

--- a/src/nodes/victron-inject.html
+++ b/src/nodes/victron-inject.html
@@ -1,5 +1,4 @@
 <link rel="stylesheet" href="resources/@victronenergy/node-red-contrib-victron/victron-styles.css">
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-common.js"></script>
 
 <script type="text/javascript">
     RED.nodes.registerType('victron-inject', {
@@ -24,6 +23,13 @@
             }
         }
     });
+
+    if (!document.querySelector('script[data-victron-common]')) {
+        var _scr = document.createElement('script');
+        _scr.setAttribute('data-victron-common', '');
+        _scr.src = 'resources/@victronenergy/node-red-contrib-victron/victron-common.js';
+        document.head.appendChild(_scr);
+    }
 </script>
 
 <script type="text/html" data-template-name="victron-inject">

--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -1,5 +1,4 @@
 <link rel="stylesheet" href="resources/@victronenergy/node-red-contrib-victron/victron-styles.css">
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-common.js"></script>
 
 <script type="text/template" id="input-edit-template">
     <div class="victron-form">
@@ -1365,4 +1364,10 @@
     registerNode('victron-input-custom', 'Custom Input', 'custom', false, true)
     registerNode('victron-output-custom', 'Custom', 'custom', true, true);
 
+    if (!document.querySelector('script[data-victron-common]')) {
+        var _scr = document.createElement('script');
+        _scr.setAttribute('data-victron-common', '');
+        _scr.src = 'resources/@victronenergy/node-red-contrib-victron/victron-common.js';
+        document.head.appendChild(_scr);
+    }
 </script>

--- a/src/nodes/victron-virtual-indicator.html
+++ b/src/nodes/victron-virtual-indicator.html
@@ -1,6 +1,4 @@
 <link rel="stylesheet" href="resources/@victronenergy/node-red-contrib-victron/victron-virtual-style.css">
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-common.js"></script>
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-virtual-functions.js"></script>
 <script type="text/javascript">
     RED.nodes.registerType('victron-virtual-indicator', {
         category: 'Victron Energy',
@@ -57,6 +55,13 @@
             initializeTooltips()
         }
     })
+
+    if (!document.querySelector('script[data-victron-vf]')) {
+        var _scr = document.createElement('script');
+        _scr.setAttribute('data-victron-vf', '');
+        _scr.src = 'resources/@victronenergy/node-red-contrib-victron/victron-virtual-functions.js';
+        document.head.appendChild(_scr);
+    }
 </script>
 
 <script type="text/html" data-template-name="victron-virtual-indicator">

--- a/src/nodes/victron-virtual-switch.html
+++ b/src/nodes/victron-virtual-switch.html
@@ -1,6 +1,4 @@
 <link rel="stylesheet" href="resources/@victronenergy/node-red-contrib-victron/victron-virtual-style.css">
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-common.js"></script>
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-virtual-functions.js"></script>
 <script type="text/javascript">
     RED.nodes.registerType('victron-virtual-switch',{
         category: 'Victron Energy',
@@ -178,6 +176,13 @@
             updateOutputs(this);
         }
     });
+
+    if (!document.querySelector('script[data-victron-vf]')) {
+        var _scr = document.createElement('script');
+        _scr.setAttribute('data-victron-vf', '');
+        _scr.src = 'resources/@victronenergy/node-red-contrib-victron/victron-virtual-functions.js';
+        document.head.appendChild(_scr);
+    }
 </script>
 
 <script type="text/html" data-template-name="victron-virtual-switch">

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -1,6 +1,4 @@
 <link rel="stylesheet" href="resources/@victronenergy/node-red-contrib-victron/victron-virtual-style.css">
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-common.js"></script>
-<script src="resources/@victronenergy/node-red-contrib-victron/victron-virtual-functions.js"></script>
 <script type="text/javascript">
     RED.nodes.registerType('victron-virtual',{
         category: 'Victron Energy',
@@ -270,6 +268,13 @@
             updateOutputs(this);
         }
     });
+
+    if (!document.querySelector('script[data-victron-vf]')) {
+        var _scr = document.createElement('script');
+        _scr.setAttribute('data-victron-vf', '');
+        _scr.src = 'resources/@victronenergy/node-red-contrib-victron/victron-virtual-functions.js';
+        document.head.appendChild(_scr);
+    }
 </script>
 
 <script type="text/html" data-template-name="victron-virtual">

--- a/test/html-deferred-scripts.test.js
+++ b/test/html-deferred-scripts.test.js
@@ -1,0 +1,36 @@
+/**
+ * Regression test for grey nodes on startup (issue #494).
+ *
+ * Node-RED's appendConfig() sets hasDeferred=true when it encounters a
+ * <script src> tag in a module's HTML. This delays all inline script
+ * execution (including RED.nodes.registerType) until the external script
+ * loads asynchronously. If the canvas renders before registration finishes,
+ * nodes appear grey (#ddd) instead of their configured colour.
+ *
+ * The fix: no <script src> tags may appear before the first registerType
+ * call in any node HTML file. External scripts must be injected dynamically
+ * at the END of the inline script block, after all registerType calls.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const HTML_DIR = path.join(__dirname, '..', 'src', 'nodes')
+
+const htmlFiles = fs.readdirSync(HTML_DIR)
+    .filter(f => f.endsWith('.html'))
+    .map(f => ({ name: f, content: fs.readFileSync(path.join(HTML_DIR, f), 'utf8') }))
+
+describe('HTML node files - no deferred <script src> before registerType', () => {
+    test.each(htmlFiles)('$name has no <script src> before first registerType call', ({ content }) => {
+        const registerTypeIndex = content.indexOf('registerType(')
+        if (registerTypeIndex === -1) return // file has no registerType, nothing to check
+
+        const preamble = content.slice(0, registerTypeIndex)
+
+        // Match <script src="..."> or <script src='...'> (case-insensitive on attribute order)
+        const deferredScript = /<script\b[^>]*\bsrc\s*=/i.test(preamble)
+
+        expect(deferredScript).toBe(false)
+    })
+})


### PR DESCRIPTION
Node-RED's appendConfig() waits for all `<script src>` tags to load before executing a module's inline scripts. Since `registerType` calls live in those inline scripts, adding `<script src="victron-common.js">` (and `victron-virtual-functions.js`) to the HTML file headers made node type registration async - introducing a race where `loadFlows()` could render the canvas before registration completed, leaving nodes grey.

Replace the header `<script src>` tags with a guard-based dynamic injection at the END of each file's inline script block, after all `registerType` calls. Node-RED's loader sees no deferred scripts and runs registration synchronously (as it did before 1.7.0). The external scripts still load in the background, well before any user can open an edit dialog.

The virtual device files (`victron-virtual`, `victron-virtual-switch`, `victron-virtual-indicator`) do not lazy-load `victron-common.js` because their `oneditprepare` functions only use `window.__victron.*` from `victron-virtual-functions.js`, which already bundles the same functions. The non-virtual files (`victron-nodes`, `victron-inject`, `victron-event`) do lazy-load it as they use `victronCommon` directly.

Regression introduced in 829026d. Fixes #494.