### PR TITLE
fix(dbus-listener): use plain cache key for singleton services

### DIFF
--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -1,9 +1,20 @@
 const { debounce } = require('../services/utils.js')
+const { serviceNamesWithoutDeviceInstance } = require('../services/dbus-listener.js')
+
+/* Those service names which should not have a device instance any more may still have
+ * a device instance in a pre-existing node definition. We therefore strip the device
+ * instance from the service name for those services.
+ * See PR#511 (https://github.com/victronenergy/node-red-contrib-victron/pull/511)
+ * for details.
+ */
+function mustRemoveDeviceInstanceFromService (service) {
+  const serviceNameBare = service.split('/')[0] // Remove any device instance suffix
+  return serviceNamesWithoutDeviceInstance.includes(serviceNameBare)
+}
 
 module.exports = function (RED) {
   const debug = require('debug')('node-red-contrib-victron:victron-nodes')
   const utils = require('../services/utils.js')
-  const { serviceNamesWithoutDeviceInstance } = require('../services/dbus-listener.js')
 
   const migrateSubscriptions = (x) => {
     // Check if client is fully initialized
@@ -115,6 +126,9 @@ module.exports = function (RED) {
 
       if (this.service && this.path) {
         // The following is for migration purposes
+        if (mustRemoveDeviceInstanceFromService(this.service)) {
+          this.service = this.service.replace(/\/\d+$/, '')
+        }
         if (!this.service.match(/\/\d+$/) && !serviceNamesWithoutDeviceInstance.includes(this.service)) {
           this.deviceInstance = this.service.replace(/^.*\.(\d+)$/, '$1')
           this.service = this.service.replace(/\.\d+$/, '')

--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -125,10 +125,14 @@ module.exports = function (RED) {
       let handlerId2 = null
 
       if (this.service && this.path) {
-        // The following is for migration purposes
         if (mustRemoveDeviceInstanceFromService(this.service)) {
-          this.service = this.service.replace(/\/\d+$/, '')
+          const newServiceName = this.service.replace(/\/\d+$/, '')
+          if (newServiceName !== this.service) {
+            console.warn(`[MIGRATE] Removing device instance from service name: ${this.service} -> ${newServiceName} (node ${this.id}). Please update this node's service in the editor to avoid this warning.`)
+            this.service = newServiceName
+          }
         }
+
         if (!this.service.match(/\/\d+$/) && !serviceNamesWithoutDeviceInstance.includes(this.service)) {
           this.deviceInstance = this.service.replace(/^.*\.(\d+)$/, '$1')
           this.service = this.service.replace(/\.\d+$/, '')

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -274,15 +274,15 @@ class VictronDbusListener {
           service.fluidType = data.FluidType
         }
 
-        const isWithoutDeviceInstance = serviceNamesWithoutDeviceInstance.includes(service.name)
+        const needsDeviceInstance = !serviceNamesWithoutDeviceInstance.includes(service.name)
 
-        if (!isWithoutDeviceInstance && !service.deviceInstance && data['/DeviceInstance'] != null) {
+        if (needsDeviceInstance && !service.deviceInstance && data['/DeviceInstance'] != null) {
           service.deviceInstance = data['/DeviceInstance']
         }
 
-        const deviceInstance = isWithoutDeviceInstance
-          ? null
-          : (data['/DeviceInstance'] != null ? data['/DeviceInstance'] : service.deviceInstance)
+        const deviceInstance = needsDeviceInstance
+          ? (data['/DeviceInstance'] != null ? data['/DeviceInstance'] : service.deviceInstance)
+          : null
 
         const messages = _.keys(data).map(path => {
           return {

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -87,7 +87,12 @@ const initServiceAllowlistRegexes = [
   /^com\.victronenergy\..+/ // anything beginning with 'com.victronenergy.' is allowed
 ]
 
-const serviceNamesWithoutDeviceInstance = ['com.victronenergy.settings']
+const serviceNamesWithoutDeviceInstance = [
+  'com.victronenergy.settings',
+  'com.victronenergy.platform',
+  'com.victronenergy.system',
+  'com.victronenergy.dynamicess'
+]
 
 class VictronDbusListener {
   constructor (address, callbacks) {
@@ -269,11 +274,15 @@ class VictronDbusListener {
           service.fluidType = data.FluidType
         }
 
-        if (!service.deviceInstance && data['/DeviceInstance'] != null) {
+        const isWithoutDeviceInstance = serviceNamesWithoutDeviceInstance.includes(service.name)
+
+        if (!isWithoutDeviceInstance && !service.deviceInstance && data['/DeviceInstance'] != null) {
           service.deviceInstance = data['/DeviceInstance']
         }
 
-        const deviceInstance = data['/DeviceInstance'] != null ? data['/DeviceInstance'] : service.deviceInstance
+        const deviceInstance = isWithoutDeviceInstance
+          ? null
+          : (data['/DeviceInstance'] != null ? data['/DeviceInstance'] : service.deviceInstance)
 
         const messages = _.keys(data).map(path => {
           return {

--- a/test/dbus-listener.test.js
+++ b/test/dbus-listener.test.js
@@ -32,5 +32,90 @@ describe('VictronDbusListener', () => {
       await listener._initService('the-other-owner', 'com.victronenergy.settings')
       expect(listener.services['the-other-owner'].deviceInstance).toBe(null)
     })
+
+    test('service "com.victronenergy.platform" won\'t get a deviceInstance', async () => {
+      await listener._initService('the-platform-owner', 'com.victronenergy.platform')
+      expect(listener.services['the-platform-owner'].deviceInstance).toBe(null)
+    })
+
+    test('service "com.victronenergy.system" won\'t get a deviceInstance', async () => {
+      await listener._initService('the-system-owner', 'com.victronenergy.system')
+      expect(listener.services['the-system-owner'].deviceInstance).toBe(null)
+    })
+
+    test('service "com.victronenergy.dynamicess" won\'t get a deviceInstance', async () => {
+      await listener._initService('the-dynamicess-owner', 'com.victronenergy.dynamicess')
+      expect(listener.services['the-dynamicess-owner'].deviceInstance).toBe(null)
+    })
+  })
+
+  describe('_requestRoot singleton service handling', () => {
+    let capturedMessages
+
+    beforeEach(() => {
+      capturedMessages = null
+      listener.messageHandler = (msgs) => { capturedMessages = msgs }
+      // GetItems returns /DeviceInstance: 0 plus one other path
+      listener.bus = {
+        invoke: jest.fn((_params, callback) => {
+          callback(null, [
+            ['/DeviceInstance', [['Value', ['i', [0]]]]],
+            ['/Version', [['Value', ['s', ['1.0']]]]]
+          ])
+        })
+      }
+    })
+
+    test.each([
+      'com.victronenergy.platform',
+      'com.victronenergy.system',
+      'com.victronenergy.dynamicess'
+    ])('%s uses null deviceInstance even when GetItems returns /DeviceInstance 0', async (serviceName) => {
+      const service = { name: serviceName, deviceInstance: null }
+      await listener._requestRoot(service)
+      expect(capturedMessages).not.toBeNull()
+      capturedMessages.forEach(msg => {
+        expect(msg.deviceInstance).toBeNull()
+      })
+    })
+
+    test('non-singleton service uses deviceInstance from GetItems data', async () => {
+      const service = { name: 'com.victronenergy.battery', deviceInstance: null }
+      await listener._requestRoot(service)
+      expect(capturedMessages).not.toBeNull()
+      capturedMessages.forEach(msg => {
+        expect(msg.deviceInstance).toBe(0)
+      })
+    })
+  })
+
+  describe('_requestRoot does not mutate service.deviceInstance for singleton services', () => {
+    beforeEach(() => {
+      listener.messageHandler = () => {}
+      listener.bus = {
+        invoke: jest.fn((_params, callback) => {
+          callback(null, [
+            ['/DeviceInstance', [['Value', ['i', [0]]]]],
+            ['/Version', [['Value', ['s', ['1.0']]]]]
+          ])
+        })
+      }
+    })
+
+    test.each([
+      'com.victronenergy.platform',
+      'com.victronenergy.system',
+      'com.victronenergy.dynamicess'
+    ])('%s does not set service.deviceInstance from GetItems data', async (serviceName) => {
+      const service = { name: serviceName, deviceInstance: null }
+      await listener._requestRoot(service)
+      expect(service.deviceInstance).toBeNull()
+    })
+
+    test('non-singleton service.deviceInstance is updated from GetItems data', async () => {
+      const service = { name: 'com.victronenergy.battery', deviceInstance: null }
+      await listener._requestRoot(service)
+      expect(service.deviceInstance).toBe(0)
+    })
   })
 })

--- a/test/victron-nodes.test.js
+++ b/test/victron-nodes.test.js
@@ -283,3 +283,19 @@ describe('victron-nodes pathObj guard', () => {
     expect(publish).not.toHaveBeenCalled()
   })
 })
+
+describe('victron-nodes', () => {
+  it('maps service names, if name is in mappings', () => {
+    const { BaseInputNode } = buildMockRED()
+
+    const oldStyleSystemInputNode = new BaseInputNode({
+      name: 'Test',
+      service: 'com.victronenergy.system/0',
+      path: '/SomePath/Foo',
+      serviceObj: { name: 'SomePath' },
+      pathObj: { name: 'Foo' }
+    })
+    expect(oldStyleSystemInputNode).toBeDefined()
+    expect(oldStyleSystemInputNode.service).toEqual('com.victronenergy.system')
+  })
+})


### PR DESCRIPTION
Services without a device instance (settings, platform, system, dynamicess) were keyed as 'service/0' in the cache, causing duplicate dropdown entries and stale lookups. Switch to the plain service name as the cache key.

Migrates previously stored '/0'-suffixed entries in flows deployed with the old key format.