### PR TITLE
fix(virtual): persist energy counters across restarts for all device types

### DIFF
--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -18,8 +18,8 @@ const phaseProperties = [
   { name: 'Current', unit: 'A' },
   { name: 'Power', unit: 'W' },
   { name: 'Voltage', unit: 'V' },
-  { name: 'Energy/Forward', unit: 'kWh' },
-  { name: 'Energy/Reverse', unit: 'kWh' },
+  { name: 'Energy/Forward', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
+  { name: 'Energy/Reverse', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
   { name: 'PowerFactor', unit: '' }
 ]
 
@@ -44,14 +44,12 @@ function initialize (config, ifaceDesc, iface, node) {
   iface.NrOfPhases = Number(config.acload_nrofphases ?? 1)
   for (let i = 1; i <= iface.NrOfPhases; i++) {
     const phase = `L${i}`
-    phaseProperties.forEach(({ name, unit }) => {
+    phaseProperties.forEach(({ name, unit, persist }) => {
       const key = `Ac/${phase}/${name}`
       const propDef = {
         type: 'd',
-        format: (v) => v != null ? v.toFixed(2) + unit : ''
-      }
-      if (name.startsWith('Energy/')) {
-        propDef.persist = ENERGY_PERSIST_SECONDS
+        format: (v) => v != null ? v.toFixed(2) + unit : '',
+        ...(persist && { persist })
       }
       ifaceDesc.properties[key] = propDef
       iface[key] = 0

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -1,6 +1,8 @@
+const ENERGY_PERSIST_SECONDS = 60
+
 const properties = {
-  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '' },
-  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '' },
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
   'Ac/L1/Current': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
   'Ac/L1/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '' },
   'Ac/L1/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(3) + 'kWh' : '' },
@@ -44,10 +46,14 @@ function initialize (config, ifaceDesc, iface, node) {
     const phase = `L${i}`
     phaseProperties.forEach(({ name, unit }) => {
       const key = `Ac/${phase}/${name}`
-      ifaceDesc.properties[key] = {
+      const propDef = {
         type: 'd',
         format: (v) => v != null ? v.toFixed(2) + unit : ''
       }
+      if (name.startsWith('Energy/')) {
+        propDef.persist = ENERGY_PERSIST_SECONDS
+      }
+      ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
   }

--- a/src/nodes/victron-virtual/device-type/energymeter.js
+++ b/src/nodes/victron-virtual/device-type/energymeter.js
@@ -1,5 +1,7 @@
 const debug = require('debug')('victron-virtual')
 
+const ENERGY_PERSIST_SECONDS = 60
+
 const ROLE_TO_SERVICE_TYPE = {
   gridmeter: 'grid',
   inverter: 'pvinverter',
@@ -10,8 +12,8 @@ const ROLE_TO_SERVICE_TYPE = {
 }
 
 const sharedProperties = {
-  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
-  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
   'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
   'Ac/PowerFactor': { type: 'd', format: (v) => v != null ? v.toFixed(2) : '' },
   Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 },
@@ -57,10 +59,14 @@ function initialize (config, ifaceDesc, iface, node) {
     const phase = `L${i}`
     phaseProperties.forEach(({ name, unit }) => {
       const key = `Ac/${phase}/${name}`
-      ifaceDesc.properties[key] = {
+      const propDef = {
         type: 'd',
         format: (v) => v != null ? v.toFixed(2) + unit : ''
       }
+      if (name.startsWith('Energy/')) {
+        propDef.persist = ENERGY_PERSIST_SECONDS
+      }
+      ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
   }

--- a/src/nodes/victron-virtual/device-type/energymeter.js
+++ b/src/nodes/victron-virtual/device-type/energymeter.js
@@ -46,8 +46,8 @@ function buildProperties (config) {
 
 const phaseProperties = [
   { name: 'Current', unit: 'A' },
-  { name: 'Energy/Forward', unit: 'kWh' },
-  { name: 'Energy/Reverse', unit: 'kWh' },
+  { name: 'Energy/Forward', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
+  { name: 'Energy/Reverse', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
   { name: 'Power', unit: 'W' },
   { name: 'PowerFactor', unit: '' },
   { name: 'Voltage', unit: 'V' }
@@ -57,14 +57,12 @@ function initialize (config, ifaceDesc, iface, node) {
   iface.NrOfPhases = Number(config.energymeter_nrofphases ?? 1)
   for (let i = 1; i <= iface.NrOfPhases; i++) {
     const phase = `L${i}`
-    phaseProperties.forEach(({ name, unit }) => {
+    phaseProperties.forEach(({ name, unit, persist }) => {
       const key = `Ac/${phase}/${name}`
       const propDef = {
         type: 'd',
-        format: (v) => v != null ? v.toFixed(2) + unit : ''
-      }
-      if (name.startsWith('Energy/')) {
-        propDef.persist = ENERGY_PERSIST_SECONDS
+        format: (v) => v != null ? v.toFixed(2) + unit : '',
+        ...(persist && { persist })
       }
       ifaceDesc.properties[key] = propDef
       iface[key] = 0

--- a/src/nodes/victron-virtual/device-type/generator.js
+++ b/src/nodes/victron-virtual/device-type/generator.js
@@ -1,3 +1,5 @@
+const ENERGY_PERSIST_SECONDS = 60
+
 const commonGeneratorProperties = {
   AutoStart: { type: 'i', format: (v) => v != null ? v : '', value: 1, persist: true },
   Start: { type: 'i', format: (v) => v != null ? v : '', value: 0, persist: true, immediate: true },
@@ -52,7 +54,7 @@ const properties = {
   genset: {
     ...commonGeneratorProperties,
     'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
-    'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
+    'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
     'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(1) + 'Hz' : '' },
     NrOfPhases: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
   },
@@ -61,7 +63,7 @@ const properties = {
     'Dc/0/Current': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
     'Dc/0/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
     'Dc/0/Voltage': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '' },
-    'History/EnergyOut': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '' },
+    'History/EnergyOut': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
     State: {
       type: 'i',
       format: (v) => ({

--- a/src/nodes/victron-virtual/device-type/grid.js
+++ b/src/nodes/victron-virtual/device-type/grid.js
@@ -15,22 +15,20 @@ const phaseProperties = [
   { name: 'Current', unit: 'A' },
   { name: 'Power', unit: 'W' },
   { name: 'Voltage', unit: 'V' },
-  { name: 'Energy/Forward', unit: 'kWh' },
-  { name: 'Energy/Reverse', unit: 'kWh' }
+  { name: 'Energy/Forward', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
+  { name: 'Energy/Reverse', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS }
 ]
 
 function initialize (config, ifaceDesc, iface, node) {
   iface.NrOfPhases = Number(config.grid_nrofphases ?? 1)
   for (let i = 1; i <= iface.NrOfPhases; i++) {
     const phase = `L${i}`
-    phaseProperties.forEach(({ name, unit }) => {
+    phaseProperties.forEach(({ name, unit, persist }) => {
       const key = `Ac/${phase}/${name}`
       const propDef = {
         type: 'd',
-        format: (v) => v != null ? v.toFixed(2) + unit : ''
-      }
-      if (name.startsWith('Energy/')) {
-        propDef.persist = ENERGY_PERSIST_SECONDS
+        format: (v) => v != null ? v.toFixed(2) + unit : '',
+        ...(persist && { persist })
       }
       ifaceDesc.properties[key] = propDef
       iface[key] = 0

--- a/src/nodes/victron-virtual/device-type/grid.js
+++ b/src/nodes/victron-virtual/device-type/grid.js
@@ -1,6 +1,8 @@
+const ENERGY_PERSIST_SECONDS = 60
+
 const properties = {
-  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0 },
-  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0 },
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0, persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', value: 0, persist: ENERGY_PERSIST_SECONDS },
   'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'Hz' : '' },
   'Ac/N/Current': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
   'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
@@ -23,10 +25,14 @@ function initialize (config, ifaceDesc, iface, node) {
     const phase = `L${i}`
     phaseProperties.forEach(({ name, unit }) => {
       const key = `Ac/${phase}/${name}`
-      ifaceDesc.properties[key] = {
+      const propDef = {
         type: 'd',
         format: (v) => v != null ? v.toFixed(2) + unit : ''
       }
+      if (name.startsWith('Energy/')) {
+        propDef.persist = ENERGY_PERSIST_SECONDS
+      }
+      ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
   }

--- a/src/nodes/victron-virtual/device-type/pvinverter.js
+++ b/src/nodes/victron-virtual/device-type/pvinverter.js
@@ -59,14 +59,14 @@ function initialize (config, ifaceDesc, iface, node) {
         type: 'd',
         format: (v) => v != null ? v.toFixed(2) + unit : ''
       }
-      if (config.pvinverter_auto_energy && name === 'Energy/Forward') {
+      if (name === 'Energy/Forward') {
         propDef.persist = ENERGY_PERSIST_SECONDS
       }
       ifaceDesc.properties[key] = propDef
       iface[key] = 0
     })
   }
-  if (config.pvinverter_auto_energy && ifaceDesc.properties['Ac/Energy/Forward']) {
+  if (ifaceDesc.properties['Ac/Energy/Forward']) {
     ifaceDesc.properties['Ac/Energy/Forward'].persist = ENERGY_PERSIST_SECONDS
   }
   if (config.default_values) {

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -60,6 +60,20 @@ describe('acload', () => {
       acload.initialize({ acload_nrofphases: 1, default_values: false }, ifaceDesc, iface, node)
       expect(iface['Ac/Power']).toBeUndefined()
     })
+
+    test('energy properties in static properties have persist set', () => {
+      expect(acload.properties['Ac/Energy/Forward'].persist).toBeDefined()
+      expect(acload.properties['Ac/Energy/Reverse'].persist).toBeDefined()
+    })
+
+    test('phase energy properties added by initialize have persist set', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 2 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L1/Energy/Reverse'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Reverse'].persist).toBeDefined()
+    })
   })
 
   describe('S2 support', () => {
@@ -495,6 +509,14 @@ describe('generator', () => {
       const result = generator.initialize({ generator_type: 'dc' }, ifaceDesc, iface, node)
       expect(result).toBe('Virtual DC generator')
     })
+
+    test('genset Ac/Energy/Forward has persist set', () => {
+      expect(generator.properties.genset['Ac/Energy/Forward'].persist).toBeDefined()
+    })
+
+    test('dcgenset History/EnergyOut has persist set', () => {
+      expect(generator.properties.dcgenset['History/EnergyOut'].persist).toBeDefined()
+    })
   })
 
   describe('format', () => {
@@ -559,6 +581,20 @@ describe('grid', () => {
       expect(iface['Ac/Power']).toBe(0)
       expect(iface['Ac/Frequency']).toBe(50)
       expect(iface['Ac/N/Current']).toBe(0)
+    })
+
+    test('static energy properties have persist set', () => {
+      expect(grid.properties['Ac/Energy/Forward'].persist).toBeDefined()
+      expect(grid.properties['Ac/Energy/Reverse'].persist).toBeDefined()
+    })
+
+    test('phase energy properties added by initialize have persist set', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      grid.initialize({ grid_nrofphases: 2 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L1/Energy/Reverse'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Reverse'].persist).toBeDefined()
     })
   })
 })
@@ -768,37 +804,24 @@ describe('pvinverter', () => {
       expect(result).toBe('Virtual 3-phase pvinverter')
     })
 
-    test('sets persist on Ac/Energy/Forward when pvinverter_auto_energy is true', () => {
+    test('sets persist on Ac/Energy/Forward regardless of pvinverter_auto_energy', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
-      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: true }, ifaceDesc, iface, node)
+      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: false }, ifaceDesc, iface, node)
       expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeDefined()
     })
 
-    test('does not set persist on Ac/Energy/Forward when pvinverter_auto_energy is false', () => {
-      const { ifaceDesc, iface, node } = makeFixtures()
-      ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
-      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: false }, ifaceDesc, iface, node)
-      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeUndefined()
-    })
-
-    test('does not set persist when pvinverter_auto_energy is undefined (existing flow migration)', () => {
+    test('sets persist on Ac/Energy/Forward when pvinverter_auto_energy is absent (existing flow migration)', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       ifaceDesc.properties['Ac/Energy/Forward'] = { type: 'd' }
       pvinverter.initialize({ pvinverter_nrofphases: 1 }, ifaceDesc, iface, node)
-      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/Energy/Forward'].persist).toBeDefined()
     })
 
-    test('sets persist on per-phase Ac/L1/Energy/Forward when pvinverter_auto_energy is true', () => {
-      const { ifaceDesc, iface, node } = makeFixtures()
-      pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: true }, ifaceDesc, iface, node)
-      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
-    })
-
-    test('does not set persist on phase energy properties when pvinverter_auto_energy is false', () => {
+    test('sets persist on per-phase Ac/L1/Energy/Forward regardless of pvinverter_auto_energy', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       pvinverter.initialize({ pvinverter_nrofphases: 1, pvinverter_auto_energy: false }, ifaceDesc, iface, node)
-      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
     })
   })
 
@@ -1086,6 +1109,20 @@ describe('energymeter', () => {
       expect(iface['Ac/Power']).toBe(0)
       expect(iface['Ac/Energy/Forward']).toBe(0)
       expect(iface['Ac/Energy/Reverse']).toBe(0)
+    })
+
+    it('shared energy properties have persist set', () => {
+      expect(energymeter.__sharedProperties['Ac/Energy/Forward'].persist).toBeDefined()
+      expect(energymeter.__sharedProperties['Ac/Energy/Reverse'].persist).toBeDefined()
+    })
+
+    it('phase energy properties added by initialize have persist set', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_nrofphases: 2 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L1/Energy/Reverse'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Forward'].persist).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Energy/Reverse'].persist).toBeDefined()
     })
   })
 })


### PR DESCRIPTION
Virtual AC load, grid meter, energy meter, and genset energy counters (`Ac/Energy/Forward`, `Ac/Energy/Reverse`, `Ac/L*/Energy/Forward`, `Ac/L*/Energy/Reverse`, `History/EnergyOut`) are now persisted with a 60s throttle. Values survive Node-RED restarts regardless of whether they are set externally or auto-calculated.

Also extends the pvinverter energy persist introduced in #514 to be unconditional: previously persist was only enabled when `pvinverter_auto_energy` was `true`, leaving manually-set energy values unprotected on restart. All device types now persist energy counters on the same basis.

Fixes https://github.com/victronenergy/node-red-contrib-victron/issues/513