### PR TITLE
fix(dbus-listener): singleton service cache keys, null suppression, pathObj guards

### DIFF
--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -1,20 +1,20 @@
 const { debounce } = require('../services/utils.js')
+const { serviceNamesWithoutDeviceInstance } = require('../services/dbus-listener.js')
 
-/*
- * If a service name in the Node-RED node differs from the actual service name used
- * in the dbus, we can define a mapping here.
- * We need this for now for system input nodes: Previously, they had '/0' appended,
- * but due to PR#511 (https://github.com/victronenergy/node-red-contrib-victron/pull/511)
- * their service name is now just 'com.victronenergy.system'.
+/* Those service names which should not have a device instance any more may still have
+ * a device instance in a pre-existing node definition. We therefore strip the device
+ * instance from the service name for those services.
+ * See PR#511 (https://github.com/victronenergy/node-red-contrib-victron/pull/511)
+ * for details.
  */
-const serviceNameMappings = {
-  'com.victronenergy.system/0': 'com.victronenergy.system'
+function mustRemoveDeviceInstanceFromService (service) {
+  const serviceNameBare = service.split('/')[0] // Remove any device instance suffix
+  return serviceNamesWithoutDeviceInstance.includes(serviceNameBare)
 }
 
 module.exports = function (RED) {
   const debug = require('debug')('node-red-contrib-victron:victron-nodes')
   const utils = require('../services/utils.js')
-  const { serviceNamesWithoutDeviceInstance } = require('../services/dbus-listener.js')
 
   const migrateSubscriptions = (x) => {
     // Check if client is fully initialized
@@ -124,12 +124,11 @@ module.exports = function (RED) {
       const handlerId = this.configNode.addStatusListener(this, this.service, this.path)
       let handlerId2 = null
 
-      if (serviceNameMappings[this.service]) {
-        this.service = serviceNameMappings[this.service]
-      }
-
       if (this.service && this.path) {
         // The following is for migration purposes
+        if (mustRemoveDeviceInstanceFromService(this.service)) {
+          this.service = this.service.replace(/\/\d+$/, '')
+        }
         if (!this.service.match(/\/\d+$/) && !serviceNamesWithoutDeviceInstance.includes(this.service)) {
           this.deviceInstance = this.service.replace(/^.*\.(\d+)$/, '$1')
           this.service = this.service.replace(/\.\d+$/, '')

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -219,9 +219,9 @@ module.exports = function (RED) {
             topic
           }
           let text = msg.value
-          if (this.node.pathObj.type === 'enum') {
-            outmsg.textvalue = this.node.pathObj.enum[msg.value] || ''
-            text = `${msg.value} (${this.node.pathObj.enum[msg.value]})`
+          if (this.pathObj && this.pathObj.type === 'enum' && this.pathObj.enum) {
+            outmsg.textvalue = this.pathObj.enum[msg.value] || ''
+            text = `${msg.value} (${this.pathObj.enum[msg.value]})`
           }
 
           // If conditional mode is enabled, send raw value to output 1 and evaluate for output 2
@@ -520,6 +520,11 @@ module.exports = function (RED) {
 
         if (!/^\/.*/.test(writepath)) {
           writepath = '/' + writepath
+        }
+
+        if (!this.pathObj) {
+          this.node.status({ fill: 'red', shape, text: 'Path not configured' })
+          return
         }
 
         if (!this.pathObj.disabled && this.service && writepath) {

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -1,5 +1,16 @@
 const { debounce } = require('../services/utils.js')
 
+/*
+ * If a service name in the Node-RED node differs from the actual service name used
+ * in the dbus, we can define a mapping here.
+ * We need this for now for system input nodes: Previously, they had '/0' appended,
+ * but due to PR#511 (https://github.com/victronenergy/node-red-contrib-victron/pull/511)
+ * their service name is now just 'com.victronenergy.system'.
+ */
+const serviceNameMappings = {
+  'com.victronenergy.system/0': 'com.victronenergy.system'
+}
+
 module.exports = function (RED) {
   const debug = require('debug')('node-red-contrib-victron:victron-nodes')
   const utils = require('../services/utils.js')
@@ -112,6 +123,10 @@ module.exports = function (RED) {
 
       const handlerId = this.configNode.addStatusListener(this, this.service, this.path)
       let handlerId2 = null
+
+      if (serviceNameMappings[this.service]) {
+        this.service = serviceNameMappings[this.service]
+      }
 
       if (this.service && this.path) {
         // The following is for migration purposes

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -284,15 +284,15 @@ class VictronDbusListener {
           ? null
           : (data['/DeviceInstance'] != null ? data['/DeviceInstance'] : service.deviceInstance)
 
-        const messages = _.keys(data).map(path => {
-          return {
+        const messages = _.keys(data)
+          .filter(path => data[path] !== null)
+          .map(path => ({
             path: '/' + path.replace(/^\/+/, ''),
             senderName: service.name.split('.').splice(0, 3).join('.'),
             value: data[path],
             deviceInstance,
             fluidType: service.fluidType
-          }
-        })
+          }))
         debug('requestRoot, messages', messages)
         this.messageHandler(messages)
         resolve()

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -87,7 +87,12 @@ const initServiceAllowlistRegexes = [
   /^com\.victronenergy\..+/ // anything beginning with 'com.victronenergy.' is allowed
 ]
 
-const serviceNamesWithoutDeviceInstance = ['com.victronenergy.settings']
+const serviceNamesWithoutDeviceInstance = [
+  'com.victronenergy.settings',
+  'com.victronenergy.platform',
+  'com.victronenergy.system',
+  'com.victronenergy.dynamicess'
+]
 
 class VictronDbusListener {
   constructor (address, callbacks) {
@@ -269,11 +274,15 @@ class VictronDbusListener {
           service.fluidType = data.FluidType
         }
 
-        if (!service.deviceInstance && data['/DeviceInstance'] != null) {
+        const isWithoutDeviceInstance = serviceNamesWithoutDeviceInstance.includes(service.name)
+
+        if (!isWithoutDeviceInstance && !service.deviceInstance && data['/DeviceInstance'] != null) {
           service.deviceInstance = data['/DeviceInstance']
         }
 
-        const deviceInstance = data['/DeviceInstance'] != null ? data['/DeviceInstance'] : service.deviceInstance
+        const deviceInstance = isWithoutDeviceInstance
+          ? null
+          : (data['/DeviceInstance'] != null ? data['/DeviceInstance'] : service.deviceInstance)
 
         const messages = _.keys(data).map(path => {
           return {

--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -47,6 +47,9 @@ class VictronClient {
     const messageHandler = messages => {
       messages.forEach(msg => {
         _this.saveToCache(msg)
+        // saveToCache converts empty-array D-Bus nulls to null; skip null values here to be
+        // consistent with the PropertiesChanged and ItemsChanged filters in dbus-listener.js
+        if (msg.value === null) return
         const deviceInstanceSuffix = msg.deviceInstance == null ? '' : `/${msg.deviceInstance}`
         const msgKey = `${msg.senderName}${deviceInstanceSuffix}:${msg.path}`
         debug(`[MESSAGE HANDLER] ${msgKey} | ${JSON.stringify(msg, null, 2)}`)

--- a/test/dbus-listener.test.js
+++ b/test/dbus-listener.test.js
@@ -89,6 +89,29 @@ describe('VictronDbusListener', () => {
     })
   })
 
+  describe('_requestRoot null value filtering', () => {
+    it('does not pass null-valued paths to messageHandler', async () => {
+      const capturedMessages = []
+      listener.messageHandler = (msgs) => capturedMessages.push(...msgs)
+      listener.services['the-owner'] = { name: 'com.victronenergy.battery', deviceInstance: 1 }
+      listener.bus = {
+        invoke: jest.fn((_params, callback) => {
+          callback(null, [
+            ['/DeviceInstance', [['Value', ['i', [1]]]]],
+            ['/Soc', [['Value', ['i', [75]]]]],
+            ['/NullPath', [['Value', ['n', [null]]]]]
+          ])
+        })
+      }
+
+      await listener._requestRoot({ name: 'com.victronenergy.battery', deviceInstance: 1 })
+
+      const paths = capturedMessages.map(m => m.path)
+      expect(paths).toContain('/Soc')
+      expect(paths).not.toContain('/NullPath')
+    })
+  })
+
   describe('_requestRoot does not mutate service.deviceInstance for singleton services', () => {
     beforeEach(() => {
       listener.messageHandler = () => {}

--- a/test/dbus-listener.test.js
+++ b/test/dbus-listener.test.js
@@ -32,5 +32,90 @@ describe('VictronDbusListener', () => {
       await listener._initService('the-other-owner', 'com.victronenergy.settings')
       expect(listener.services['the-other-owner'].deviceInstance).toBe(null)
     })
+
+    test('service "com.victronenergy.platform" won\'t get a deviceInstance', async () => {
+      await listener._initService('the-platform-owner', 'com.victronenergy.platform')
+      expect(listener.services['the-platform-owner'].deviceInstance).toBe(null)
+    })
+
+    test('service "com.victronenergy.system" won\'t get a deviceInstance', async () => {
+      await listener._initService('the-system-owner', 'com.victronenergy.system')
+      expect(listener.services['the-system-owner'].deviceInstance).toBe(null)
+    })
+
+    test('service "com.victronenergy.dynamicess" won\'t get a deviceInstance', async () => {
+      await listener._initService('the-dynamicess-owner', 'com.victronenergy.dynamicess')
+      expect(listener.services['the-dynamicess-owner'].deviceInstance).toBe(null)
+    })
+  })
+
+  describe('_requestRoot singleton service handling', () => {
+    let capturedMessages
+
+    beforeEach(() => {
+      capturedMessages = null
+      listener.messageHandler = (msgs) => { capturedMessages = msgs }
+      // GetItems returns /DeviceInstance: 0 plus one other path
+      listener.bus = {
+        invoke: jest.fn((_params, callback) => {
+          callback(null, [
+            ['/DeviceInstance', [['Value', ['i', [0]]]]],
+            ['/Version', [['Value', ['s', ['1.0']]]]]
+          ])
+        })
+      }
+    })
+
+    test.each([
+      'com.victronenergy.platform',
+      'com.victronenergy.system',
+      'com.victronenergy.dynamicess'
+    ])('%s uses null deviceInstance even when GetItems returns /DeviceInstance 0', async (serviceName) => {
+      const service = { name: serviceName, deviceInstance: null }
+      await listener._requestRoot(service)
+      expect(capturedMessages).not.toBeNull()
+      capturedMessages.forEach(msg => {
+        expect(msg.deviceInstance).toBeNull()
+      })
+    })
+
+    test('non-singleton service uses deviceInstance from GetItems data', async () => {
+      const service = { name: 'com.victronenergy.battery', deviceInstance: null }
+      await listener._requestRoot(service)
+      expect(capturedMessages).not.toBeNull()
+      capturedMessages.forEach(msg => {
+        expect(msg.deviceInstance).toBe(0)
+      })
+    })
+  })
+
+  describe('_requestRoot does not mutate service.deviceInstance for singleton services', () => {
+    beforeEach(() => {
+      listener.messageHandler = () => {}
+      listener.bus = {
+        invoke: jest.fn((_params, callback) => {
+          callback(null, [
+            ['/DeviceInstance', [['Value', ['i', [0]]]]],
+            ['/Version', [['Value', ['s', ['1.0']]]]]
+          ])
+        })
+      }
+    })
+
+    test.each([
+      'com.victronenergy.platform',
+      'com.victronenergy.system',
+      'com.victronenergy.dynamicess'
+    ])('%s does not set service.deviceInstance from GetItems data', async (serviceName) => {
+      const service = { name: serviceName, deviceInstance: null }
+      await listener._requestRoot(service)
+      expect(service.deviceInstance).toBeNull()
+    })
+
+    test('non-singleton service.deviceInstance is updated from GetItems data', async () => {
+      const service = { name: 'com.victronenergy.battery', deviceInstance: null }
+      await listener._requestRoot(service)
+      expect(service.deviceInstance).toBe(0)
+    })
   })
 })

--- a/test/victron-client.test.js
+++ b/test/victron-client.test.js
@@ -114,6 +114,16 @@ describe('saveToCache - stale no-trail entry cleanup', () => {
     expect(client.system.cache['com.victronenergy.generator']).toBeDefined()
   })
 
+  it('converts empty-array D-Bus null values to null in cache', () => {
+    client.saveToCache({
+      senderName: 'com.victronenergy.battery',
+      path: '/Relay/0/State',
+      value: [],
+      deviceInstance: 0
+    })
+    expect(client.system.cache['com.victronenergy.battery/0']['/Relay/0/State']).toBeNull()
+  })
+
   it('does not delete anything when no stale entry exists', () => {
     client.saveToCache({
       senderName: 'com.victronenergy.generator',

--- a/test/victron-nodes.test.js
+++ b/test/victron-nodes.test.js
@@ -3,6 +3,7 @@ const { serviceNamesWithoutDeviceInstance } = require('../src/services/dbus-list
 
 function buildMockRED ({ services = {}, connected = true, hasConfigNode = true } = {}) {
   const subscribe = jest.fn()
+  const publish = jest.fn()
   const mockRED = {
     nodes: {
       registerType: jest.fn(),
@@ -22,6 +23,7 @@ function buildMockRED ({ services = {}, connected = true, hasConfigNode = true }
             addStatusListener: jest.fn(),
             client: {
               subscribe,
+              publish,
               subscriptions: {},
               system: { cache: {} },
               onStatusUpdate: jest.fn(),
@@ -38,7 +40,7 @@ function buildMockRED ({ services = {}, connected = true, hasConfigNode = true }
   const BaseInputNode = mockRED.nodes.registerType.mock.calls[0][1]
   const outputCallIndex = mockRED.nodes.registerType.mock.calls.findIndex(c => c[0].startsWith('victron-output-'))
   const BaseOutputNode = mockRED.nodes.registerType.mock.calls[outputCallIndex][1]
-  return { mockRED, BaseInputNode, BaseOutputNode, subscribe }
+  return { mockRED, BaseInputNode, BaseOutputNode, subscribe, publish }
 }
 
 describe('victron-nodes migration', () => {
@@ -243,6 +245,42 @@ describe('victron-nodes', () => {
     // ... and we expect the status to be set to 'null'
     expect(handleStatus.mock.calls.length).toBe(2)
     expect(handleStatus.mock.calls[1][1].text).toEqual('null')
+  })
+})
+
+describe('victron-nodes pathObj guard', () => {
+  it('BaseInputNode does not crash and still emits value when pathObj is undefined', () => {
+    const { BaseInputNode, subscribe } = buildMockRED()
+
+    const node = new BaseInputNode({
+      name: 'Test',
+      service: 'com.victronenergy.battery',
+      path: '/Soc',
+      serviceObj: { name: 'Battery' },
+      pathObj: undefined
+    })
+
+    const processMessage = subscribe.mock.calls[0][2]
+    expect(() => processMessage({ value: 42 })).not.toThrow()
+    expect(node.send).toHaveBeenCalledWith(expect.objectContaining({ payload: 42 }))
+  })
+
+  it('BaseOutputNode shows error status and does not publish when pathObj is undefined', () => {
+    const { BaseOutputNode, publish } = buildMockRED()
+
+    const node = new BaseOutputNode({
+      name: 'Test',
+      service: 'com.victronenergy.system',
+      path: '/Relay/0/State',
+      serviceObj: { name: 'System' },
+      pathObj: undefined
+    })
+
+    const inputHandler = node.on.mock.calls.find(c => c[0] === 'input')[1]
+    inputHandler({ payload: 1 })
+
+    expect(node.status).toHaveBeenCalledWith(expect.objectContaining({ fill: 'red' }))
+    expect(publish).not.toHaveBeenCalled()
   })
 })
 

--- a/test/victron-nodes.test.js
+++ b/test/victron-nodes.test.js
@@ -245,3 +245,19 @@ describe('victron-nodes', () => {
     expect(handleStatus.mock.calls[1][1].text).toEqual('null')
   })
 })
+
+describe('victron-nodes', () => {
+  it('maps service names, if name is in mappings', () => {
+    const { BaseInputNode } = buildMockRED()
+
+    const oldStyleSystemInputNode = new BaseInputNode({
+      name: 'Test',
+      service: 'com.victronenergy.system/0',
+      path: '/SomePath/Foo',
+      serviceObj: { name: 'SomePath' },
+      pathObj: { name: 'Foo' }
+    })
+    expect(oldStyleSystemInputNode).toBeDefined()
+    expect(oldStyleSystemInputNode.service).toEqual('com.victronenergy.system')
+  })
+})


### PR DESCRIPTION
## Summary

- **Singleton service cache keys** (`0810cd9`, `8eb62d2`, `bd67dc8`): Services without a device instance (system, settings, platform, dynamicess) were previously keyed inconsistently in the cache, causing duplicate dropdown entries and stale lookups. Now uses a plain key (no `/0` suffix) for singleton services, with migration for previously stored service names.

- **Suppress null values from reaching node subscribers** (`85628d8`): During service re-initialization (e.g. a solar charger reconnecting at sunrise), `_requestRoot` sent GetItems results including paths whose D-Bus value is temporarily null. These bypassed the `onlyChanges` filter and were emitted as spurious null payloads to flows. Two complementary guards added - one in `_requestRoot` for explicit null, one in `messageHandler` after `saveToCache` converts Victron's empty-array null encoding - making all three signal paths (`PropertiesChanged`, `ItemsChanged`, `_requestRoot`) consistent. Null values are still saved to cache so paths appear in the dropdown with their `- (null)` label. Fixes #346.

- **Guard against undefined pathObj** (`4474922`): Input and output nodes crashed on the first received message when `pathObj` was undefined (legacy flows, unconfigured nodes, imported flows without a path selected). Input nodes now skip enum formatting and still emit the raw value; output nodes show a red status and skip the write.

