### PR TITLE
feat(virtual-acload): add S2 support with configurable power measurement

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -2150,6 +2150,39 @@
 	}
 
 	/**
+	 * Return the label for a single output port of a virtual device node.
+	 * @param {{ device?: string, enable_s2support?: boolean, switch_1_type?: number|string }} node
+	 * @param {number} index - Zero-based output index
+	 * @returns {string}
+	 */
+	function determineOutputLabel (node, index) {
+	  if (index === 0) return 'Passthrough'
+
+	  if (node.device === 'pulsemeter') {
+	    return 'Aggregate'
+	  }
+
+	  if (node.device === 'acload' && node.enable_s2support) {
+	    return 'S2 communication'
+	  }
+
+	  if (node.device === 'switch') {
+	    const switchType = Number(node.switch_1_type !== undefined ? node.switch_1_type : victronVirtualConstantsExports.SWITCH_TYPE_MAP.TOGGLE);
+	    const outputCount = victronVirtualConstantsExports.SWITCH_OUTPUT_CONFIG[switchType] || 2;
+
+	    if (index === 1) {
+	      return victronVirtualConstantsExports.SWITCH_SECOND_OUTPUT_LABEL[switchType] || 'State'
+	    }
+
+	    if (index === 2 && outputCount >= 3) {
+	      return victronVirtualConstantsExports.SWITCH_THIRD_OUTPUT_LABEL[switchType] || 'Value'
+	    }
+	  }
+
+	  return 'Output ' + (index + 1)
+	}
+
+	/**
 	 * Returns the Node-RED palette label for a virtual node.
 	 * Priority: name -> customname + group + typeName -> fallback + typeName
 	 * @param {{ name?: string, customname?: string, group?: string, typeName?: string, fallback?: string }} opts
@@ -2182,7 +2215,8 @@
 	  renderShowInUICheckboxes,
 	  getShowUIValue,
 	  initializeTooltips,
-	  getVirtualNodeLabel
+	  getVirtualNodeLabel,
+	  determineOutputLabel
 	};
 
 })();

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1794,10 +1794,16 @@
 	  $('.input-' + selected).show();
 
 	  if (selected === 'acload') {
+	    function updateS2SectionVisibility () {
+	      const s2enabled = $('#node-input-enable_s2support').is(':checked');
+	      $('.input-acload-s2').toggle(s2enabled);
+	    }
 	    $('#node-input-enable_s2support').off('change.s2support').on('change.s2support', function () {
 	      context.enable_s2support = $(this).is(':checked');
 	      updateOutputs(context);
+	      updateS2SectionVisibility();
 	    });
+	    updateS2SectionVisibility();
 	  }
 
 	  if (selected === 'battery') {

--- a/src/nodes/victron-virtual-browser.js
+++ b/src/nodes/victron-virtual-browser.js
@@ -15,7 +15,8 @@ import {
   updateIndicatorLivePreview,
   renderShowInUICheckboxes,
   getShowUIValue,
-  getVirtualNodeLabel
+  getVirtualNodeLabel,
+  determineOutputLabel
 } from './victron-virtual-functions.js'
 import { initializeTooltips } from './victron-common.js'
 
@@ -36,5 +37,6 @@ window.__victron = {
   renderShowInUICheckboxes,
   getShowUIValue,
   initializeTooltips,
-  getVirtualNodeLabel
+  getVirtualNodeLabel,
+  determineOutputLabel
 }

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1006,10 +1006,16 @@ export function checkSelectedVirtualDevice (context) {
   $('.input-' + selected).show()
 
   if (selected === 'acload') {
+    function updateS2SectionVisibility () {
+      const s2enabled = $('#node-input-enable_s2support').is(':checked')
+      $('.input-acload-s2').toggle(s2enabled)
+    }
     $('#node-input-enable_s2support').off('change.s2support').on('change.s2support', function () {
       context.enable_s2support = $(this).is(':checked')
       updateOutputs(context)
+      updateS2SectionVisibility()
     })
+    updateS2SectionVisibility()
   }
 
   if (selected === 'battery') {

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1363,6 +1363,39 @@ export function updateOutputs (context) {
 }
 
 /**
+ * Return the label for a single output port of a virtual device node.
+ * @param {{ device?: string, enable_s2support?: boolean, switch_1_type?: number|string }} node
+ * @param {number} index - Zero-based output index
+ * @returns {string}
+ */
+export function determineOutputLabel (node, index) {
+  if (index === 0) return 'Passthrough'
+
+  if (node.device === 'pulsemeter') {
+    return 'Aggregate'
+  }
+
+  if (node.device === 'acload' && node.enable_s2support) {
+    return 'S2 communication'
+  }
+
+  if (node.device === 'switch') {
+    const switchType = Number(node.switch_1_type !== undefined ? node.switch_1_type : SWITCH_TYPE_MAP.TOGGLE)
+    const outputCount = SWITCH_OUTPUT_CONFIG[switchType] || 2
+
+    if (index === 1) {
+      return SWITCH_SECOND_OUTPUT_LABEL[switchType] || 'State'
+    }
+
+    if (index === 2 && outputCount >= 3) {
+      return SWITCH_THIRD_OUTPUT_LABEL[switchType] || 'Value'
+    }
+  }
+
+  return 'Output ' + (index + 1)
+}
+
+/**
  * Get output labels for a virtual device
  * @param {string} device - Device type (e.g., 'battery', 'switch', 'gps')
  * @param {object} config - Device configuration object

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -89,57 +89,7 @@
             return (this.name||"Virtual "+this.device)
         },
         outputLabels: function(index) {
-            // Inline logic since window.getOutputLabels may not be loaded yet
-            if (this.device === 'pulsemeter') {
-                return index === 0 ? 'Passthrough' : 'Aggregate'
-            }
-            if (this.device === 'acload' && this.enable_s2support) {
-                return index === 0 ? 'Passthrough' : 'S2 communication'
-            }
-            if (!this.device || this.device !== 'switch') {
-                return index === 0 ? 'Passthrough' : 'Output ' + (index + 1)
-            }
-
-            const switchType = this.switch_1_type
-            const typeKey = switchType !== undefined ? parseInt(switchType, 10) : 1 // TOGGLE = 1
-
-            // Map of second output labels (for switches that don't have "State")
-            const secondLabels = {
-                3: 'Temperature',  // TEMPERATURE_SETPOINT
-                6: 'Selected',     // DROPDOWN
-                7: 'Value'         // BASIC_SLIDER
-            }
-
-            // Map of third output labels (only for switches with 3 outputs)
-            const thirdLabels = {
-                2: 'Dimming',      // DIMMABLE
-                4: 'Value',        // STEPPED
-                8: 'Value',        // NUMERIC_INPUT
-                11: 'LightControls', // RGB_COLOR_WHEEL
-                12: 'LightControls', // CCT_WHEEL
-                13: 'LightControls'  // RGB_WHITE_DIMMER
-            }
-
-            // Output count map
-            const outputCounts = {
-                0: 2, 1: 2, 2: 3, 3: 2, 4: 3, 6: 2, 7: 2, 8: 3, 9: 2, 10: 2, 11: 3, 12: 3, 13: 3
-            }
-
-            if (index === 0) return 'Passthrough'
-
-            if (index === 1) {
-                return secondLabels[typeKey] || 'State'
-            }
-
-            if (index === 2) {
-                // Only return third label if this switch type actually has 3 outputs
-                const outputCount = outputCounts[typeKey] || 2
-                if (outputCount >= 3) {
-                    return thirdLabels[typeKey] || 'Value'
-                }
-            }
-
-            return 'Output ' + (index + 1)
+            return window.__victron.determineOutputLabel(this, index)
         },
         oneditprepare: function oneditprepare() {
             const self = this;

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -12,6 +12,7 @@
             // acload
             acload_nrofphases: {value: 1, required: false},
             enable_s2support: {value: false, required: false},
+            s2_measurement_type: {value: '3_PHASE_SYMMETRIC', required: false},
             // battery
             battery_capacity: {value: 25, required: false},
             include_battery_temperature: {value: false},
@@ -91,6 +92,9 @@
             // Inline logic since window.getOutputLabels may not be loaded yet
             if (this.device === 'pulsemeter') {
                 return index === 0 ? 'Passthrough' : 'Aggregate'
+            }
+            if (this.device === 'acload' && this.enable_s2support) {
+                return index === 0 ? 'Passthrough' : 'S2 communication'
             }
             if (!this.device || this.device !== 'switch') {
                 return index === 0 ? 'Passthrough' : 'Output ' + (index + 1)
@@ -302,6 +306,18 @@
                 S2 support
                 <i class="fa fa-info-circle tooltip-icon" data-tooltip="Enable Victron S2 protocol support for smart charging"></i>
             </label>
+        </div>
+        <div class="form-row input-acload input-acload-s2" style="display:none">
+            <label for="node-input-s2_measurement_type"><i class="fa fa-bar-chart"></i> S2 Measurement
+                <i class="fa fa-info-circle tooltip-icon" data-tooltip="How power is reported to the CEM. Must match the RM's Power Measurement setting."></i>
+            </label>
+            <select id="node-input-s2_measurement_type">
+                <option value="3_PHASE_SYMMETRIC">3-phase symmetric</option>
+                <option value="L1_L2_L3">Per phase (L1/L2/L3)</option>
+                <option value="L1">Single phase L1</option>
+                <option value="L2">Single phase L2</option>
+                <option value="L3">Single phase L3</option>
+            </select>
         </div>
         <div class="input-battery">
             <div class="form-row" id="battery-capacity">

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -59,7 +59,7 @@ function initialize (config, ifaceDesc, iface, node) {
   }
 
   if (config.enable_s2support) {
-    console.warn('S2 support for acload virtual device is not yet implemented.')
+    console.warn('S2 support for acload virtual device is experimental.')
 
     Object.entries(additionalS2Properties).forEach(([key, desc]) => {
       ifaceDesc.properties[key] = desc
@@ -68,11 +68,23 @@ function initialize (config, ifaceDesc, iface, node) {
 
     ifaceDesc.__enableS2 = true
     // Maps D-Bus property names to S2 CommodityQuantity values for power measurement reporting
-    ifaceDesc.__s2PowerMeasurementProps = {
-      'Ac/Power': 'ELECTRIC.POWER.3_PHASE_SYMMETRIC'
+    const measurementType = config.s2_measurement_type || '3_PHASE_SYMMETRIC'
+    const measurementPropsMap = {
+      '3_PHASE_SYMMETRIC': { 'Ac/Power': 'ELECTRIC.POWER.3_PHASE_SYMMETRIC' },
+      L1_L2_L3: {
+        'Ac/L1/Power': 'ELECTRIC.POWER.L1',
+        'Ac/L2/Power': 'ELECTRIC.POWER.L2',
+        'Ac/L3/Power': 'ELECTRIC.POWER.L3'
+      },
+      L1: { 'Ac/L1/Power': 'ELECTRIC.POWER.L1' },
+      L2: { 'Ac/L2/Power': 'ELECTRIC.POWER.L2' },
+      L3: { 'Ac/L3/Power': 'ELECTRIC.POWER.L3' }
     }
+    ifaceDesc.__s2PowerMeasurementProps = measurementPropsMap[measurementType] || measurementPropsMap['3_PHASE_SYMMETRIC']
     ifaceDesc.__s2Handlers = {
       Connect: function (cemId, timeout) {
+        node._s2PowerMeasurementActive = false
+        node._s2PowerMeasurementCemId = null
         console.log('Connect received for CEM ID:', cemId, 'timeout', timeout)
         node.send([
           null,
@@ -86,6 +98,8 @@ function initialize (config, ifaceDesc, iface, node) {
         ])
       },
       Disconnect: function (cemId) {
+        node._s2PowerMeasurementActive = false
+        node._s2PowerMeasurementCemId = null
         node.send([
           null,
           {

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -80,7 +80,7 @@ function initialize (config, ifaceDesc, iface, node) {
       L2: { 'Ac/L2/Power': 'ELECTRIC.POWER.L2' },
       L3: { 'Ac/L3/Power': 'ELECTRIC.POWER.L3' }
     }
-    ifaceDesc.__s2PowerMeasurementProps = measurementPropsMap[measurementType] || measurementPropsMap['3_PHASE_SYMMETRIC']
+    ifaceDesc.__s2PowerMeasurementProps = measurementPropsMap[measurementType]
     ifaceDesc.__s2Handlers = {
       Connect: function (cemId, timeout) {
         node._s2PowerMeasurementActive = false

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -194,21 +194,26 @@ module.exports = function (RED) {
     const { shouldApplyImmediately, getDebouncedSetter } = createDebouncedSetters(node, debounce, DEBOUNCE_DELAY_MS)
 
     function handleInput (msg, done) {
-      // Send passthrough message FIRST, before any validation
-      const userSetConnected = msg.connected !== undefined
-      if (!userSetConnected) {
-        msg.connected = node.presenceConnected
-      }
-      const outputs = [msg]
-      // Fill remaining outputs with null
-      for (let i = 1; i < config.outputs; i++) {
-        outputs.push(null)
-      }
-      node.send(outputs)
+      // S2 signal messages are internal control - never pass through to any output
+      if (msg.payload && msg.payload.s2Signal !== undefined) {
+        // Fall through to s2Signal handler below
+      } else {
+        // Send passthrough message FIRST, before any validation
+        const userSetConnected = msg.connected !== undefined
+        if (!userSetConnected) {
+          msg.connected = node.presenceConnected
+        }
+        const outputs = [msg]
+        // Fill remaining outputs with null
+        for (let i = 1; i < config.outputs; i++) {
+          outputs.push(null)
+        }
+        node.send(outputs)
 
-      if (userSetConnected) {
-        node.setPresence(!!msg.connected, done)
-        return
+        if (userSetConnected) {
+          node.setPresence(!!msg.connected, done)
+          return
+        }
       }
 
       // Now do validation with more helpful messages
@@ -270,7 +275,6 @@ module.exports = function (RED) {
       }
 
       if (msg.payload.s2Signal !== undefined) {
-        console.warn('About to send s2Signal', msg.payload)
         switch (msg.payload.s2Signal) {
           case 'Message':
             if (!msg.payload.message) {
@@ -284,6 +288,31 @@ module.exports = function (RED) {
             }
             node.emitS2Signal(msg.payload.s2Signal, [msg.payload.reason])
             return successAndDone('Sent s2Signal "Disconnect"', done)
+          case 'PowerMeasurementStart': {
+            node._s2PowerMeasurementActive = true
+            node._s2PowerMeasurementCemId = msg.cemId
+            // Emit current values immediately so the CEM doesn't wait for the first change
+            const measurementProps = node.ifaceDesc && node.ifaceDesc.__s2PowerMeasurementProps
+            if (measurementProps && node.iface) {
+              const values = Object.entries(measurementProps)
+                .filter(([pName]) => node.iface[pName] !== null && node.iface[pName] !== undefined)
+                .map(([pName, commodityQuantity]) => ({ commodity_quantity: commodityQuantity, value: node.iface[pName] }))
+              if (values.length > 0) {
+                node.send([null, {
+                  payload: {
+                    command: 'PowerMeasurement',
+                    cemId: node._s2PowerMeasurementCemId,
+                    values
+                  }
+                }])
+              }
+            }
+            return successAndDone('Power measurement started', done)
+          }
+          case 'PowerMeasurementStop':
+            node._s2PowerMeasurementActive = false
+            node._s2PowerMeasurementCemId = null
+            return successAndDone('Power measurement stopped', done)
           default:
             return failAndDone(`s2Signal "${msg.payload.s2Signal}" not implemented`, done)
         }
@@ -687,6 +716,25 @@ module.exports = function (RED) {
           // Legacy support: Handle outputs for existing Virtual Device (switch) nodes
           if (config.device === 'switch') {
             handleSwitchOutputs(config, node, propName, propValue)
+          }
+
+          // S2 power measurement: when any tracked property changes, emit a snapshot of all tracked values
+          if (node._s2PowerMeasurementActive &&
+              ifaceDesc.__s2PowerMeasurementProps &&
+              ifaceDesc.__s2PowerMeasurementProps[propName] !== undefined &&
+              propValue !== null && propValue !== undefined) {
+            const values = Object.entries(ifaceDesc.__s2PowerMeasurementProps)
+              .filter(([pName]) => iface[pName] !== null && iface[pName] !== undefined)
+              .map(([pName, commodityQuantity]) => ({ commodity_quantity: commodityQuantity, value: iface[pName] }))
+            if (values.length > 0) {
+              node.send([null, {
+                payload: {
+                  command: 'PowerMeasurement',
+                  cemId: node._s2PowerMeasurementCemId,
+                  values
+                }
+              }])
+            }
           }
         }
 

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -61,6 +61,90 @@ describe('acload', () => {
       expect(iface['Ac/Power']).toBeUndefined()
     })
   })
+
+  describe('S2 support', () => {
+    test('sets __enableS2 and __s2PowerMeasurementProps when enabled', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
+      expect(ifaceDesc.__enableS2).toBe(true)
+      expect(ifaceDesc.__s2PowerMeasurementProps).toEqual({
+        'Ac/Power': 'ELECTRIC.POWER.3_PHASE_SYMMETRIC'
+      })
+    })
+
+    test('uses 3_PHASE_SYMMETRIC props when s2_measurement_type is absent', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 3, enable_s2support: true }, ifaceDesc, iface, node)
+      expect(ifaceDesc.__s2PowerMeasurementProps).toEqual({
+        'Ac/Power': 'ELECTRIC.POWER.3_PHASE_SYMMETRIC'
+      })
+    })
+
+    test('uses per-phase props when s2_measurement_type is L1_L2_L3', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 3, enable_s2support: true, s2_measurement_type: 'L1_L2_L3' }, ifaceDesc, iface, node)
+      expect(ifaceDesc.__s2PowerMeasurementProps).toEqual({
+        'Ac/L1/Power': 'ELECTRIC.POWER.L1',
+        'Ac/L2/Power': 'ELECTRIC.POWER.L2',
+        'Ac/L3/Power': 'ELECTRIC.POWER.L3'
+      })
+    })
+
+    test.each([
+      ['L1', { 'Ac/L1/Power': 'ELECTRIC.POWER.L1' }],
+      ['L2', { 'Ac/L2/Power': 'ELECTRIC.POWER.L2' }],
+      ['L3', { 'Ac/L3/Power': 'ELECTRIC.POWER.L3' }]
+    ])('uses single-phase props when s2_measurement_type is %s', (type, expected) => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 1, enable_s2support: true, s2_measurement_type: type }, ifaceDesc, iface, node)
+      expect(ifaceDesc.__s2PowerMeasurementProps).toEqual(expected)
+    })
+
+    test('sets __s2Handlers with all four methods when enabled', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
+      expect(typeof ifaceDesc.__s2Handlers.Connect).toBe('function')
+      expect(typeof ifaceDesc.__s2Handlers.Disconnect).toBe('function')
+      expect(typeof ifaceDesc.__s2Handlers.Message).toBe('function')
+      expect(typeof ifaceDesc.__s2Handlers.KeepAlive).toBe('function')
+    })
+
+    test('does not set S2 properties when disabled', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 1, enable_s2support: false }, ifaceDesc, iface, node)
+      expect(ifaceDesc.__enableS2).toBeUndefined()
+      expect(ifaceDesc.__s2PowerMeasurementProps).toBeUndefined()
+      expect(ifaceDesc.__s2Handlers).toBeUndefined()
+    })
+
+    test('Connect handler resets power measurement state and sends command on port 2', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      node.send = jest.fn()
+      node._s2PowerMeasurementActive = true
+      node._s2PowerMeasurementCemId = 'old-cem'
+      acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
+      ifaceDesc.__s2Handlers.Connect('cem-1', 30)
+      expect(node._s2PowerMeasurementActive).toBe(false)
+      expect(node._s2PowerMeasurementCemId).toBeNull()
+      expect(node.send).toHaveBeenCalledWith([null, {
+        payload: { command: 'Connect', cemId: 'cem-1', keepAliveInterval: 30 }
+      }])
+    })
+
+    test('Disconnect handler resets power measurement state and sends command on port 2', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      node.send = jest.fn()
+      node._s2PowerMeasurementActive = true
+      node._s2PowerMeasurementCemId = 'cem-1'
+      acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
+      ifaceDesc.__s2Handlers.Disconnect('cem-1')
+      expect(node._s2PowerMeasurementActive).toBe(false)
+      expect(node._s2PowerMeasurementCemId).toBeNull()
+      expect(node.send).toHaveBeenCalledWith([null, {
+        payload: { command: 'Disconnect', cemId: 'cem-1' }
+      }])
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/test/victron-virtual-functions.switch.test.js
+++ b/test/victron-virtual-functions.switch.test.js
@@ -11,11 +11,12 @@ const {
   getFirstRgbType,
   formatLightControls,
   formatBitmask,
-  fetchSwitchNodeNameAndGroupFromCache
+  fetchSwitchNodeNameAndGroupFromCache,
+  determineOutputLabel
 } = require('./fixtures/victron-virtual-functions.cjs')
 
 // Helper to create mock jQuery element
-function createMockElement(customValues = {}) {
+function createMockElement (customValues = {}) {
   const mockDOMElement = {
     setCustomValidity: jest.fn(),
     reportValidity: jest.fn().mockReturnValue(customValues.reportValidity !== false)
@@ -42,23 +43,22 @@ function createMockElement(customValues = {}) {
 global.$ = jest.fn()
 
 describe('fetchSwitchNodeNameAndGroupFromCache', () => {
-  const originalFetch = global.fetch;
+  const originalFetch = global.fetch
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   afterAll(() => {
-    global.fetch = originalFetch;
+    global.fetch = originalFetch
   })
 
   test('returns name and group when found in cache', async () => {
-
     const mockCache = {
       'com.victronenergy.123': {
         '/Serial': '12345',
         '/SwitchableOutput/output_1/Settings/CustomName': 'Test Switch',
-        '/SwitchableOutput/output_1/Settings/Group': 'Test Group',
-      },
+        '/SwitchableOutput/output_1/Settings/Group': 'Test Group'
+      }
     }
 
     global.fetch = jest.fn(() => Promise.resolve({
@@ -75,9 +75,9 @@ describe('fetchSwitchNodeNameAndGroupFromCache', () => {
     // expect it to fail if no id given
     try {
       await fetchSwitchNodeNameAndGroupFromCache()
-      expect(true).toBe(false); // should not reach here
+      expect(true).toBe(false) // should not reach here
     } catch (e) {
-      expect(e.message).toMatch('id is required');
+      expect(e.message).toMatch('id is required')
     }
 
     // expect it to fail if fetch fails
@@ -89,12 +89,11 @@ describe('fetchSwitchNodeNameAndGroupFromCache', () => {
 
     try {
       await fetchSwitchNodeNameAndGroupFromCache('12345')
-      expect(true).toBe(false); // should not reach here
+      expect(true).toBe(false) // should not reach here
     } catch (e) {
-      expect(e.message).toBeDefined();
+      expect(e.message).toBeDefined()
     }
   })
-
 })
 
 describe('Switch Configuration Tests', () => {
@@ -105,9 +104,9 @@ describe('Switch Configuration Tests', () => {
   describe('SWITCH_TYPE_CONFIGS', () => {
     test('has correct switch type configurations', () => {
       Object.values(SWITCH_TYPE_CONFIGS).forEach(cfg => {
-        expect(cfg.fields[0].id).toBe('customname');
-        expect(cfg.fields[1].id).toBe('group');
-      });
+        expect(cfg.fields[0].id).toBe('customname')
+        expect(cfg.fields[1].id).toBe('group')
+      })
 
       expect(SWITCH_TYPE_CONFIGS[4]).toBeDefined()
       expect(SWITCH_TYPE_CONFIGS[4].label).toBe('Stepped switch')
@@ -278,7 +277,6 @@ describe('Switch Configuration Tests', () => {
       expect(result).toBe(false)
       expect(mockValueField[0].setCustomValidity).toHaveBeenCalledWith('Label is required')
     })
-
   })
 
   describe('edge cases', () => {
@@ -571,5 +569,62 @@ describe('Switch Configuration Tests', () => {
       })
     })
   })
+})
 
+describe('determineOutputLabel', () => {
+  test('index 0 is always Passthrough', () => {
+    expect(determineOutputLabel({}, 0)).toBe('Passthrough')
+    expect(determineOutputLabel({ device: 'battery' }, 0)).toBe('Passthrough')
+    expect(determineOutputLabel({ device: 'switch', switch_1_type: SWITCH_TYPE_MAP.TOGGLE }, 0)).toBe('Passthrough')
+  })
+
+  test('pulsemeter index 1 is Aggregate', () => {
+    expect(determineOutputLabel({ device: 'pulsemeter' }, 1)).toBe('Aggregate')
+  })
+
+  test('acload with s2 index 1 is S2 communication', () => {
+    expect(determineOutputLabel({ device: 'acload', enable_s2support: true }, 1)).toBe('S2 communication')
+  })
+
+  test('acload without s2 index 1 falls back to Output 2', () => {
+    expect(determineOutputLabel({ device: 'acload', enable_s2support: false }, 1)).toBe('Output 2')
+    expect(determineOutputLabel({ device: 'acload' }, 1)).toBe('Output 2')
+  })
+
+  test('generic device index > 0 returns Output N+1', () => {
+    expect(determineOutputLabel({ device: 'battery' }, 1)).toBe('Output 2')
+    expect(determineOutputLabel({ device: 'battery' }, 2)).toBe('Output 3')
+  })
+
+  test('switch toggle returns State for index 1', () => {
+    expect(determineOutputLabel({ device: 'switch', switch_1_type: SWITCH_TYPE_MAP.TOGGLE }, 1)).toBe('State')
+  })
+
+  test('switch dimmable returns State/Dimming for index 1/2', () => {
+    const node = { device: 'switch', switch_1_type: SWITCH_TYPE_MAP.DIMMABLE }
+    expect(determineOutputLabel(node, 1)).toBe('State')
+    expect(determineOutputLabel(node, 2)).toBe('Dimming')
+  })
+
+  test('switch temperature setpoint returns Temperature for index 1', () => {
+    expect(determineOutputLabel({ device: 'switch', switch_1_type: SWITCH_TYPE_MAP.TEMPERATURE_SETPOINT }, 1)).toBe('Temperature')
+  })
+
+  test('switch dropdown returns Selected for index 1', () => {
+    expect(determineOutputLabel({ device: 'switch', switch_1_type: SWITCH_TYPE_MAP.DROPDOWN }, 1)).toBe('Selected')
+  })
+
+  test('switch basic slider returns Value for index 1', () => {
+    expect(determineOutputLabel({ device: 'switch', switch_1_type: SWITCH_TYPE_MAP.BASIC_SLIDER }, 1)).toBe('Value')
+  })
+
+  test('switch stepped returns State/Value for index 1/2', () => {
+    const node = { device: 'switch', switch_1_type: SWITCH_TYPE_MAP.STEPPED }
+    expect(determineOutputLabel(node, 1)).toBe('State')
+    expect(determineOutputLabel(node, 2)).toBe('Value')
+  })
+
+  test('switch with no type defaults to toggle behavior', () => {
+    expect(determineOutputLabel({ device: 'switch' }, 1)).toBe('State')
+  })
 })


### PR DESCRIPTION
- Add Connect/Disconnect/Message/KeepAlive D-Bus handlers for S2 sessions
- Restore PowerMeasurementStart/Stop handling and emitCallback snapshot emission
- Add s2_measurement_type config: 3-phase symmetric, per-phase (L1/L2/L3), or single-phase on L1/L2/L3
- Show 'S2 communication' label on port 2 when S2 is enabled
- Show/hide measurement type dropdown based on S2 checkbox state
- Reset power measurement state on Connect/Disconnect

Note that this isn't easy to test. Please just check the code if there isn't anything obviously wrong. 