### PR TITLE
fix(dbus-listener): suppress null values from reaching node subscribers

### DIFF
--- a/src/services/victron-client.js
+++ b/src/services/victron-client.js
@@ -47,6 +47,9 @@ class VictronClient {
     const messageHandler = messages => {
       messages.forEach(msg => {
         _this.saveToCache(msg)
+        // saveToCache converts empty-array D-Bus nulls to null; skip null values here to be
+        // consistent with the PropertiesChanged and ItemsChanged filters in dbus-listener.js
+        if (msg.value === null) return
         const deviceInstanceSuffix = msg.deviceInstance == null ? '' : `/${msg.deviceInstance}`
         const msgKey = `${msg.senderName}${deviceInstanceSuffix}:${msg.path}`
         debug(`[MESSAGE HANDLER] ${msgKey} | ${JSON.stringify(msg, null, 2)}`)

--- a/test/dbus-listener.test.js
+++ b/test/dbus-listener.test.js
@@ -33,4 +33,28 @@ describe('VictronDbusListener', () => {
       expect(listener.services['the-other-owner'].deviceInstance).toBe(null)
     })
   })
+
+  describe('_requestRoot null value handling', () => {
+    it('passes null-valued paths to messageHandler so they are cached for the dropdown', async () => {
+      const capturedMessages = []
+      listener.messageHandler = (msgs) => capturedMessages.push(...msgs)
+      listener.services['the-owner'] = { name: 'com.victronenergy.battery', deviceInstance: 1 }
+      listener.bus = {
+        invoke: jest.fn((_params, callback) => {
+          callback(null, [
+            ['/DeviceInstance', [['Value', ['i', [1]]]]],
+            ['/Soc', [['Value', ['i', [75]]]]],
+            ['/NullPath', [['Value', ['n', [null]]]]]
+          ])
+        })
+      }
+
+      await listener._requestRoot({ name: 'com.victronenergy.battery', deviceInstance: 1 })
+
+      const paths = capturedMessages.map(m => m.path)
+      expect(paths).toContain('/Soc')
+      expect(paths).toContain('/NullPath')
+      expect(capturedMessages.find(m => m.path === '/NullPath').value).toBeNull()
+    })
+  })
 })

--- a/test/victron-client.test.js
+++ b/test/victron-client.test.js
@@ -114,6 +114,16 @@ describe('saveToCache - stale no-trail entry cleanup', () => {
     expect(client.system.cache['com.victronenergy.generator']).toBeDefined()
   })
 
+  it('converts empty-array D-Bus null values to null in cache', () => {
+    client.saveToCache({
+      senderName: 'com.victronenergy.battery',
+      path: '/Relay/0/State',
+      value: [],
+      deviceInstance: 0
+    })
+    expect(client.system.cache['com.victronenergy.battery/0']['/Relay/0/State']).toBeNull()
+  })
+
   it('does not delete anything when no stale entry exists', () => {
     client.saveToCache({
       senderName: 'com.victronenergy.generator',


### PR DESCRIPTION
During service re-initialization (e.g. a solar charger reconnecting at sunrise), _requestRoot sends GetItems results that include paths whose D-Bus value is temporarily null. These nulls bypassed the onlyChanges filter and were emitted as null payloads to flows (issue #346).

Adds a null check in messageHandler after saveToCache runs, so:
- null values are still saved to cache (paths appear in the dropdown as '- (null)', consistent with PropertiesChanged / ItemsChanged)
- subscriber callbacks are skipped for null values

https://github.com/victronenergy/node-red-contrib-victron/issues/346