### PR TITLE
fix(virtual-switch): default STEPPED DimmingMax to 7 when not configured

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -957,6 +957,8 @@
     const savedType = context.switch_1_type !== undefined ? context.switch_1_type : victronVirtualConstantsExports.SWITCH_TYPE_MAP.TOGGLE;
     $('#node-input-switch_1_type').val(String(savedType));
 
+    let isInitialRender = true;
+
     function renderTypeConfig () {
       $('#switch-1-config-row').remove();
       $('#switch-1-pairs-row').remove();
@@ -970,6 +972,8 @@
         // Render each field as a separate row
         const fieldsHtml = cfg.fields.map(field => {
           const stepAttr = field.id === 'step' || field.id === 'stepsize' ? 'step="any"' : '';
+          const minAttr = field.min !== undefined ? `min="${field.min}"` : '';
+          const maxAttr = field.max !== undefined ? `max="${field.max}"` : '';
           const tooltipHtml = field.tooltip
             ? `<i class="fa fa-info-circle tooltip-icon"
                 data-tooltip="${field.tooltip}"></i>`
@@ -982,7 +986,7 @@
             </label>
             <input type="${field.type}" id="node-input-switch_1_${field.id}"
                   placeholder="${field.placeholder}"
-                  ${stepAttr} required>
+                  ${minAttr} ${maxAttr} ${stepAttr} required>
           </div>
         `
         }).join('');
@@ -996,9 +1000,10 @@
       `);
         $('#node-input-switch_1_type').closest('.form-row').after(configRow);
 
-        // Restore saved values
+        // Restore saved values; on type change, skip type-specific fields
         cfg.fields.forEach(field => {
-          const val = context[`switch_1_${field.id}`];
+          const isCommonField = COMMON_SWITCH_FIELDS.some(f => f.id === field.id);
+          const val = (isInitialRender || isCommonField) ? context[`switch_1_${field.id}`] : undefined;
           if (typeof val !== 'undefined') {
             $(`#node-input-switch_1_${field.id}`).val(val);
           }
@@ -1176,6 +1181,7 @@
 
       makeBoltBullets($('#switch-docs-container'));
       initializeTooltips();
+      isInitialRender = false;
     }
 
     $('#node-input-switch_1_type').on('change', renderTypeConfig);

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -114,6 +114,9 @@
 		// Default debounce delay for virtual device property writes (in milliseconds)
 		const DEBOUNCE_DELAY_MS = 100;
 
+		// Maximum number of steps for a STEPPED switch (range 1-7 inclusive)
+		const STEPPED_DEFAULT_MAX = 7;
+
 		victronVirtualConstants = {
 		  SWITCH_TYPE_MAP,
 		  SWITCH_TYPE_NAMES,
@@ -122,7 +125,8 @@
 		  SWITCH_SECOND_OUTPUT_LABEL,
 		  SWITCH_THIRD_OUTPUT_LABEL,
 		  SWITCH_DEFAULT_PATH,
-		  DEBOUNCE_DELAY_MS
+		  DEBOUNCE_DELAY_MS,
+		  STEPPED_DEFAULT_MAX
 		};
 		return victronVirtualConstants;
 	}
@@ -1510,10 +1514,16 @@
       `);
 	      $('#node-input-switch_1_type').closest('.form-row').after(configRow);
 
-	      // Restore saved values; on type change, skip type-specific fields
+	      // Restore saved values; on type change, skip type-specific fields.
+	      // Also restore if the rendered type matches the saved type (handles spurious change events
+	      // triggered by Node-RED's post-oneditprepare field population).
 	      cfg.fields.forEach(field => {
 	        const isCommonField = COMMON_SWITCH_FIELDS.some(f => f.id === field.id);
-	        const val = (isInitialRender || isCommonField) ? context[`switch_1_${field.id}`] : undefined;
+	        const typeUnchanged = Number(type) === Number(context.switch_1_type);
+	        let val = (isInitialRender || isCommonField || typeUnchanged) ? context[`switch_1_${field.id}`] : undefined;
+	        if (!val && field.id === 'max' && Number(type) === victronVirtualConstantsExports.SWITCH_TYPE_MAP.STEPPED) {
+	          val = victronVirtualConstantsExports.STEPPED_DEFAULT_MAX;
+	        }
 	        if (typeof val !== 'undefined') {
 	          $(`#node-input-switch_1_${field.id}`).val(val);
 	        }

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1519,8 +1519,8 @@
 	      // triggered by Node-RED's post-oneditprepare field population).
 	      cfg.fields.forEach(field => {
 	        const isCommonField = COMMON_SWITCH_FIELDS.some(f => f.id === field.id);
-	        const typeUnchanged = Number(type) === Number(context.switch_1_type);
-	        let val = (isInitialRender || isCommonField || typeUnchanged) ? context[`switch_1_${field.id}`] : undefined;
+	        const isTypeUnchanged = Number(type) === Number(context.switch_1_type);
+	        let val = (isInitialRender || isCommonField || isTypeUnchanged) ? context[`switch_1_${field.id}`] : undefined;
 	        if (!val && field.id === 'max' && Number(type) === victronVirtualConstantsExports.SWITCH_TYPE_MAP.STEPPED) {
 	          val = victronVirtualConstantsExports.STEPPED_DEFAULT_MAX;
 	        }

--- a/src/nodes/victron-virtual-constants.js
+++ b/src/nodes/victron-virtual-constants.js
@@ -99,6 +99,9 @@ const SWITCH_DEFAULT_PATH = {
 // Default debounce delay for virtual device property writes (in milliseconds)
 const DEBOUNCE_DELAY_MS = 100
 
+// Maximum number of steps for a STEPPED switch (range 1-7 inclusive)
+const STEPPED_DEFAULT_MAX = 7
+
 module.exports = {
   SWITCH_TYPE_MAP,
   SWITCH_TYPE_NAMES,
@@ -107,5 +110,6 @@ module.exports = {
   SWITCH_SECOND_OUTPUT_LABEL,
   SWITCH_THIRD_OUTPUT_LABEL,
   SWITCH_DEFAULT_PATH,
-  DEBOUNCE_DELAY_MS
+  DEBOUNCE_DELAY_MS,
+  STEPPED_DEFAULT_MAX
 }

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -728,8 +728,8 @@ export function renderSwitchConfigRow (context) {
       // triggered by Node-RED's post-oneditprepare field population).
       cfg.fields.forEach(field => {
         const isCommonField = COMMON_SWITCH_FIELDS.some(f => f.id === field.id)
-        const typeUnchanged = Number(type) === Number(context.switch_1_type)
-        let val = (isInitialRender || isCommonField || typeUnchanged) ? context[`switch_1_${field.id}`] : undefined
+        const isTypeUnchanged = Number(type) === Number(context.switch_1_type)
+        let val = (isInitialRender || isCommonField || isTypeUnchanged) ? context[`switch_1_${field.id}`] : undefined
         if (!val && field.id === 'max' && Number(type) === SWITCH_TYPE_MAP.STEPPED) {
           val = STEPPED_DEFAULT_MAX
         }

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -678,6 +678,8 @@ export function renderSwitchConfigRow (context) {
   const savedType = context.switch_1_type !== undefined ? context.switch_1_type : SWITCH_TYPE_MAP.TOGGLE
   $('#node-input-switch_1_type').val(String(savedType))
 
+  let isInitialRender = true
+
   function renderTypeConfig () {
     $('#switch-1-config-row').remove()
     $('#switch-1-pairs-row').remove()
@@ -691,6 +693,8 @@ export function renderSwitchConfigRow (context) {
       // Render each field as a separate row
       const fieldsHtml = cfg.fields.map(field => {
         const stepAttr = field.id === 'step' || field.id === 'stepsize' ? 'step="any"' : ''
+        const minAttr = field.min !== undefined ? `min="${field.min}"` : ''
+        const maxAttr = field.max !== undefined ? `max="${field.max}"` : ''
         const tooltipHtml = field.tooltip
           ? `<i class="fa fa-info-circle tooltip-icon"
                 data-tooltip="${field.tooltip}"></i>`
@@ -703,7 +707,7 @@ export function renderSwitchConfigRow (context) {
             </label>
             <input type="${field.type}" id="node-input-switch_1_${field.id}"
                   placeholder="${field.placeholder}"
-                  ${stepAttr} required>
+                  ${minAttr} ${maxAttr} ${stepAttr} required>
           </div>
         `
       }).join('')
@@ -717,9 +721,10 @@ export function renderSwitchConfigRow (context) {
       `)
       $('#node-input-switch_1_type').closest('.form-row').after(configRow)
 
-      // Restore saved values
+      // Restore saved values; on type change, skip type-specific fields
       cfg.fields.forEach(field => {
-        const val = context[`switch_1_${field.id}`]
+        const isCommonField = COMMON_SWITCH_FIELDS.some(f => f.id === field.id)
+        const val = (isInitialRender || isCommonField) ? context[`switch_1_${field.id}`] : undefined
         if (typeof val !== 'undefined') {
           $(`#node-input-switch_1_${field.id}`).val(val)
         }
@@ -897,6 +902,7 @@ export function renderSwitchConfigRow (context) {
 
     makeBoltBullets($('#switch-docs-container'))
     initializeTooltips()
+    isInitialRender = false
   }
 
   $('#node-input-switch_1_type').on('change', renderTypeConfig)

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -6,7 +6,8 @@ import {
   SWITCH_TYPE_BITMASK_NAMES,
   SWITCH_OUTPUT_CONFIG,
   SWITCH_SECOND_OUTPUT_LABEL,
-  SWITCH_THIRD_OUTPUT_LABEL
+  SWITCH_THIRD_OUTPUT_LABEL,
+  STEPPED_DEFAULT_MAX
 } from './victron-virtual-constants'
 import { initializeTooltips } from './victron-common'
 import escape from 'lodash/escape'
@@ -722,10 +723,16 @@ export function renderSwitchConfigRow (context) {
       `)
       $('#node-input-switch_1_type').closest('.form-row').after(configRow)
 
-      // Restore saved values; on type change, skip type-specific fields
+      // Restore saved values; on type change, skip type-specific fields.
+      // Also restore if the rendered type matches the saved type (handles spurious change events
+      // triggered by Node-RED's post-oneditprepare field population).
       cfg.fields.forEach(field => {
         const isCommonField = COMMON_SWITCH_FIELDS.some(f => f.id === field.id)
-        const val = (isInitialRender || isCommonField) ? context[`switch_1_${field.id}`] : undefined
+        const typeUnchanged = Number(type) === Number(context.switch_1_type)
+        let val = (isInitialRender || isCommonField || typeUnchanged) ? context[`switch_1_${field.id}`] : undefined
+        if (!val && field.id === 'max' && Number(type) === SWITCH_TYPE_MAP.STEPPED) {
+          val = STEPPED_DEFAULT_MAX
+        }
         if (typeof val !== 'undefined') {
           $(`#node-input-switch_1_${field.id}`).val(val)
         }

--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -17,6 +17,8 @@ const {
   SWITCH_DEFAULT_PATH
 } = require('../nodes/victron-virtual-constants')
 
+const STEPPED_DEFAULT_MAX = 7
+
 const { hsbToRgb } = require('./color-utils')
 
 // Status bitmask bit names (index = bit position)
@@ -212,7 +214,7 @@ function createSwitchProperties (config, ifaceDesc, iface) {
       type: 'i',
       format: (v) => v != null ? `Option ${v}` : '',
       min: 0,
-      max: Number(config.switch_1_max ?? 7),
+      max: Number(config.switch_1_max || STEPPED_DEFAULT_MAX),
       persist: true
     }
     iface[dimmingKey] = 0
@@ -222,7 +224,7 @@ function createSwitchProperties (config, ifaceDesc, iface) {
       type: 'i',
       format: (v) => v != null ? `Options: ${v}` : ''
     }
-    iface[maxKey] = Number(config.switch_1_max ?? 7)
+    iface[maxKey] = Number(config.switch_1_max || STEPPED_DEFAULT_MAX)
   }
 
   if (switchType === SWITCH_TYPE_MAP.DROPDOWN) {
@@ -702,5 +704,6 @@ module.exports = {
   updateSwitchStatus,
   emitInitialSwitchOutputs,
   expandSwitchPayload,
-  shouldApplyPayloadToDBus
+  shouldApplyPayloadToDBus,
+  STEPPED_DEFAULT_MAX
 }

--- a/src/services/virtual-switch.js
+++ b/src/services/virtual-switch.js
@@ -14,10 +14,9 @@ const {
   SWITCH_TYPE_BITMASK_NAMES,
   SWITCH_SECOND_OUTPUT_LABEL,
   SWITCH_THIRD_OUTPUT_LABEL,
-  SWITCH_DEFAULT_PATH
+  SWITCH_DEFAULT_PATH,
+  STEPPED_DEFAULT_MAX
 } = require('../nodes/victron-virtual-constants')
-
-const STEPPED_DEFAULT_MAX = 7
 
 const { hsbToRgb } = require('./color-utils')
 
@@ -215,7 +214,8 @@ function createSwitchProperties (config, ifaceDesc, iface) {
       format: (v) => v != null ? `Option ${v}` : '',
       min: 0,
       max: Number(config.switch_1_max || STEPPED_DEFAULT_MAX),
-      persist: true
+      persist: true,
+      immediate: true
     }
     iface[dimmingKey] = 0
 

--- a/test/virtual-switch.test.js
+++ b/test/virtual-switch.test.js
@@ -1,5 +1,5 @@
 // test/virtual-switch.test.js
-const { updateSwitchStatus, emitInitialSwitchOutputs, handleSwitchOutputs, createSwitchProperties, expandSwitchPayload, shouldApplyPayloadToDBus } = require('../src/services/virtual-switch')
+const { updateSwitchStatus, emitInitialSwitchOutputs, handleSwitchOutputs, createSwitchProperties, expandSwitchPayload, shouldApplyPayloadToDBus, STEPPED_DEFAULT_MAX } = require('../src/services/virtual-switch')
 const { SWITCH_TYPE_MAP } = require('../src/nodes/victron-virtual-constants')
 
 function makeNode (ifaceOverrides = {}, ifaceDescOverrides = {}) {
@@ -317,6 +317,29 @@ describe('createSwitchProperties - Adjustable', () => {
     const { format } = ifaceDesc.properties[adjustableKey]
     expect(format(0)).toBe('Read-only')
     expect(format(1)).toBe('Writable')
+  })
+})
+
+describe('createSwitchProperties - STEPPED DimmingMax', () => {
+  const maxKey = 'SwitchableOutput/output_1/Settings/DimmingMax'
+
+  function run (config) {
+    const ifaceDesc = { properties: {} }
+    const iface = {}
+    createSwitchProperties({ switch_1_type: SWITCH_TYPE_MAP.STEPPED, ...config }, ifaceDesc, iface)
+    return iface[maxKey]
+  }
+
+  test('defaults to STEPPED_DEFAULT_MAX when switch_1_max is not set', () => {
+    expect(run({})).toBe(STEPPED_DEFAULT_MAX)
+  })
+
+  test('defaults to STEPPED_DEFAULT_MAX when switch_1_max is empty string', () => {
+    expect(run({ switch_1_max: '' })).toBe(STEPPED_DEFAULT_MAX)
+  })
+
+  test('uses switch_1_max when set to a valid value', () => {
+    expect(run({ switch_1_max: '3' })).toBe(3)
   })
 })
 


### PR DESCRIPTION
Empty string default for switch_1_max caused `Number('') = 0`, setting DimmingMax to `0` on D-Bus. Replace `??` with `||` so falsy values (empty string, 0) fall back to `STEPPED_DEFAULT_MAX`.

The reported 10 segments could not be traced in the code; the root cause found was DimmingMax being set to `0`.

Fixes  https://github.com/victronenergy/node-red-contrib-victron/issues/500