### PR TITLE
feat(system): add ESS battery status reason code paths

### DIFF
--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -6570,6 +6570,69 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Serial (System)<span class="property-type">string</span></dt>
   <dd>Dbus path: <b>/Serial</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">ESS battery status: BatteryLife active<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemState/BatteryLife</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Inactive</li>
+  <li>1 - Active</li>
+</ul></dd>
+  <dt class="optional">ESS battery status: BMS disabled charging<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemState/ChargeDisabled</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">ESS battery status: BMS disabled discharge<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemState/DischargeDisabled</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">ESS battery status: SOC is low<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemState/LowSoc</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">ESS battery status: Slow charge in progress<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemState/SlowCharge</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">System state<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemState/State</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Low power</li>
+  <li>2 - VE.Bus fault</li>
+  <li>3 - Bulk charging</li>
+  <li>4 - Absorption</li>
+  <li>5 - Float</li>
+  <li>6 - Storage</li>
+  <li>7 - Equalisation</li>
+  <li>8 - Passthru</li>
+  <li>9 - Inverting</li>
+  <li>10 - Assisting</li>
+  <li>244 - Battery sustain</li>
+  <li>252 - External control</li>
+  <li>256 - Discharging</li>
+  <li>257 - Sustain</li>
+  <li>258 - Recharge</li>
+  <li>259 - Scheduled recharge</li>
+</ul></dd>
+  <dt class="optional">ESS battery status: User charge limit zero<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemState/UserChargeLimited</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">ESS battery status: User discharge limit zero<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemState/UserDischargeLimited</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
   <dt class="optional">System type<span class="property-type">string</span></dt>
   <dd>Dbus path: <b>/SystemType</b><span class="property-mode"></span>
 </dd>

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -4653,6 +4653,93 @@
         "name": "Serial (System)"
       },
       {
+        "path": "/SystemState/BatteryLife",
+        "type": "enum",
+        "name": "ESS battery status: BatteryLife active",
+        "enum": {
+          "0": "Inactive",
+          "1": "Active"
+        }
+      },
+      {
+        "path": "/SystemState/ChargeDisabled",
+        "type": "enum",
+        "name": "ESS battery status: BMS disabled charging",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/SystemState/DischargeDisabled",
+        "type": "enum",
+        "name": "ESS battery status: BMS disabled discharge",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/SystemState/LowSoc",
+        "type": "enum",
+        "name": "ESS battery status: SOC is low",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/SystemState/SlowCharge",
+        "type": "enum",
+        "name": "ESS battery status: Slow charge in progress",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/SystemState/State",
+        "type": "enum",
+        "name": "System state",
+        "enum": {
+          "0": "Off",
+          "1": "Low power",
+          "2": "VE.Bus fault",
+          "3": "Bulk charging",
+          "4": "Absorption",
+          "5": "Float",
+          "6": "Storage",
+          "7": "Equalisation",
+          "8": "Passthru",
+          "9": "Inverting",
+          "10": "Assisting",
+          "244": "Battery sustain",
+          "252": "External control",
+          "256": "Discharging",
+          "257": "Sustain",
+          "258": "Recharge",
+          "259": "Scheduled recharge"
+        }
+      },
+      {
+        "path": "/SystemState/UserChargeLimited",
+        "type": "enum",
+        "name": "ESS battery status: User charge limit zero",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
+        "path": "/SystemState/UserDischargeLimited",
+        "type": "enum",
+        "name": "ESS battery status: User discharge limit zero",
+        "enum": {
+          "0": "No",
+          "1": "Yes"
+        }
+      },
+      {
         "path": "/SystemType",
         "type": "string",
         "name": "System type"

--- a/test/victron-system.test.js
+++ b/test/victron-system.test.js
@@ -291,3 +291,39 @@ describe('SystemConfiguration path sorting', () => {
     expect(paths[3].name).toBe('Watt (W)')
   })
 })
+
+describe('ESS battery status reason codes (issue #342)', () => {
+  const ESS_REASON_PATHS = [
+    '/SystemState/LowSoc',
+    '/SystemState/BatteryLife',
+    '/SystemState/ChargeDisabled',
+    '/SystemState/DischargeDisabled',
+    '/SystemState/SlowCharge',
+    '/SystemState/UserChargeLimited',
+    '/SystemState/UserDischargeLimited'
+  ]
+
+  test.each(ESS_REASON_PATHS)('%s is in services.json system section as an enum', (path) => {
+    const item = servicesJson.system.system.find(p => p.path === path)
+    expect(item).toBeDefined()
+    expect(item.type).toBe('enum')
+    expect(item.enum).toHaveProperty('0')
+    expect(item.enum).toHaveProperty('1')
+  })
+
+  test('input-system node exposes all ESS reason code paths when present in cache', () => {
+    const systemConfig = new SystemConfiguration()
+    const cacheValues = Object.fromEntries(ESS_REASON_PATHS.map(p => [p, 0]))
+    systemConfig.cache = {
+      'com.victronenergy.system/0': {
+        '/DeviceInstance': 0,
+        ...cacheValues
+      }
+    }
+    const result = systemConfig.getNodeServices('input-system')
+    const exposedPaths = result.services[0].paths.map(p => p.path)
+    for (const essPath of ESS_REASON_PATHS) {
+      expect(exposedPaths).toContain(essPath)
+    }
+  })
+})


### PR DESCRIPTION
Add `SystemState/{LowSoc,BatteryLife,ChargeDisabled,DischargeDisabled, SlowCharge,UserChargeLimited,UserDischargeLimited}` and `/SystemState/State` to the system input node, exposing the ESS battery status reason codes (ESS #1-#7) from ESS manual section 6.5.

Closes https://github.com/victronenergy/node-red-contrib-victron/issues/342