### PR TITLE
feat(gps): add UtcTime path to virtual GPS and input node

### DIFF
--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -4180,6 +4180,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Speed (m/s)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Speed</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">UTC Time (ms since midnight)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/UtcTime</b><span class="property-mode"></span>
+</dd>
 </dl>
 </script>
 

--- a/src/nodes/victron-virtual/device-type/gps.js
+++ b/src/nodes/victron-virtual/device-type/gps.js
@@ -6,10 +6,20 @@ const properties = {
   'Position/Longitude': { type: 'd', format: (v) => v != null ? v.toFixed(6) + '°' : '', persist: 300 },
   Speed: { type: 'd', format: (v) => v != null ? v.toFixed(1) + 'm/s' : '' },
   Course: { type: 'd', format: (v) => v != null ? v.toFixed(1) + '°' : '' },
+  UtcTime: { type: 'u', format: (v) => { if (v == null) return ''; const h = Math.floor(v / 3600000); const m = Math.floor((v % 3600000) / 60000); const s = Math.floor((v % 60000) / 1000); return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')} UTC` } },
   Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
 }
+
+const GPS_DATA_FIELDS = ['Position/Latitude', 'Position/Longitude', 'Speed', 'Course', 'Altitude', 'Fix', 'NrOfSatellites']
 
 function initialize (config, ifaceDesc, iface, node) {
 }
 
-module.exports = { properties, initialize, label: 'GPS' }
+function onPropertiesChanged ({ changes }) {
+  if (GPS_DATA_FIELDS.some(f => f in changes) && !('UtcTime' in changes)) {
+    changes.UtcTime = Date.now() % 86400000
+  }
+  return changes
+}
+
+module.exports = { properties, initialize, onPropertiesChanged, label: 'GPS' }

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -2972,6 +2972,11 @@
         "path": "/Speed",
         "type": "float",
         "name": "Speed (m/s)"
+      },
+      {
+        "path": "/UtcTime",
+        "type": "integer",
+        "name": "UTC Time (ms since midnight)"
       }
     ],
     "communityTag": "gps"

--- a/test/victron-virtual-gps.test.js
+++ b/test/victron-virtual-gps.test.js
@@ -1,0 +1,60 @@
+// test/victron-virtual-gps.test.js
+/* eslint-env jest */
+const gps = require('../src/nodes/victron-virtual/device-type/gps')
+
+describe('gps device module', () => {
+  test('exports required contract', () => {
+    expect(typeof gps.properties).toBe('object')
+    expect(typeof gps.initialize).toBe('function')
+    expect(typeof gps.onPropertiesChanged).toBe('function')
+  })
+
+  describe('UtcTime format', () => {
+    const fmt = gps.properties.UtcTime.format
+
+    test('null returns empty string', () => {
+      expect(fmt(null)).toBe('')
+    })
+
+    test.each([
+      [0, '00:00:00 UTC'],
+      [3600000, '01:00:00 UTC'],
+      [43200000, '12:00:00 UTC'],
+      [86399000, '23:59:59 UTC']
+    ])('%i ms formats to "%s"', (value, expected) => {
+      expect(fmt(value)).toBe(expected)
+    })
+  })
+
+  describe('onPropertiesChanged', () => {
+    const GPS_DATA_FIELDS = ['Position/Latitude', 'Position/Longitude', 'Speed', 'Course', 'Altitude', 'Fix', 'NrOfSatellites']
+
+    test.each(GPS_DATA_FIELDS)('auto-injects UtcTime when %s changes', (field) => {
+      const before = Date.now() % 86400000
+      const result = gps.onPropertiesChanged({ changes: { [field]: 1 }, instance: {} })
+      const after = Date.now() % 86400000
+      expect(result.UtcTime).toBeGreaterThanOrEqual(before)
+      expect(result.UtcTime).toBeLessThanOrEqual(after)
+    })
+
+    test('does not override UtcTime when explicitly provided', () => {
+      const explicit = 43200000
+      const result = gps.onPropertiesChanged({
+        changes: { 'Position/Latitude': 52.5, UtcTime: explicit },
+        instance: {}
+      })
+      expect(result.UtcTime).toBe(explicit)
+    })
+
+    test('does not inject UtcTime when no GPS data fields are in changes', () => {
+      const result = gps.onPropertiesChanged({ changes: { Connected: 1 }, instance: {} })
+      expect(result).not.toHaveProperty('UtcTime')
+    })
+
+    test('injected UtcTime is within a valid day range', () => {
+      const result = gps.onPropertiesChanged({ changes: { Speed: 5 }, instance: {} })
+      expect(result.UtcTime).toBeGreaterThanOrEqual(0)
+      expect(result.UtcTime).toBeLessThan(86400000)
+    })
+  })
+})


### PR DESCRIPTION
Adds `/UtcTime` (uint32, ms since midnight UTC) to the GPS service definition and virtual device, matching the dbus_gps implementation added in December 2025. The virtual GPS auto-injects the current UTC time via `onPropertiesChanged` whenever any position/data field changes and `UtcTime` is not explicitly provided by the caller, so flows do not need to set it manually.

Closes #503