### PR TITLE
feat(s2): set S2/0/Active and S2/0/Rm on CEM connect/disconnect

### DIFF
--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -89,6 +89,7 @@ function initialize (config, ifaceDesc, iface, node) {
       Connect: function (cemId, timeout) {
         node._s2PowerMeasurementActive = false
         node._s2PowerMeasurementCemId = null
+        node.setValuesLocally({ 'S2/0/Active': 1, 'S2/0/Rm': cemId })
         console.log('Connect received for CEM ID:', cemId, 'timeout', timeout)
         node.send([
           null,
@@ -104,6 +105,7 @@ function initialize (config, ifaceDesc, iface, node) {
       Disconnect: function (cemId) {
         node._s2PowerMeasurementActive = false
         node._s2PowerMeasurementCemId = null
+        node.setValuesLocally({ 'S2/0/Active': 0, 'S2/0/Rm': '' })
         node.send([
           null,
           {

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -89,7 +89,7 @@ function initialize (config, ifaceDesc, iface, node) {
       Connect: function (cemId, timeout) {
         node._s2PowerMeasurementActive = false
         node._s2PowerMeasurementCemId = null
-        node.setValuesLocally({ 'S2/0/Active': 1, 'S2/0/Rm': cemId })
+        node.setValuesLocally({ 'S2/0/Active': 1, 'S2/0/Rm': 'CEM: ' + cemId })
         console.log('Connect received for CEM ID:', cemId, 'timeout', timeout)
         node.send([
           null,

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -141,7 +141,7 @@ describe('acload', () => {
       ifaceDesc.__s2Handlers.Connect('cem-1', 30)
       expect(node._s2PowerMeasurementActive).toBe(false)
       expect(node._s2PowerMeasurementCemId).toBeNull()
-      expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Active': 1, 'S2/0/Rm': 'cem-1' })
+      expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Active': 1, 'S2/0/Rm': 'CEM: cem-1' })
       expect(node.send).toHaveBeenCalledWith([null, {
         payload: { command: 'Connect', cemId: 'cem-1', keepAliveInterval: 30 }
       }])

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -131,29 +131,33 @@ describe('acload', () => {
       expect(ifaceDesc.__s2Handlers).toBeUndefined()
     })
 
-    test('Connect handler resets power measurement state and sends command on port 2', () => {
+    test('Connect handler resets power measurement state, updates S2 active/rm, and sends command on port 2', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       node.send = jest.fn()
+      node.setValuesLocally = jest.fn()
       node._s2PowerMeasurementActive = true
       node._s2PowerMeasurementCemId = 'old-cem'
       acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
       ifaceDesc.__s2Handlers.Connect('cem-1', 30)
       expect(node._s2PowerMeasurementActive).toBe(false)
       expect(node._s2PowerMeasurementCemId).toBeNull()
+      expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Active': 1, 'S2/0/Rm': 'cem-1' })
       expect(node.send).toHaveBeenCalledWith([null, {
         payload: { command: 'Connect', cemId: 'cem-1', keepAliveInterval: 30 }
       }])
     })
 
-    test('Disconnect handler resets power measurement state and sends command on port 2', () => {
+    test('Disconnect handler resets power measurement state, clears S2 active/rm, and sends command on port 2', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       node.send = jest.fn()
+      node.setValuesLocally = jest.fn()
       node._s2PowerMeasurementActive = true
       node._s2PowerMeasurementCemId = 'cem-1'
       acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
       ifaceDesc.__s2Handlers.Disconnect('cem-1')
       expect(node._s2PowerMeasurementActive).toBe(false)
       expect(node._s2PowerMeasurementCemId).toBeNull()
+      expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Active': 0, 'S2/0/Rm': '' })
       expect(node.send).toHaveBeenCalledWith([null, {
         payload: { command: 'Disconnect', cemId: 'cem-1' }
       }])


### PR DESCRIPTION
Virtual ACLoad already exposed these D-Bus properties but never updated them. On CEM connect, set `Active=1` and `Rm=<cemId>`; on disconnect reset both to their defaults. Aligns behaviour with dbus-shelly and dbus-mqttintegration which report the same paths.