### PR TITLE
fix(virtual): sanitize node ID for D-Bus paths to support subflows

### DIFF
--- a/src/nodes/victron-virtual-dbus-helpers.js
+++ b/src/nodes/victron-virtual-dbus-helpers.js
@@ -2,6 +2,15 @@ const { addSettings } = require('dbus-victron-virtual')
 const debug = require('debug')('victron-virtual')
 
 /**
+ * Replaces any character that is not alphanumeric or underscore with '_',
+ * producing a string safe for use in D-Bus object path elements and service names.
+ * The original node.id is preserved for filesystem persistence.
+ */
+function sanitizeIdForDbus (id) {
+  return id.replace(/[^A-Za-z0-9_]/g, '_')
+}
+
+/**
  * Parses NODE_RED_DBUS_ADDRESS and returns a tcp: bus address string,
  * or null if not set (caller should fall back to session/system bus).
  */
@@ -125,4 +134,4 @@ function createDebouncedSetters (node, debounce, delayMs) {
   return { shouldApplyImmediately, getDebouncedSetter }
 }
 
-module.exports = { getTcpBusAddress, callAddSettingsWithRetry, getDeviceInstance, registerInputHandler, flushPendingInputs, createDebouncedSetters }
+module.exports = { sanitizeIdForDbus, getTcpBusAddress, callAddSettingsWithRetry, getDeviceInstance, registerInputHandler, flushPendingInputs, createDebouncedSetters }

--- a/src/nodes/victron-virtual-indicator.js
+++ b/src/nodes/victron-virtual-indicator.js
@@ -8,7 +8,7 @@ const { DEBOUNCE_DELAY_MS } = require('./victron-virtual-constants')
 const { validateVirtualDevicePayload, debounce } = require('../services/utils')
 const { createIndicatorProperties, updateIndicatorStatus, expandIndicatorPayload, INDICATOR_INPUT_KEY } = require('../services/virtual-indicator')
 const { filterInactiveVirtualDevices } = require('../services/virtual-device-cleanup')
-const { getTcpBusAddress, callAddSettingsWithRetry, getDeviceInstance, registerInputHandler, flushPendingInputs, createDebouncedSetters } = require('./victron-virtual-dbus-helpers')
+const { sanitizeIdForDbus, getTcpBusAddress, callAddSettingsWithRetry, getDeviceInstance, registerInputHandler, flushPendingInputs, createDebouncedSetters } = require('./victron-virtual-dbus-helpers')
 
 module.exports = function (RED) {
   let hasRunOnce = false
@@ -111,7 +111,8 @@ module.exports = function (RED) {
       // The indicator uses the switch service type: a digital switching device
       // typically has both inputs and outputs; the indicator only uses the input
       // side, but it is the closest available fit on Venus OS.
-      const serviceName = `com.victronenergy.switch.vindic_${self.id}`
+      const dbusId = sanitizeIdForDbus(self.id)
+      const serviceName = `com.victronenergy.switch.vindic_${dbusId}`
       const interfaceName = serviceName
       const objectPath = `/${serviceName.replace(/\./g, '/')}`
 
@@ -166,7 +167,7 @@ module.exports = function (RED) {
         let settingsResult = null
         try {
           settingsResult = await callAddSettingsWithRetry(usedBus, [{
-            path: `/Settings/Devices/vindic_${node.id}/ClassAndVrmInstance`,
+            path: `/Settings/Devices/vindic_${dbusId}/ClassAndVrmInstance`,
             default: 'switch:100',
             type: 's'
           }])

--- a/src/nodes/victron-virtual-switch.js
+++ b/src/nodes/victron-virtual-switch.js
@@ -16,7 +16,7 @@ const debugConnection = require('debug')('victron-virtual-switch:connection')
 const { validateVirtualDevicePayload, validateLightControls } = require('../services/utils')
 const { createSwitchProperties, handleSwitchOutputs, updateSwitchStatus, emitInitialSwitchOutputs, expandSwitchPayload, shouldApplyPayloadToDBus } = require('../services/virtual-switch')
 const { filterInactiveVirtualDevices } = require('../services/virtual-device-cleanup')
-const { getTcpBusAddress, callAddSettingsWithRetry, getDeviceInstance, registerInputHandler, flushPendingInputs } = require('./victron-virtual-dbus-helpers')
+const { sanitizeIdForDbus, getTcpBusAddress, callAddSettingsWithRetry, getDeviceInstance, registerInputHandler, flushPendingInputs } = require('./victron-virtual-dbus-helpers')
 
 module.exports = function (RED) {
   // Shared state across all instances
@@ -151,7 +151,8 @@ module.exports = function (RED) {
         return
       }
 
-      const serviceName = `com.victronenergy.switch.virtual_${self.id}`
+      const dbusId = sanitizeIdForDbus(self.id)
+      const serviceName = `com.victronenergy.switch.virtual_${dbusId}`
       const interfaceName = serviceName
       const objectPath = `/${serviceName.replace(/\./g, '/')}`
 
@@ -229,7 +230,7 @@ module.exports = function (RED) {
         try {
           settingsResult = await callAddSettingsWithRetry(usedBus, [
             {
-              path: `/Settings/Devices/virtual_${node.id}/ClassAndVrmInstance`,
+              path: `/Settings/Devices/virtual_${dbusId}/ClassAndVrmInstance`,
               default: 'switch:100',
               type: 's'
             }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -13,7 +13,7 @@ const { validateVirtualDevicePayload, validateLightControls, debounce } = requir
 const { handleSwitchOutputs } = require('../../services/virtual-switch')
 const { filterInactiveVirtualDevices } = require('../../services/virtual-device-cleanup')
 const { makeSetPresence } = require('./helpers')
-const { registerInputHandler, flushPendingInputs, createDebouncedSetters } = require('../victron-virtual-dbus-helpers')
+const { sanitizeIdForDbus, registerInputHandler, flushPendingInputs, createDebouncedSetters } = require('../victron-virtual-dbus-helpers')
 
 const acloadModule = require('./device-type/acload')
 const batteryModule = require('./device-type/battery')
@@ -395,7 +395,8 @@ module.exports = function (RED) {
       const dbusServiceType = deviceModules[config.device]?.getServiceType?.(config) ?? actualDeviceType
       const onPropertiesChanged = deviceModules[config.device]?.onPropertiesChanged
 
-      const serviceName = `com.victronenergy.${dbusServiceType}.virtual_${self.id}`
+      const dbusId = sanitizeIdForDbus(self.id)
+      const serviceName = `com.victronenergy.${dbusServiceType}.virtual_${dbusId}`
       const interfaceName = serviceName
       const objectPath = `/${serviceName.replace(/\./g, '/')}`
 
@@ -536,7 +537,7 @@ module.exports = function (RED) {
           // First we use addSettings to claim a deviceInstance
           settingsResult = await callAddSettingsWithRetry(usedBus, [
             {
-              path: `/Settings/Devices/virtual_${node.id}/ClassAndVrmInstance`,
+              path: `/Settings/Devices/virtual_${dbusId}/ClassAndVrmInstance`,
               default: `${dbusServiceType}:100`,
               type: 's'
             }
@@ -601,7 +602,7 @@ module.exports = function (RED) {
             const newValue = `${dbusServiceType}:${vrmInstance}`
             const migrationSucceeded = await new Promise(resolve => {
               usedBus.invoke({
-                path: `/Settings/Devices/virtual_${node.id}/ClassAndVrmInstance`,
+                path: `/Settings/Devices/virtual_${dbusId}/ClassAndVrmInstance`,
                 destination: 'com.victronenergy.settings',
                 interface: 'com.victronenergy.BusItem',
                 member: 'SetValue',
@@ -622,7 +623,7 @@ module.exports = function (RED) {
               // the VRM instance if the target class already had a conflict.
               try {
                 const updatedResult = await callAddSettingsWithRetry(usedBus, [{
-                  path: `/Settings/Devices/virtual_${node.id}/ClassAndVrmInstance`,
+                  path: `/Settings/Devices/virtual_${dbusId}/ClassAndVrmInstance`,
                   default: `${actualDeviceType}:${vrmInstance}`,
                   type: 's'
                 }])

--- a/test/victron-virtual-dbus-helpers.test.js
+++ b/test/victron-virtual-dbus-helpers.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+
+const { sanitizeIdForDbus } = require('../src/nodes/victron-virtual-dbus-helpers')
+
+describe('sanitizeIdForDbus', () => {
+  it('leaves purely alphanumeric IDs unchanged', () => {
+    expect(sanitizeIdForDbus('a1b2c3d4e5f6a7b8')).toBe('a1b2c3d4e5f6a7b8')
+  })
+
+  it('leaves underscores unchanged', () => {
+    expect(sanitizeIdForDbus('abc_123')).toBe('abc_123')
+  })
+
+  it('replaces the hyphen introduced by subflow instance ID concatenation', () => {
+    expect(sanitizeIdForDbus('abc12345.56789abc-def67890.12345def')).toBe('abc12345_56789abc_def67890_12345def')
+  })
+
+  it('replaces dots in old-format Node-RED IDs', () => {
+    expect(sanitizeIdForDbus('3f4a9c2d.5e6b78')).toBe('3f4a9c2d_5e6b78')
+  })
+
+  it('handles empty string', () => {
+    expect(sanitizeIdForDbus('')).toBe('')
+  })
+})


### PR DESCRIPTION
Node-RED generates subflow node IDs as `${instanceId}-${templateId}` introducing hyphens (and dots from old-format IDs) that are invalid in D-Bus object path elements. The Venus OS settings daemon rejects `AddSettings` calls for paths like `/Settings/Devices/virtual_abc-def/...`, causing 'Virtual switch setup failed' for any node placed in a subflow.

Replace any non-alphanumeric character with `_` before building the D-Bus service name and settings path. Persistence file names keep the original node ID since the filesystem accepts those characters.

Applies to victron-virtual, victron-virtual-switch, and victron-virtual-indicator nodes.

Closes https://github.com/victronenergy/node-red-contrib-victron/issues/525