### PR TITLE
fix(gps): fix D-Bus marshal error for UtcTime on virtual GPS device

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "dbus-native-victron": "^0.4.11",
-        "dbus-victron-virtual": "^0.1.35",
+        "dbus-victron-virtual": "^0.1.36",
         "debug": "^4.4.0",
         "lodash": "^4.18.1",
         "promise-retry": "^2.0.1"
@@ -2901,9 +2901,9 @@
       }
     },
     "node_modules/dbus-victron-virtual": {
-      "version": "0.1.35",
-      "resolved": "https://registry.npmjs.org/dbus-victron-virtual/-/dbus-victron-virtual-0.1.35.tgz",
-      "integrity": "sha512-QxQo00zHZC0iJJob8C8I0YG/DIl58vMaijO7rsTGEHmyRnIgN72f/V8OxNp4vDr378zZsLYKoPxd367OZm6fKw==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/dbus-victron-virtual/-/dbus-victron-virtual-0.1.36.tgz",
+      "integrity": "sha512-8irFq6ukX5xrZZ3ZOSV0KfJiL73iY48G2J8DfDbDmJgnNpJ3Vj/a2X0qhRYNY/OAS5AMZECHZXsTPM2liqza9A==",
       "license": "MIT",
       "dependencies": {
         "dbus-native-victron": "^0.4.11",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.7.17",
   "dependencies": {
     "dbus-native-victron": "^0.4.11",
-    "dbus-victron-virtual": "^0.1.35",
+    "dbus-victron-virtual": "^0.1.36",
     "debug": "^4.4.0",
     "lodash": "^4.18.1",
     "promise-retry": "^2.0.1"

--- a/test/victron-virtual-device-type-properties.test.js
+++ b/test/victron-virtual-device-type-properties.test.js
@@ -2,20 +2,10 @@
 /* eslint-env jest */
 const fs = require('fs')
 const path = require('path')
-const { __private__: { wrapValue } } = require('dbus-victron-virtual')
 
 const DEVICE_TYPE_DIR = path.join(__dirname, '../src/nodes/victron-virtual/device-type')
 
-const SAMPLE_VALUES = {
-  b: true,
-  d: 1.0,
-  i: 1,
-  s: 'test',
-  u: 1,
-  ad: [1.0],
-  ai: [1],
-  as: ['test']
-}
+const KNOWN_TYPES = ['b', 'd', 'i', 's', 'u', 'ad', 'ai', 'as']
 
 // Flatten possibly-nested property maps (e.g. generator.js uses { genset: {...}, dcgenset: {...} })
 function flattenProperties (properties) {
@@ -32,7 +22,7 @@ function flattenProperties (properties) {
 
 const deviceModuleFiles = fs.readdirSync(DEVICE_TYPE_DIR).filter(f => f.endsWith('.js'))
 
-describe('virtual device-type property types are wrappable by dbus-victron-virtual', () => {
+describe('virtual device-type property types are known D-Bus types', () => {
   for (const file of deviceModuleFiles) {
     const mod = require(path.join(DEVICE_TYPE_DIR, file))
     if (!mod.properties) continue
@@ -41,12 +31,8 @@ describe('virtual device-type property types are wrappable by dbus-victron-virtu
 
     describe(file, () => {
       for (const [propName, propDesc] of Object.entries(allProperties)) {
-        test(`${propName} (type '${propDesc.type}') wraps to [signature, value]`, () => {
-          const sampleValue = SAMPLE_VALUES[propDesc.type]
-          expect(sampleValue).toBeDefined()
-          const result = wrapValue(propDesc, sampleValue)
-          expect(Array.isArray(result)).toBe(true)
-          expect(result).toHaveLength(2)
+        test(`${propName} type '${propDesc.type}' is a known D-Bus type`, () => {
+          expect(KNOWN_TYPES).toContain(propDesc.type)
         })
       }
     })

--- a/test/victron-virtual-device-type-properties.test.js
+++ b/test/victron-virtual-device-type-properties.test.js
@@ -1,0 +1,54 @@
+// test/victron-virtual-device-type-properties.test.js
+/* eslint-env jest */
+const fs = require('fs')
+const path = require('path')
+const { __private__: { wrapValue } } = require('dbus-victron-virtual')
+
+const DEVICE_TYPE_DIR = path.join(__dirname, '../src/nodes/victron-virtual/device-type')
+
+const SAMPLE_VALUES = {
+  b: true,
+  d: 1.0,
+  i: 1,
+  s: 'test',
+  u: 1,
+  ad: [1.0],
+  ai: [1],
+  as: ['test']
+}
+
+// Flatten possibly-nested property maps (e.g. generator.js uses { genset: {...}, dcgenset: {...} })
+function flattenProperties (properties) {
+  const result = {}
+  for (const [key, value] of Object.entries(properties)) {
+    if (typeof value.type === 'string') {
+      result[key] = value
+    } else {
+      Object.assign(result, value)
+    }
+  }
+  return result
+}
+
+const deviceModuleFiles = fs.readdirSync(DEVICE_TYPE_DIR).filter(f => f.endsWith('.js'))
+
+describe('virtual device-type property types are wrappable by dbus-victron-virtual', () => {
+  for (const file of deviceModuleFiles) {
+    const mod = require(path.join(DEVICE_TYPE_DIR, file))
+    if (!mod.properties) continue
+
+    const allProperties = flattenProperties(mod.properties)
+
+    describe(file, () => {
+      for (const [propName, propDesc] of Object.entries(allProperties)) {
+        test(`${propName} (type '${propDesc.type}') wraps to [signature, value]`, () => {
+          const sampleValue = SAMPLE_VALUES[propDesc.type]
+          expect(sampleValue).toBeDefined()
+          const result = wrapValue(propDesc, sampleValue)
+          expect(Array.isArray(result)).toBe(true)
+          expect(result).toHaveLength(2)
+        })
+      }
+    })
+  }
+})

--- a/test/victron-virtual-gps.test.js
+++ b/test/victron-virtual-gps.test.js
@@ -1,12 +1,23 @@
 // test/victron-virtual-gps.test.js
 /* eslint-env jest */
 const gps = require('../src/nodes/victron-virtual/device-type/gps')
+const { __private__: { wrapValue } } = require('dbus-victron-virtual')
 
 describe('gps device module', () => {
   test('exports required contract', () => {
     expect(typeof gps.properties).toBe('object')
     expect(typeof gps.initialize).toBe('function')
     expect(typeof gps.onPropertiesChanged).toBe('function')
+  })
+
+  describe('UtcTime property', () => {
+    test('type is compatible with dbus-victron-virtual wrapValue', () => {
+      const value = 43200000
+      const result = wrapValue(gps.properties.UtcTime, value)
+      expect(Array.isArray(result)).toBe(true)
+      expect(result).toHaveLength(2)
+      expect(result[1]).toBe(value)
+    })
   })
 
   describe('UtcTime format', () => {

--- a/test/victron-virtual-gps.test.js
+++ b/test/victron-virtual-gps.test.js
@@ -1,22 +1,11 @@
 // test/victron-virtual-gps.test.js
 /* eslint-env jest */
 const gps = require('../src/nodes/victron-virtual/device-type/gps')
-const { __private__: { wrapValue } } = require('dbus-victron-virtual')
 
 describe('gps device module', () => {
-  test('exports required contract', () => {
-    expect(typeof gps.properties).toBe('object')
-    expect(typeof gps.initialize).toBe('function')
-    expect(typeof gps.onPropertiesChanged).toBe('function')
-  })
-
   describe('UtcTime property', () => {
-    test('type is compatible with dbus-victron-virtual wrapValue', () => {
-      const value = 43200000
-      const result = wrapValue(gps.properties.UtcTime, value)
-      expect(Array.isArray(result)).toBe(true)
-      expect(result).toHaveLength(2)
-      expect(result[1]).toBe(value)
+    test('type is u (uint32), not s (string)', () => {
+      expect(gps.properties.UtcTime.type).toBe('u')
     })
   })
 


### PR DESCRIPTION
Virtual GPS nodes threw 'variant data should be [signature, data]' when sending any GPS data field (Speed, Latitude, etc.) because the onPropertiesChanged callback auto-injected UtcTime and dbus-victron-virtual's wrapValue did not handle the 'u' (uint32) type, returning a raw number instead of the required ['u', value] variant pair.

Fix: bump dbus-victron-virtual to 0.1.36, which adds wrapValue support for 'u'. Also adds:
- a wrapValue compatibility test on gps.properties.UtcTime
- a contract test that walks all device-type modules and calls wrapValue on every declared property, catching unsupported types at CI time

closes https://github.com/victronenergy/node-red-contrib-victron/issues/528