### PR TITLE
fix(nodes): guard against undefined pathObj in input and output nodes

### DIFF
--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -205,9 +205,9 @@ module.exports = function (RED) {
             topic
           }
           let text = msg.value
-          if (this.node.pathObj.type === 'enum') {
-            outmsg.textvalue = this.node.pathObj.enum[msg.value] || ''
-            text = `${msg.value} (${this.node.pathObj.enum[msg.value]})`
+          if (this.pathObj && this.pathObj.type === 'enum' && this.pathObj.enum) {
+            outmsg.textvalue = this.pathObj.enum[msg.value] || ''
+            text = `${msg.value} (${this.pathObj.enum[msg.value]})`
           }
 
           // If conditional mode is enabled, send raw value to output 1 and evaluate for output 2
@@ -506,6 +506,11 @@ module.exports = function (RED) {
 
         if (!/^\/.*/.test(writepath)) {
           writepath = '/' + writepath
+        }
+
+        if (!this.pathObj) {
+          this.node.status({ fill: 'red', shape, text: 'Path not configured' })
+          return
         }
 
         if (!this.pathObj.disabled && this.service && writepath) {

--- a/test/victron-nodes.test.js
+++ b/test/victron-nodes.test.js
@@ -3,6 +3,7 @@ const { serviceNamesWithoutDeviceInstance } = require('../src/services/dbus-list
 
 function buildMockRED ({ services = {}, connected = true, hasConfigNode = true } = {}) {
   const subscribe = jest.fn()
+  const publish = jest.fn()
   const mockRED = {
     nodes: {
       registerType: jest.fn(),
@@ -22,6 +23,7 @@ function buildMockRED ({ services = {}, connected = true, hasConfigNode = true }
             addStatusListener: jest.fn(),
             client: {
               subscribe,
+              publish,
               subscriptions: {},
               system: { cache: {} },
               onStatusUpdate: jest.fn(),
@@ -38,7 +40,7 @@ function buildMockRED ({ services = {}, connected = true, hasConfigNode = true }
   const BaseInputNode = mockRED.nodes.registerType.mock.calls[0][1]
   const outputCallIndex = mockRED.nodes.registerType.mock.calls.findIndex(c => c[0].startsWith('victron-output-'))
   const BaseOutputNode = mockRED.nodes.registerType.mock.calls[outputCallIndex][1]
-  return { mockRED, BaseInputNode, BaseOutputNode, subscribe }
+  return { mockRED, BaseInputNode, BaseOutputNode, subscribe, publish }
 }
 
 describe('victron-nodes migration', () => {
@@ -243,5 +245,41 @@ describe('victron-nodes', () => {
     // ... and we expect the status to be set to 'null'
     expect(handleStatus.mock.calls.length).toBe(2)
     expect(handleStatus.mock.calls[1][1].text).toEqual('null')
+  })
+})
+
+describe('victron-nodes pathObj guard', () => {
+  it('BaseInputNode does not crash and still emits value when pathObj is undefined', () => {
+    const { BaseInputNode, subscribe } = buildMockRED()
+
+    const node = new BaseInputNode({
+      name: 'Test',
+      service: 'com.victronenergy.battery',
+      path: '/Soc',
+      serviceObj: { name: 'Battery' },
+      pathObj: undefined
+    })
+
+    const processMessage = subscribe.mock.calls[0][2]
+    expect(() => processMessage({ value: 42 })).not.toThrow()
+    expect(node.send).toHaveBeenCalledWith(expect.objectContaining({ payload: 42 }))
+  })
+
+  it('BaseOutputNode shows error status and does not publish when pathObj is undefined', () => {
+    const { BaseOutputNode, publish } = buildMockRED()
+
+    const node = new BaseOutputNode({
+      name: 'Test',
+      service: 'com.victronenergy.system',
+      path: '/Relay/0/State',
+      serviceObj: { name: 'System' },
+      pathObj: undefined
+    })
+
+    const inputHandler = node.on.mock.calls.find(c => c[0] === 'input')[1]
+    inputHandler({ payload: 1 })
+
+    expect(node.status).toHaveBeenCalledWith(expect.objectContaining({ fill: 'red' }))
+    expect(publish).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Input nodes crashed on the first received message when pathObj was undefined (legacy flows, unconfigured nodes, imported flows without a path selected). Output nodes crashed on the first input message for the same reason.

- Skip enum formatting in processMessage when pathObj is absent; raw value is still emitted
- Return early with a red status in setValue when pathObj is absent
- Use this.pathObj consistently (not this.node.pathObj) in BaseInputNode