### PR TITLE
feat(pvinverter): auto-calculate Ac/Energy/Forward from power

### DIFF
--- a/src/nodes/persist.js
+++ b/src/nodes/persist.js
@@ -182,7 +182,9 @@ function flushPersistedState (RED, id, iface, ifaceDesc) {
   if (!timers[id]) return
   clearTimeout(timers[id].timeout)
   delete timers[id]
-  savePersistedState(RED, id, iface, ifaceDesc)
+  savePersistedState(RED, id, iface, ifaceDesc).catch(err => {
+    console.error(`Failed to flush persisted state for ${id}:`, err)
+  })
 }
 
 module.exports = {

--- a/src/nodes/persist.js
+++ b/src/nodes/persist.js
@@ -178,9 +178,17 @@ async function savePersistedState (RED, id, iface, ifaceDesc, propName) {
   }
 }
 
+function flushPersistedState (RED, id, iface, ifaceDesc) {
+  if (!timers[id]) return
+  clearTimeout(timers[id].timeout)
+  delete timers[id]
+  savePersistedState(RED, id, iface, ifaceDesc)
+}
+
 module.exports = {
   hasPersistedState,
   needsPersistedState,
   loadPersistedState,
-  savePersistedState
+  savePersistedState,
+  flushPersistedState
 }

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -479,7 +479,9 @@
             </div>
             <div class="form-row victron-checkbox">
                 <input type="checkbox" id="node-input-pvinverter_auto_energy">
-                <label for="node-input-pvinverter_auto_energy">Auto-calculate energy (Ac/Energy/Forward)</label>
+                <label for="node-input-pvinverter_auto_energy">Auto-calculate energy (Ac/Energy/Forward)
+                    <i class="fa fa-info-circle tooltip-icon" data-tooltip="Integrates power over time to estimate energy. Precision improves with higher update frequency."></i>
+                </label>
             </div>
         </div>
 

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -38,6 +38,7 @@
             // pvinverter
             position: { value: 0, required: false},
             pvinverter_nrofphases: {value: 1, required: false},
+            pvinverter_auto_energy: {value: true, required: false},
             // switch
             switch_1_type: {value: 1, required: false},
             switch_1_min: {value: 0, required: false},
@@ -475,6 +476,10 @@
                     <option value="1">1</option>
                     <option value="3">3</option>
                 </select>
+            </div>
+            <div class="form-row victron-checkbox">
+                <input type="checkbox" id="node-input-pvinverter_auto_energy">
+                <label for="node-input-pvinverter_auto_energy">Auto-calculate energy (Ac/Energy/Forward)</label>
             </div>
         </div>
 

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -1,6 +1,8 @@
+const ENERGY_PERSIST_SECONDS = 60
+
 const properties = {
-  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '' },
-  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '' },
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
   'Ac/L1/Current': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
   'Ac/L1/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '' },
   'Ac/L1/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '' },
@@ -16,8 +18,8 @@ const phaseProperties = [
   { name: 'Current', unit: 'A' },
   { name: 'Power', unit: 'W' },
   { name: 'Voltage', unit: 'V' },
-  { name: 'Energy/Forward', unit: 'kWh' },
-  { name: 'Energy/Reverse', unit: 'kWh' },
+  { name: 'Energy/Forward', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
+  { name: 'Energy/Reverse', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
   { name: 'PowerFactor', unit: '' }
 ]
 
@@ -42,12 +44,14 @@ function initialize (config, ifaceDesc, iface, node) {
   iface.NrOfPhases = Number(config.acload_nrofphases ?? 1)
   for (let i = 1; i <= iface.NrOfPhases; i++) {
     const phase = `L${i}`
-    phaseProperties.forEach(({ name, unit }) => {
+    phaseProperties.forEach(({ name, unit, persist }) => {
       const key = `Ac/${phase}/${name}`
-      ifaceDesc.properties[key] = {
+      const propDef = {
         type: 'd',
-        format: (v) => v != null ? v.toFixed(2) + unit : ''
+        format: (v) => v != null ? v.toFixed(2) + unit : '',
+        ...(persist && { persist })
       }
+      ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
   }

--- a/src/nodes/victron-virtual/device-type/energymeter.js
+++ b/src/nodes/victron-virtual/device-type/energymeter.js
@@ -1,5 +1,7 @@
 const debug = require('debug')('victron-virtual')
 
+const ENERGY_PERSIST_SECONDS = 60
+
 const ROLE_TO_SERVICE_TYPE = {
   gridmeter: 'grid',
   inverter: 'pvinverter',
@@ -10,8 +12,8 @@ const ROLE_TO_SERVICE_TYPE = {
 }
 
 const sharedProperties = {
-  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
-  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
   'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
   'Ac/PowerFactor': { type: 'd', format: (v) => v != null ? v.toFixed(2) : '' },
   Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 },
@@ -44,8 +46,8 @@ function buildProperties (config) {
 
 const phaseProperties = [
   { name: 'Current', unit: 'A' },
-  { name: 'Energy/Forward', unit: 'kWh' },
-  { name: 'Energy/Reverse', unit: 'kWh' },
+  { name: 'Energy/Forward', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
+  { name: 'Energy/Reverse', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
   { name: 'Power', unit: 'W' },
   { name: 'PowerFactor', unit: '' },
   { name: 'Voltage', unit: 'V' }
@@ -55,12 +57,14 @@ function initialize (config, ifaceDesc, iface, node) {
   iface.NrOfPhases = Number(config.energymeter_nrofphases ?? 1)
   for (let i = 1; i <= iface.NrOfPhases; i++) {
     const phase = `L${i}`
-    phaseProperties.forEach(({ name, unit }) => {
+    phaseProperties.forEach(({ name, unit, persist }) => {
       const key = `Ac/${phase}/${name}`
-      ifaceDesc.properties[key] = {
+      const propDef = {
         type: 'd',
-        format: (v) => v != null ? v.toFixed(2) + unit : ''
+        format: (v) => v != null ? v.toFixed(2) + unit : '',
+        ...(persist && { persist })
       }
+      ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
   }

--- a/src/nodes/victron-virtual/device-type/generator.js
+++ b/src/nodes/victron-virtual/device-type/generator.js
@@ -1,3 +1,5 @@
+const ENERGY_PERSIST_SECONDS = 60
+
 const commonGeneratorProperties = {
   AutoStart: { type: 'i', format: (v) => v != null ? v : '', value: 1, persist: true },
   Start: { type: 'i', format: (v) => v != null ? v : '', value: 0, persist: true, immediate: true },
@@ -52,7 +54,7 @@ const properties = {
   genset: {
     ...commonGeneratorProperties,
     'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
-    'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
+    'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
     'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(1) + 'Hz' : '' },
     NrOfPhases: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
   },
@@ -61,7 +63,7 @@ const properties = {
     'Dc/0/Current': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
     'Dc/0/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
     'Dc/0/Voltage': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '' },
-    'History/EnergyOut': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
+    'History/EnergyOut': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
     State: {
       type: 'i',
       format: (v) => ({

--- a/src/nodes/victron-virtual/device-type/grid.js
+++ b/src/nodes/victron-virtual/device-type/grid.js
@@ -1,6 +1,8 @@
+const ENERGY_PERSIST_SECONDS = 60
+
 const properties = {
-  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0 },
-  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0 },
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0, persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0, persist: ENERGY_PERSIST_SECONDS },
   'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'Hz' : '' },
   'Ac/N/Current': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
   'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
@@ -13,20 +15,22 @@ const phaseProperties = [
   { name: 'Current', unit: 'A' },
   { name: 'Power', unit: 'W' },
   { name: 'Voltage', unit: 'V' },
-  { name: 'Energy/Forward', unit: 'kWh' },
-  { name: 'Energy/Reverse', unit: 'kWh' }
+  { name: 'Energy/Forward', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
+  { name: 'Energy/Reverse', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS }
 ]
 
 function initialize (config, ifaceDesc, iface, node) {
   iface.NrOfPhases = Number(config.grid_nrofphases ?? 1)
   for (let i = 1; i <= iface.NrOfPhases; i++) {
     const phase = `L${i}`
-    phaseProperties.forEach(({ name, unit }) => {
+    phaseProperties.forEach(({ name, unit, persist }) => {
       const key = `Ac/${phase}/${name}`
-      ifaceDesc.properties[key] = {
+      const propDef = {
         type: 'd',
-        format: (v) => v != null ? v.toFixed(2) + unit : ''
+        format: (v) => v != null ? v.toFixed(2) + unit : '',
+        ...(persist && { persist })
       }
+      ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
   }

--- a/src/nodes/victron-virtual/device-type/pvinverter.js
+++ b/src/nodes/victron-virtual/device-type/pvinverter.js
@@ -81,9 +81,11 @@ function initialize (config, ifaceDesc, iface, node) {
 }
 
 function accumulateDelta (changes, instance, energyKey, oldPower, lastTs, now) {
-  if (lastTs != null && oldPower != null && oldPower > 0 && !(energyKey in changes)) {
-    const deltaKwh = oldPower * (now - lastTs) / WATT_MILLISECONDS_PER_KWH
-    changes[energyKey] = (instance[energyKey] || 0) + deltaKwh
+  if (lastTs != null && oldPower != null && !(energyKey in changes)) {
+    const deltaKwh = Math.max(0, oldPower) * (now - lastTs) / WATT_MILLISECONDS_PER_KWH
+    if (deltaKwh > 0) {
+      changes[energyKey] = (instance[energyKey] || 0) + deltaKwh
+    }
   }
 }
 

--- a/src/nodes/victron-virtual/device-type/pvinverter.js
+++ b/src/nodes/victron-virtual/device-type/pvinverter.js
@@ -59,14 +59,14 @@ function initialize (config, ifaceDesc, iface, node) {
         type: 'd',
         format: (v) => v != null ? v.toFixed(2) + unit : ''
       }
-      if (config.pvinverter_auto_energy && name === 'Energy/Forward') {
+      if (name === 'Energy/Forward') {
         propDef.persist = ENERGY_PERSIST_SECONDS
       }
       ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
   }
-  if (config.pvinverter_auto_energy && ifaceDesc.properties['Ac/Energy/Forward']) {
+  if (ifaceDesc.properties['Ac/Energy/Forward']) {
     ifaceDesc.properties['Ac/Energy/Forward'].persist = ENERGY_PERSIST_SECONDS
   }
   if (config.default_values) {

--- a/src/nodes/victron-virtual/device-type/pvinverter.js
+++ b/src/nodes/victron-virtual/device-type/pvinverter.js
@@ -1,3 +1,6 @@
+const WATT_MILLISECONDS_PER_KWH = 3_600_000_000
+const ENERGY_PERSIST_SECONDS = 60
+
 const properties = {
   'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
   'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
@@ -52,12 +55,19 @@ function initialize (config, ifaceDesc, iface, node) {
     const phase = `L${i}`
     phaseProperties.forEach(({ name, unit }) => {
       const key = `Ac/${phase}/${name}`
-      ifaceDesc.properties[key] = {
+      const propDef = {
         type: 'd',
         format: (v) => v != null ? v.toFixed(2) + unit : ''
       }
+      if (config.pvinverter_auto_energy && name === 'Energy/Forward') {
+        propDef.persist = ENERGY_PERSIST_SECONDS
+      }
+      ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
+  }
+  if (config.pvinverter_auto_energy && ifaceDesc.properties['Ac/Energy/Forward']) {
+    ifaceDesc.properties['Ac/Energy/Forward'].persist = ENERGY_PERSIST_SECONDS
   }
   if (config.default_values) {
     iface['Ac/Power'] = 0
@@ -70,4 +80,46 @@ function initialize (config, ifaceDesc, iface, node) {
   return `Virtual ${iface.NrOfPhases}-phase pvinverter`
 }
 
-module.exports = { properties, initialize, label: 'PV inverter' }
+function accumulateDelta (changes, instance, energyKey, oldPower, lastTs, now) {
+  if (lastTs != null && oldPower != null && oldPower > 0 && !(energyKey in changes)) {
+    const deltaKwh = oldPower * (now - lastTs) / WATT_MILLISECONDS_PER_KWH
+    changes[energyKey] = (instance[energyKey] || 0) + deltaKwh
+  }
+}
+
+function onPropertiesChanged ({ changes, instance, config }) {
+  if (!config.pvinverter_auto_energy) return changes
+
+  const now = Date.now()
+  const nrOfPhases = Number(config.pvinverter_nrofphases ?? 1)
+  let anyPhaseUpdated = false
+  let phaseTotal = 0
+
+  for (let i = 1; i <= nrOfPhases; i++) {
+    const powerKey = `Ac/L${i}/Power`
+    const energyKey = `Ac/L${i}/Energy/Forward`
+    const tsKey = `_lastL${i}PowerTimestamp`
+    if (powerKey in changes) {
+      accumulateDelta(changes, instance, energyKey, instance[powerKey], instance[tsKey], now)
+      instance[tsKey] = now
+      anyPhaseUpdated = true
+    }
+    phaseTotal += energyKey in changes ? changes[energyKey] : (instance[energyKey] || 0)
+  }
+
+  if (anyPhaseUpdated && !('Ac/Energy/Forward' in changes)) {
+    changes['Ac/Energy/Forward'] = phaseTotal
+  }
+
+  if ('Ac/Power' in changes) {
+    if (!anyPhaseUpdated) {
+      accumulateDelta(changes, instance, 'Ac/Energy/Forward', instance['Ac/Power'], instance._lastPowerTimestamp, now)
+    }
+    // Always update; prevents stale-delta spike when switching from per-phase to total-power reporting.
+    instance._lastPowerTimestamp = now
+  }
+
+  return changes
+}
+
+module.exports = { properties, initialize, onPropertiesChanged, label: 'PV inverter' }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const { addVictronInterfaces, addSettings } = require('dbus-victron-virtual')
-const { needsPersistedState, hasPersistedState, loadPersistedState, savePersistedState } = require('../persist')
+const { needsPersistedState, hasPersistedState, loadPersistedState, savePersistedState, flushPersistedState } = require('../persist')
 const dbus = require('dbus-native-victron')
 const debug = require('debug')('victron-virtual')
 const debugInput = require('debug')('victron-virtual:input')
@@ -859,6 +859,10 @@ module.exports = function (RED) {
       }
 
       function finishClose () {
+        if (node.iface && node.ifaceDesc) {
+          flushPersistedState(RED, node.id, node.iface, node.ifaceDesc)
+        }
+
         // TODO: previously, we called end() on the connection only if no nodeInstances
         // were left. Calling end() here resolves an issue with the VictronDbusListener
         // not responding to ItemsChanged signals any more after a redeploy here:

--- a/test/persist.test.js
+++ b/test/persist.test.js
@@ -1,0 +1,83 @@
+// test/persist.test.js
+/* eslint-env jest */
+
+describe('flushPersistedState', () => {
+  const RED = { settings: { userDir: '/tmp/test' } }
+  const id = 'test-node-id'
+  const ifaceDesc = {
+    properties: {
+      'Ac/Energy/Forward': { type: 'd', persist: 60 }
+    }
+  }
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function setup () {
+    jest.mock('fs', () => ({
+      existsSync: jest.fn(() => false),
+      mkdirSync: jest.fn(),
+      writeFileSync: jest.fn(),
+      renameSync: jest.fn(),
+      readFileSync: jest.fn()
+    }))
+    const fs = require('fs')
+    const persist = require('../src/nodes/persist')
+    return { fs, persist }
+  }
+
+  test('is exported from persist.js', () => {
+    const { persist } = setup()
+    expect(typeof persist.flushPersistedState).toBe('function')
+  })
+
+  test('cancels a pending throttle timer and writes immediately', () => {
+    const { fs, persist } = setup()
+    const { savePersistedState, flushPersistedState } = persist
+    const iface = { 'Ac/Energy/Forward': 1.5 }
+
+    // Initial save primes the cache and sets lastSaveAt
+    savePersistedState(RED, id, iface, ifaceDesc)
+
+    // Change value so isSaveNeeded returns true on next call
+    iface['Ac/Energy/Forward'] = 2.0
+
+    // Second save within 60s throttle window - queues a timer, does not write now
+    savePersistedState(RED, id, iface, ifaceDesc, 'Ac/Energy/Forward')
+    const writesBefore = fs.writeFileSync.mock.calls.length
+
+    // Flush must cancel the timer and write immediately
+    flushPersistedState(RED, id, iface, ifaceDesc)
+    expect(fs.writeFileSync.mock.calls.length).toBeGreaterThan(writesBefore)
+  })
+
+  test('is a no-op when there is no pending timer', () => {
+    const { fs, persist } = setup()
+    const { flushPersistedState } = persist
+    const iface = { 'Ac/Energy/Forward': 1.5 }
+
+    expect(() => flushPersistedState(RED, id, iface, ifaceDesc)).not.toThrow()
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+  })
+
+  test('does not fire the timer after flush', () => {
+    const { fs, persist } = setup()
+    const { savePersistedState, flushPersistedState } = persist
+    const iface = { 'Ac/Energy/Forward': 1.5 }
+
+    savePersistedState(RED, id, iface, ifaceDesc)
+    iface['Ac/Energy/Forward'] = 3.0
+    savePersistedState(RED, id, iface, ifaceDesc, 'Ac/Energy/Forward')
+    flushPersistedState(RED, id, iface, ifaceDesc)
+
+    const writesAfterFlush = fs.writeFileSync.mock.calls.length
+    jest.runAllTimers() // timer was cancelled - no additional writes
+    expect(fs.writeFileSync.mock.calls.length).toBe(writesAfterFlush)
+  })
+})

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -767,6 +767,39 @@ describe('pvinverter', () => {
       const result = pvinverter.initialize({ pvinverter_nrofphases: 3 }, ifaceDesc, iface, node)
       expect(result).toBe('Virtual 3-phase pvinverter')
     })
+
+    test('sets persist on Ac/Energy/Forward when pvinverter_auto_energy is true', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
+      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: true }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeDefined()
+    })
+
+    test('does not set persist on Ac/Energy/Forward when pvinverter_auto_energy is false', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
+      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: false }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeUndefined()
+    })
+
+    test('does not set persist when pvinverter_auto_energy is undefined (existing flow migration)', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
+      pvinverter.initialize({ pvinverter_nrofphases: 1 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeUndefined()
+    })
+
+    test('sets persist on per-phase Ac/L1/Energy/Forward when pvinverter_auto_energy is true', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: true }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
+    })
+
+    test('does not set persist on phase energy properties when pvinverter_auto_energy is false', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: false }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeUndefined()
+    })
   })
 
   describe('format', () => {

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -60,6 +60,20 @@ describe('acload', () => {
       acload.initialize({ acload_nrofphases: 1, default_values: false }, ifaceDesc, iface, node)
       expect(iface['Ac/Power']).toBeUndefined()
     })
+
+    test('energy properties in static properties have persist set', () => {
+      expect(acload.properties['Ac/Energy/Forward'].persist).toBeDefined()
+      expect(acload.properties['Ac/Energy/Reverse'].persist).toBeDefined()
+    })
+
+    test('phase energy properties added by initialize have persist set', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 2 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L1/Energy/Reverse'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Reverse'].persist).toBeDefined()
+    })
   })
 
   describe('S2 support', () => {
@@ -495,6 +509,14 @@ describe('generator', () => {
       const result = generator.initialize({ generator_type: 'dc' }, ifaceDesc, iface, node)
       expect(result).toBe('Virtual DC generator')
     })
+
+    test('genset Ac/Energy/Forward has persist set', () => {
+      expect(generator.properties.genset['Ac/Energy/Forward'].persist).toBeDefined()
+    })
+
+    test('dcgenset History/EnergyOut has persist set', () => {
+      expect(generator.properties.dcgenset['History/EnergyOut'].persist).toBeDefined()
+    })
   })
 
   describe('format', () => {
@@ -559,6 +581,20 @@ describe('grid', () => {
       expect(iface['Ac/Power']).toBe(0)
       expect(iface['Ac/Frequency']).toBe(50)
       expect(iface['Ac/N/Current']).toBe(0)
+    })
+
+    test('static energy properties have persist set', () => {
+      expect(grid.properties['Ac/Energy/Forward'].persist).toBeDefined()
+      expect(grid.properties['Ac/Energy/Reverse'].persist).toBeDefined()
+    })
+
+    test('phase energy properties added by initialize have persist set', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      grid.initialize({ grid_nrofphases: 2 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L1/Energy/Reverse'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Reverse'].persist).toBeDefined()
     })
   })
 })
@@ -768,37 +804,24 @@ describe('pvinverter', () => {
       expect(result).toBe('Virtual 3-phase pvinverter')
     })
 
-    test('sets persist on Ac/Energy/Forward when pvinverter_auto_energy is true', () => {
+    test('sets persist on Ac/Energy/Forward regardless of pvinverter_auto_energy', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
-      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: true }, ifaceDesc, iface, node)
+      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: false }, ifaceDesc, iface, node)
       expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeDefined()
     })
 
-    test('does not set persist on Ac/Energy/Forward when pvinverter_auto_energy is false', () => {
-      const { ifaceDesc, iface, node } = makeFixtures()
-      ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
-      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: false }, ifaceDesc, iface, node)
-      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeUndefined()
-    })
-
-    test('does not set persist when pvinverter_auto_energy is undefined (existing flow migration)', () => {
+    test('sets persist on Ac/Energy/Forward when pvinverter_auto_energy is absent (existing flow migration)', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
       pvinverter.initialize({ pvinverter_nrofphases: 1 }, ifaceDesc, iface, node)
-      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeDefined()
     })
 
-    test('sets persist on per-phase Ac/L1/Energy/Forward when pvinverter_auto_energy is true', () => {
-      const { ifaceDesc, iface, node } = makeFixtures()
-      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: true }, ifaceDesc, iface, node)
-      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
-    })
-
-    test('does not set persist on phase energy properties when pvinverter_auto_energy is false', () => {
+    test('sets persist on per-phase Ac/L1/Energy/Forward regardless of pvinverter_auto_energy', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: false }, ifaceDesc, iface, node)
-      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
     })
   })
 
@@ -1086,6 +1109,20 @@ describe('energymeter', () => {
       expect(iface['Ac/Power']).toBe(0)
       expect(iface['Ac/Energy/Forward']).toBe(0)
       expect(iface['Ac/Energy/Reverse']).toBe(0)
+    })
+
+    it('shared energy properties have persist set', () => {
+      expect(energymeter.__sharedProperties['Ac/Energy/Forward'].persist).toBeDefined()
+      expect(energymeter.__sharedProperties['Ac/Energy/Reverse'].persist).toBeDefined()
+    })
+
+    it('phase energy properties added by initialize have persist set', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_nrofphases: 2 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L1/Energy/Reverse'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Reverse'].persist).toBeDefined()
     })
   })
 })

--- a/test/victron-virtual-pvinverter.test.js
+++ b/test/victron-virtual-pvinverter.test.js
@@ -1,0 +1,290 @@
+// test/victron-virtual-pvinverter.test.js
+/* eslint-env jest */
+const pvinverter = require('../src/nodes/victron-virtual/device-type/pvinverter')
+
+describe('pvinverter device module', () => {
+  test('exports required contract', () => {
+    expect(typeof pvinverter.properties).toBe('object')
+    expect(typeof pvinverter.initialize).toBe('function')
+    expect(typeof pvinverter.onPropertiesChanged).toBe('function')
+  })
+
+  describe('onPropertiesChanged - auto_energy disabled', () => {
+    test('returns changes unmodified when pvinverter_auto_energy is false', () => {
+      const instance = { 'Ac/Power': 500 }
+      const changes = { 'Ac/Power': 600 }
+      const result = pvinverter.onPropertiesChanged({
+        changes,
+        instance,
+        config: { pvinverter_auto_energy: false, pvinverter_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+      expect(result['Ac/Power']).toBe(600)
+    })
+
+    test('does not set timestamp on instance when disabled', () => {
+      const instance = { 'Ac/Power': 500 }
+      pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 600 },
+        instance,
+        config: { pvinverter_auto_energy: false, pvinverter_nrofphases: 1 }
+      })
+      expect(instance._lastPowerTimestamp).toBeUndefined()
+    })
+
+    test('treats undefined pvinverter_auto_energy as disabled (migration from older flows)', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { pvinverter_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+  })
+
+  describe('onPropertiesChanged - auto_energy enabled', () => {
+    test('sets timestamp on first power reading, does not inject energy', () => {
+      const instance = { 'Ac/Power': null }
+      const before = Date.now()
+      pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      expect(instance._lastPowerTimestamp).toBeGreaterThanOrEqual(before)
+    })
+
+    test('accumulates energy on second power reading', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      // Simulate previous reading 1 hour ago (3,600,000 ms)
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      // 1000 W for 1 hour = 1 kWh
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.0, 2)
+    })
+
+    test('adds delta to existing accumulated energy', () => {
+      const instance = { 'Ac/Power': 2000, 'Ac/Energy/Forward': 5.0 }
+      instance._lastPowerTimestamp = Date.now() - 1_800_000 // 30 minutes
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 2000 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      // 2000 W for 0.5 h = 1 kWh; prior = 5.0; total ~= 6.0
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(6.0, 2)
+    })
+
+    test('skips energy injection when power is zero', () => {
+      const instance = { 'Ac/Power': 0, 'Ac/Energy/Forward': 2.0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 0 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+
+    test('skips energy injection when old power is null', () => {
+      const instance = { 'Ac/Power': null, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 500 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+
+    test('does not overwrite user-provided Ac/Energy/Forward in same payload', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000, 'Ac/Energy/Forward': 99 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBe(99)
+    })
+
+    test('updates timestamp on every power change', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const before = Date.now()
+      pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      expect(instance._lastPowerTimestamp).toBeGreaterThanOrEqual(before)
+    })
+  })
+
+  describe('onPropertiesChanged - per-phase energy', () => {
+    test('accumulates per-phase energy for L1 on second reading', () => {
+      const instance = { 'Ac/L1/Power': 500, 'Ac/L1/Energy/Forward': 0 }
+      instance._lastL1PowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/L1/Power': 500 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      // 500 W for 1 h = 0.5 kWh
+      expect(result['Ac/L1/Energy/Forward']).toBeCloseTo(0.5, 2)
+    })
+
+    test('sets Ac/Energy/Forward as sum of all phase energies', () => {
+      const instance = {
+        'Ac/L1/Power': 300,
+        'Ac/L2/Power': 600,
+        'Ac/L3/Power': 900,
+        'Ac/L1/Energy/Forward': 0,
+        'Ac/L2/Energy/Forward': 0,
+        'Ac/L3/Energy/Forward': 0
+      }
+      const oneHourAgo = Date.now() - 3_600_000
+      instance._lastL1PowerTimestamp = oneHourAgo
+      instance._lastL2PowerTimestamp = oneHourAgo
+      instance._lastL3PowerTimestamp = oneHourAgo
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/L1/Power': 300, 'Ac/L2/Power': 600, 'Ac/L3/Power': 900 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 3 }
+      })
+      expect(result['Ac/L1/Energy/Forward']).toBeCloseTo(0.3, 2)
+      expect(result['Ac/L2/Energy/Forward']).toBeCloseTo(0.6, 2)
+      expect(result['Ac/L3/Energy/Forward']).toBeCloseTo(0.9, 2)
+      // Total = 0.3 + 0.6 + 0.9 = 1.8 kWh
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.8, 2)
+    })
+
+    test('includes existing phase energy from instance when only some phases are updated', () => {
+      const instance = {
+        'Ac/L1/Power': 300,
+        'Ac/L1/Energy/Forward': 1.0,
+        'Ac/L2/Energy/Forward': 2.0,
+        'Ac/L3/Energy/Forward': 3.0
+      }
+      instance._lastL1PowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/L1/Power': 300 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 3 }
+      })
+      // L1 adds 0.3 kWh to existing 1.0 = 1.3; L2 and L3 unchanged at 2.0 and 3.0
+      expect(result['Ac/L1/Energy/Forward']).toBeCloseTo(1.3, 2)
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.3 + 2.0 + 3.0, 2)
+    })
+
+    test('does not accumulate phase energy beyond configured nrOfPhases', () => {
+      const instance = { 'Ac/L3/Power': 500 }
+      instance._lastL3PowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/L3/Power': 500 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      // 1-phase config - L3 should not be touched
+      expect(result['Ac/L3/Energy/Forward']).toBeUndefined()
+    })
+
+    test('does not overwrite user-provided Ac/Energy/Forward even when phases update', () => {
+      const instance = {
+        'Ac/L1/Power': 1000,
+        'Ac/L1/Energy/Forward': 0
+      }
+      instance._lastL1PowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/L1/Power': 1000, 'Ac/Energy/Forward': 99 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBe(99)
+    })
+  })
+
+  describe('onPropertiesChanged - Ac/Power fallback (no per-phase data)', () => {
+    test('uses Ac/Power when no phase powers are in changes', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.0, 2)
+    })
+
+    test('does not use Ac/Power fallback when phase powers are also in changes', () => {
+      const instance = {
+        'Ac/Power': 1000,
+        'Ac/L1/Power': 1000,
+        'Ac/Energy/Forward': 0,
+        'Ac/L1/Energy/Forward': 0
+      }
+      const oneHourAgo = Date.now() - 3_600_000
+      instance._lastPowerTimestamp = oneHourAgo
+      instance._lastL1PowerTimestamp = oneHourAgo
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000, 'Ac/L1/Power': 1000 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      // Energy comes from L1 phase sum (1.0 kWh), not double-counted from Ac/Power
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.0, 2)
+    })
+
+    test('updates _lastPowerTimestamp even when per-phase data drives the update', () => {
+      // Guards against: user sends per-phase for hours then switches to Ac/Power-only;
+      // stale _lastPowerTimestamp would cause a massive spurious energy spike.
+      const instance = {
+        'Ac/Power': 500,
+        'Ac/L1/Power': 500,
+        'Ac/Energy/Forward': 0,
+        'Ac/L1/Energy/Forward': 0
+      }
+      const tenHoursAgo = Date.now() - 36_000_000
+      instance._lastPowerTimestamp = tenHoursAgo
+      instance._lastL1PowerTimestamp = Date.now() - 3_600_000
+
+      pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 500, 'Ac/L1/Power': 500 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+
+      // _lastPowerTimestamp must be refreshed so a subsequent Ac/Power-only message
+      // does not compute a 10-hour delta
+      expect(instance._lastPowerTimestamp).toBeGreaterThan(tenHoursAgo)
+
+      // Now send Ac/Power only - must NOT produce a huge delta
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': 500 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      // Delta should be tiny (milliseconds), not hours
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(0, 3)
+    })
+  })
+})

--- a/test/victron-virtual-pvinverter.test.js
+++ b/test/victron-virtual-pvinverter.test.js
@@ -95,6 +95,18 @@ describe('pvinverter device module', () => {
       expect(result['Ac/Energy/Forward']).toBeUndefined()
     })
 
+    test('does not accumulate energy when old power is negative (clamps to zero)', () => {
+      const instance = { 'Ac/Power': -100, 'Ac/Energy/Forward': 2.0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = pvinverter.onPropertiesChanged({
+        changes: { 'Ac/Power': -100 },
+        instance,
+        config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+
     test('skips energy injection when old power is null', () => {
       const instance = { 'Ac/Power': null, 'Ac/Energy/Forward': 0 }
       instance._lastPowerTimestamp = Date.now() - 3_600_000
@@ -283,8 +295,8 @@ describe('pvinverter device module', () => {
         instance,
         config: { pvinverter_auto_energy: true, pvinverter_nrofphases: 1 }
       })
-      // Delta should be tiny (milliseconds), not hours
-      expect(result['Ac/Energy/Forward']).toBeCloseTo(0, 3)
+      // Delta should be tiny (or zero/absent if same-tick), not hours
+      expect(result['Ac/Energy/Forward'] ?? 0).toBeCloseTo(0, 3)
     })
   })
 })


### PR DESCRIPTION
When enabled, the virtual PV inverter integrates power over time to accumulate `Ac/Energy/Forward`. For multi-phase setups the total is the sum of per-phase energies; falls back to `Ac/Power` when no per-phase data is provided. Value persists across restarts.

Configurable via checkbox; defaults to on for new nodes. Existing flows treat the absent field as disabled (safe migration).

Also adds `flushPersistedState()` to `persist.js`: cancels any pending throttle timer and writes immediately. Called on node close so throttled-persist state (e.g. accumulated energy) is not lost on redeploy.