### PR TITLE
fix(generator): remove duplicate Generator Start/Stop dropdown entry (#490)

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -693,6 +693,13 @@
         </ol>
       </div>
     </div>
+    <div>
+      <div><strong>Generator Start/Stop:</strong>
+        <p>When a virtual generator is deployed, Venus OS automatically creates a <em>Generator Start/Stop</em> service (<code>com.victronenergy.generator</code>) for it. This service controls and monitors the generator from the Venus OS side &mdash; including auto-start conditions, manual start, and runtime tracking.</p>
+        <p>Use the <strong>input-generator</strong> node to read from that service (e.g. <code>/State</code>, <code>/Runtime</code>, <code>/RunningByConditionCode</code>) and the <strong>output-generator</strong> node to control it (e.g. <code>/ManualStart</code>, <code>/AutoStartEnabled</code>).</p>
+        <p>See the <a href="https://github.com/victronenergy/venus/wiki/dbus#generator-startstop" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS Generator Start/Stop documentation</a> for the full path list.</p>
+      </div>
+    </div>
   `,
       img: null
     },

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -414,6 +414,13 @@ export const DEVICE_TYPE_DOCS = {
         </ol>
       </div>
     </div>
+    <div>
+      <div><strong>Generator Start/Stop:</strong>
+        <p>When a virtual generator is deployed, Venus OS automatically creates a <em>Generator Start/Stop</em> service (<code>com.victronenergy.generator</code>) for it. This service controls and monitors the generator from the Venus OS side &mdash; including auto-start conditions, manual start, and runtime tracking.</p>
+        <p>Use the <strong>input-generator</strong> node to read from that service (e.g. <code>/State</code>, <code>/Runtime</code>, <code>/RunningByConditionCode</code>) and the <strong>output-generator</strong> node to control it (e.g. <code>/ManualStart</code>, <code>/AutoStartEnabled</code>).</p>
+        <p>See the <a href="https://github.com/victronenergy/venus/wiki/dbus#generator-startstop" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS Generator Start/Stop documentation</a> for the full path list.</p>
+      </div>
+    </div>
   `,
     img: null
   },

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -324,8 +324,8 @@ class VictronDbusListener {
         } else {
           const oldOwner = msg.body[1]
           if (oldOwner && this.services[oldOwner]) {
-            const trail = ('/' + (this.services[oldOwner].deviceInstance != null ? this.services[oldOwner].deviceInstance : '')).replace(/\.$/, '')
-            const svcName = this.services[oldOwner].name.split('.').splice(0, 3).join('.') + trail
+            const deviceInstanceSuffix = ('/' + (this.services[oldOwner].deviceInstance != null ? this.services[oldOwner].deviceInstance : '')).replace(/\.$/, '')
+            const svcName = this.services[oldOwner].name.split('.').splice(0, 3).join('.') + deviceInstanceSuffix
             this.eventHandler('DELETE', this.services[oldOwner].name)
             delete this.services[oldOwner]
             this.eventHandler('DELETE', svcName)

--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -51,8 +51,8 @@ class VictronClient {
     const messageHandler = messages => {
       messages.forEach(msg => {
         _this.saveToCache(msg)
-        const trail = msg.deviceInstance == null ? '' : `/${msg.deviceInstance}`
-        const msgKey = `${msg.senderName}${trail}:${msg.path}`
+        const deviceInstanceSuffix = msg.deviceInstance == null ? '' : `/${msg.deviceInstance}`
+        const msgKey = `${msg.senderName}${deviceInstanceSuffix}:${msg.path}`
         debug(`[MESSAGE HANDLER] ${msgKey} | ${JSON.stringify(msg, null, 2)}`)
         // we remove msg.text, as we don't use it, and removing it makes it "in line" with what
         // we do in case of using regular callbacks from the cache, instead of polling (see
@@ -167,16 +167,16 @@ class VictronClient {
   saveToCache (msg) {
     let dbusPaths = {}
 
-    const trail = msg.deviceInstance == null ? '' : `/${msg.deviceInstance}`
+    const deviceInstanceSuffix = msg.deviceInstance == null ? '' : `/${msg.deviceInstance}`
 
-    if (this.system.cache[msg.senderName + trail]) { dbusPaths = this.system.cache[msg.senderName + trail] }
+    if (this.system.cache[msg.senderName + deviceInstanceSuffix]) { dbusPaths = this.system.cache[msg.senderName + deviceInstanceSuffix] }
 
-    // When a device instance is known, remove any stale no-trail entry for the same
+    // When a device instance is known, remove any stale no-suffix entry for the same
     // service. Such entries are created during _initService's async window (before
     // GetValue returns the device instance) when ItemsChanged signals arrive with
     // deviceInstance=undefined. Without this cleanup, both the stale entry and the
-    // correct trail entry match getNodeServices(), producing duplicate dropdown entries.
-    if (trail !== '') { delete this.system.cache[msg.senderName] }
+    // correct suffixed entry match getNodeServices(), producing duplicate dropdown entries.
+    if (deviceInstanceSuffix !== '') { delete this.system.cache[msg.senderName] }
 
     // some dbus messages are empty arrays [], and we interpret empty arrays as null values,
     // compare https://github.com/Chris927/dbus-native/commit/0080b9226a0ed9474be1e5ceeae58a9c78dfa046
@@ -184,13 +184,13 @@ class VictronClient {
 
     // We need to update the nodes on new paths
     // e.g. in the case of system relays, which might or might not be there
-    const sender = msg.senderName.split('.').splice(0, 3).join('.') + trail
+    const sender = msg.senderName.split('.').splice(0, 3).join('.') + deviceInstanceSuffix
 
     // TODO: this.onStatusUpdate() is a noop, can perhaps be removed
     if (!(msg.path in dbusPaths)) { this.onStatusUpdate({ service: sender, path: msg.path }, utils.STATUS.PATH_ADD) }
 
     dbusPaths[msg.path] = msg.value
-    this.system.cache[msg.senderName + trail] = dbusPaths
+    this.system.cache[msg.senderName + deviceInstanceSuffix] = dbusPaths
   }
 
   /**

--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -51,7 +51,7 @@ class VictronClient {
     const messageHandler = messages => {
       messages.forEach(msg => {
         _this.saveToCache(msg)
-        const trail = ('/' + (msg.deviceInstance != null ? msg.deviceInstance : '')).replace(/\/$/, '')
+        const trail = msg.deviceInstance == null ? '' : `/${msg.deviceInstance}`
         const msgKey = `${msg.senderName}${trail}:${msg.path}`
         debug(`[MESSAGE HANDLER] ${msgKey} | ${JSON.stringify(msg, null, 2)}`)
         // we remove msg.text, as we don't use it, and removing it makes it "in line" with what
@@ -167,7 +167,7 @@ class VictronClient {
   saveToCache (msg) {
     let dbusPaths = {}
 
-    const trail = ('/' + (msg.deviceInstance != null ? msg.deviceInstance : '')).replace(/\/$/, '')
+    const trail = msg.deviceInstance == null ? '' : `/${msg.deviceInstance}`
 
     if (this.system.cache[msg.senderName + trail]) { dbusPaths = this.system.cache[msg.senderName + trail] }
 

--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -171,6 +171,13 @@ class VictronClient {
 
     if (this.system.cache[msg.senderName + trail]) { dbusPaths = this.system.cache[msg.senderName + trail] }
 
+    // When a device instance is known, remove any stale no-trail entry for the same
+    // service. Such entries are created during _initService's async window (before
+    // GetValue returns the device instance) when ItemsChanged signals arrive with
+    // deviceInstance=undefined. Without this cleanup, both the stale entry and the
+    // correct trail entry match getNodeServices(), producing duplicate dropdown entries.
+    if (trail !== '') { delete this.system.cache[msg.senderName] }
+
     // some dbus messages are empty arrays [], and we interpret empty arrays as null values,
     // compare https://github.com/Chris927/dbus-native/commit/0080b9226a0ed9474be1e5ceeae58a9c78dfa046
     if (msg.value && msg.value.length === 0) { msg.value = null }

--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -126,7 +126,7 @@ class SystemConfiguration {
                 this.cache[service]['/ProductName'] ||
                 service.split('.').pop()
 
-      const deviceInstance = this.cache[service]['/DeviceInstance'] || service.split('/')[1] || '-'
+      const deviceInstance = this.cache[service]['/DeviceInstance'] ?? service.split('/')[1] ?? '-'
 
       return utils.TEMPLATE(service, name, deviceInstance, pathObjects)
     }

--- a/src/services/victron-system.js
+++ b/src/services/victron-system.js
@@ -68,7 +68,7 @@ class SystemConfiguration {
 
           expandedPaths.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
 
-          const deviceInstance = cachedPaths['/DeviceInstance'] || ''
+          const deviceInstance = cachedPaths['/DeviceInstance'] != null ? cachedPaths['/DeviceInstance'] : ''
           if (expandedPaths.length) {
             acc.push(utils.TEMPLATE(dbusInterface, name, deviceInstance, expandedPaths, communityTag))
           }

--- a/test/victron-client.test.js
+++ b/test/victron-client.test.js
@@ -100,6 +100,20 @@ describe('saveToCache - stale no-trail entry cleanup', () => {
     expect(client.system.cache['com.victronenergy.generator']).toBeDefined()
   })
 
+  it('treats undefined deviceInstance as no suffix (loose == null, not strict === null)', () => {
+    // During _initService's async window, msg.deviceInstance is undefined (not null).
+    // Strict === null would produce trail '/undefined'; loose == null correctly gives ''.
+    client.saveToCache({
+      senderName: 'com.victronenergy.generator',
+      path: '/State',
+      value: 0,
+      deviceInstance: undefined
+    })
+
+    expect(client.system.cache['com.victronenergy.generator/undefined']).toBeUndefined()
+    expect(client.system.cache['com.victronenergy.generator']).toBeDefined()
+  })
+
   it('does not delete anything when no stale entry exists', () => {
     client.saveToCache({
       senderName: 'com.victronenergy.generator',

--- a/test/victron-client.test.js
+++ b/test/victron-client.test.js
@@ -56,3 +56,60 @@ describe('victron-client', () => {
 
 })
 
+describe('saveToCache - stale no-trail entry cleanup', () => {
+  let client
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    client = new VictronClient('mock-client-id', { enablePolling: false })
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  it('removes stale no-trail entry when a trail entry is saved for the same service', () => {
+    // Simulate the stale no-trail entry created during _initService async window
+    client.system.cache['com.victronenergy.generator'] = { '/State': 0 }
+
+    // Simulate _requestRoot completing with the correct device instance
+    client.saveToCache({
+      senderName: 'com.victronenergy.generator',
+      path: '/State',
+      value: 0,
+      deviceInstance: 1
+    })
+
+    expect(client.system.cache['com.victronenergy.generator']).toBeUndefined()
+    expect(client.system.cache['com.victronenergy.generator/1']).toBeDefined()
+  })
+
+  it('does not remove trail entries when saving a no-trail entry', () => {
+    // Services without device instances (e.g. settings) must not lose trail entries
+    client.system.cache['com.victronenergy.generator/0'] = { '/State': 0 }
+
+    client.saveToCache({
+      senderName: 'com.victronenergy.generator',
+      path: '/State',
+      value: 1,
+      deviceInstance: null
+    })
+
+    expect(client.system.cache['com.victronenergy.generator/0']).toBeDefined()
+    expect(client.system.cache['com.victronenergy.generator']).toBeDefined()
+  })
+
+  it('does not delete anything when no stale entry exists', () => {
+    client.saveToCache({
+      senderName: 'com.victronenergy.generator',
+      path: '/State',
+      value: 0,
+      deviceInstance: 0
+    })
+
+    expect(client.system.cache['com.victronenergy.generator']).toBeUndefined()
+    expect(client.system.cache['com.victronenergy.generator/0']).toBeDefined()
+  })
+})
+

--- a/test/victron-system.test.js
+++ b/test/victron-system.test.js
@@ -117,6 +117,66 @@ describe('getNodeServices null value handling', () => {
   })
 })
 
+describe('generator input node - device instance display', () => {
+  let systemConfig
+
+  beforeEach(() => {
+    systemConfig = new SystemConfiguration()
+  })
+
+  test('device instance 0 is returned as string "0", not empty string', () => {
+    systemConfig.cache = {
+      'com.victronenergy.generator/0': {
+        '/ProductName': 'Generator Start/Stop',
+        '/DeviceInstance': 0,
+        '/State': 0
+      }
+    }
+    const result = systemConfig.getNodeServices('input-generator')
+    expect(result.services).toHaveLength(1)
+    expect(result.services[0].deviceInstance).toBe('0')
+  })
+
+  test('two generator controllers produce two distinct dropdown entries with device instances', () => {
+    systemConfig.cache = {
+      'com.victronenergy.generator/0': {
+        '/ProductName': 'Generator Start/Stop',
+        '/DeviceInstance': 0,
+        '/State': 0
+      },
+      'com.victronenergy.generator/1': {
+        '/ProductName': 'Generator Start/Stop',
+        '/DeviceInstance': 1,
+        '/State': 0
+      }
+    }
+    const result = systemConfig.getNodeServices('input-generator')
+    expect(result.services).toHaveLength(2)
+    const instances = result.services.map(s => s.deviceInstance).sort()
+    expect(instances).toEqual(['0', '1'])
+  })
+
+  test('stale no-trail entry alongside trail entry returns two services (cache dedup is in saveToCache)', () => {
+    // This documents the expected behavior when the cache has BOTH a stale no-trail
+    // entry and a correct trail entry. The fix (in saveToCache) prevents this state
+    // from occurring. If it does occur, getNodeServices shows both.
+    systemConfig.cache = {
+      'com.victronenergy.generator': {
+        '/ProductName': 'Generator Start/Stop',
+        '/State': 0
+      },
+      'com.victronenergy.generator/0': {
+        '/ProductName': 'Generator Start/Stop',
+        '/DeviceInstance': 0,
+        '/State': 0
+      }
+    }
+    const result = systemConfig.getNodeServices('input-generator')
+    // Both entries are found - this confirms what the bug looks like
+    expect(result.services).toHaveLength(2)
+  })
+})
+
 describe('getCachedServices null value handling (custom nodes)', () => {
   let systemConfig
 


### PR DESCRIPTION
When Venus OS creates a generator controller for a virtual genset, `ItemsChanged` signals can arrive during `_initService`'s async window before `GetValue` returns the device instance. With `deviceInstance=undefined`, `saveToCache` stores the entry under a no-trail key (e.g. `com.victronenergy.generator)` alongside the correct trail key (`com.victronenergy.generator/1`), and `getNodeServices` finds both, producing duplicate entries in the input-generator dropdown.

Fix: delete the stale no-trail cache entry whenever a trail entry is saved for the same service.

Also fix device instance `0` being treated as falsy in `getNodeServices`, which caused two controllers to both display as "Generator Start/Stop ()" instead of "Generator Start/Stop (0)" and "Generator Start/Stop (1)".

Add a Generator Start/Stop section to the virtual generator node docs explaining that Venus OS automatically creates a `com.victronenergy.generator` service and that input-generator/output-generator nodes should be used to interact with it.

Fixes https://github.com/victronenergy/node-red-contrib-victron/issues/490