### PR TITLE
feat(acload): auto-calculate Ac/Energy/Forward from power

### DIFF
--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -11,6 +11,7 @@
             default_values: {value: true, required: false},
             // acload
             acload_nrofphases: {value: 1, required: false},
+            acload_auto_energy: {value: true, required: false},
             enable_s2support: {value: false, required: false},
             s2_measurement_type: {value: '3_PHASE_SYMMETRIC', required: false},
             // battery
@@ -250,6 +251,12 @@
                 <option value="2">Split phase</option>
                 <option value="3">3 phase</option>
             </select>
+        </div>
+        <div class="form-row input-acload victron-checkbox" class="hidden-row">
+            <input type="checkbox" id="node-input-acload_auto_energy">
+            <label for="node-input-acload_auto_energy">Auto-calculate energy (Ac/Energy/Forward)
+                <i class="fa fa-info-circle tooltip-icon" data-tooltip="Integrates power over time to estimate energy. Precision improves with higher update frequency."></i>
+            </label>
         </div>
         <div class="form-row input-acload victron-checkbox" class="hidden-row">
             <input type="checkbox" id="node-input-enable_s2support" class="s2-checkbox">

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -160,7 +160,7 @@ function onPropertiesChanged ({ changes, instance, config }) {
     const energyKey = `Ac/L${i}/Energy/Forward`
     const tsKey = `_lastL${i}PowerTimestamp`
     if (powerKey in changes) {
-      accumulateDelta(changes, instance, energyKey, instance[powerKey], instance[tsKey], now)
+      accumulateDelta({ changes, instance, energyKey, oldPower: instance[powerKey], lastTs: instance[tsKey], now })
       instance[tsKey] = now
       anyPhaseUpdated = true
     }
@@ -173,7 +173,7 @@ function onPropertiesChanged ({ changes, instance, config }) {
 
   if ('Ac/Power' in changes) {
     if (!anyPhaseUpdated) {
-      accumulateDelta(changes, instance, 'Ac/Energy/Forward', instance['Ac/Power'], instance._lastPowerTimestamp, now)
+      accumulateDelta({ changes, instance, energyKey: 'Ac/Energy/Forward', oldPower: instance['Ac/Power'], lastTs: instance._lastPowerTimestamp, now })
     }
     // Always update; prevents stale-delta spike when switching from per-phase to total-power reporting.
     instance._lastPowerTimestamp = now

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -1,3 +1,4 @@
+const { accumulateDelta } = require('../energy-utils')
 const ENERGY_PERSIST_SECONDS = 60
 
 const properties = {
@@ -146,4 +147,39 @@ function initialize (config, ifaceDesc, iface, node) {
   return `Virtual ${iface.NrOfPhases}-phase AC load`
 }
 
-module.exports = { properties, initialize, label: 'AC Load' }
+function onPropertiesChanged ({ changes, instance, config }) {
+  if (!config.acload_auto_energy) return changes
+
+  const now = Date.now()
+  const nrOfPhases = Number(config.acload_nrofphases ?? 1)
+  let anyPhaseUpdated = false
+  let phaseTotal = 0
+
+  for (let i = 1; i <= nrOfPhases; i++) {
+    const powerKey = `Ac/L${i}/Power`
+    const energyKey = `Ac/L${i}/Energy/Forward`
+    const tsKey = `_lastL${i}PowerTimestamp`
+    if (powerKey in changes) {
+      accumulateDelta(changes, instance, energyKey, instance[powerKey], instance[tsKey], now)
+      instance[tsKey] = now
+      anyPhaseUpdated = true
+    }
+    phaseTotal += energyKey in changes ? changes[energyKey] : (instance[energyKey] || 0)
+  }
+
+  if (anyPhaseUpdated && !('Ac/Energy/Forward' in changes)) {
+    changes['Ac/Energy/Forward'] = phaseTotal
+  }
+
+  if ('Ac/Power' in changes) {
+    if (!anyPhaseUpdated) {
+      accumulateDelta(changes, instance, 'Ac/Energy/Forward', instance['Ac/Power'], instance._lastPowerTimestamp, now)
+    }
+    // Always update; prevents stale-delta spike when switching from per-phase to total-power reporting.
+    instance._lastPowerTimestamp = now
+  }
+
+  return changes
+}
+
+module.exports = { properties, initialize, onPropertiesChanged, label: 'AC Load' }

--- a/src/nodes/victron-virtual/device-type/pvinverter.js
+++ b/src/nodes/victron-virtual/device-type/pvinverter.js
@@ -93,7 +93,7 @@ function onPropertiesChanged ({ changes, instance, config }) {
     const energyKey = `Ac/L${i}/Energy/Forward`
     const tsKey = `_lastL${i}PowerTimestamp`
     if (powerKey in changes) {
-      accumulateDelta(changes, instance, energyKey, instance[powerKey], instance[tsKey], now)
+      accumulateDelta({ changes, instance, energyKey, oldPower: instance[powerKey], lastTs: instance[tsKey], now })
       instance[tsKey] = now
       anyPhaseUpdated = true
     }
@@ -106,7 +106,7 @@ function onPropertiesChanged ({ changes, instance, config }) {
 
   if ('Ac/Power' in changes) {
     if (!anyPhaseUpdated) {
-      accumulateDelta(changes, instance, 'Ac/Energy/Forward', instance['Ac/Power'], instance._lastPowerTimestamp, now)
+      accumulateDelta({ changes, instance, energyKey: 'Ac/Energy/Forward', oldPower: instance['Ac/Power'], lastTs: instance._lastPowerTimestamp, now })
     }
     // Always update; prevents stale-delta spike when switching from per-phase to total-power reporting.
     instance._lastPowerTimestamp = now

--- a/src/nodes/victron-virtual/device-type/pvinverter.js
+++ b/src/nodes/victron-virtual/device-type/pvinverter.js
@@ -1,4 +1,4 @@
-const WATT_MILLISECONDS_PER_KWH = 3_600_000_000
+const { accumulateDelta } = require('../energy-utils')
 const ENERGY_PERSIST_SECONDS = 60
 
 const properties = {
@@ -78,15 +78,6 @@ function initialize (config, ifaceDesc, iface, node) {
     iface.StatusCode = 0
   }
   return `Virtual ${iface.NrOfPhases}-phase pvinverter`
-}
-
-function accumulateDelta (changes, instance, energyKey, oldPower, lastTs, now) {
-  if (lastTs != null && oldPower != null && !(energyKey in changes)) {
-    const deltaKwh = Math.max(0, oldPower) * (now - lastTs) / WATT_MILLISECONDS_PER_KWH
-    if (deltaKwh > 0) {
-      changes[energyKey] = (instance[energyKey] || 0) + deltaKwh
-    }
-  }
 }
 
 function onPropertiesChanged ({ changes, instance, config }) {

--- a/src/nodes/victron-virtual/energy-utils.js
+++ b/src/nodes/victron-virtual/energy-utils.js
@@ -1,6 +1,6 @@
 const WATT_MILLISECONDS_PER_KWH = 3_600_000_000
 
-function accumulateDelta (changes, instance, energyKey, oldPower, lastTs, now) {
+function accumulateDelta ({ changes, instance, energyKey, oldPower, lastTs, now }) {
   if (lastTs != null && oldPower != null && !(energyKey in changes)) {
     const deltaKwh = Math.max(0, oldPower) * (now - lastTs) / WATT_MILLISECONDS_PER_KWH
     if (deltaKwh > 0) {

--- a/src/nodes/victron-virtual/energy-utils.js
+++ b/src/nodes/victron-virtual/energy-utils.js
@@ -1,0 +1,12 @@
+const WATT_MILLISECONDS_PER_KWH = 3_600_000_000
+
+function accumulateDelta (changes, instance, energyKey, oldPower, lastTs, now) {
+  if (lastTs != null && oldPower != null && !(energyKey in changes)) {
+    const deltaKwh = Math.max(0, oldPower) * (now - lastTs) / WATT_MILLISECONDS_PER_KWH
+    if (deltaKwh > 0) {
+      changes[energyKey] = (instance[energyKey] || 0) + deltaKwh
+    }
+  }
+}
+
+module.exports = { WATT_MILLISECONDS_PER_KWH, accumulateDelta }

--- a/test/energy-utils.test.js
+++ b/test/energy-utils.test.js
@@ -1,0 +1,103 @@
+// test/energy-utils.test.js
+/* eslint-env jest */
+const { accumulateDelta } = require('../src/nodes/victron-virtual/energy-utils')
+
+describe('accumulateDelta', () => {
+  test('accumulates energy for a given power over time', () => {
+    const changes = {}
+    const instance = { 'Ac/Energy/Forward': 0 }
+    accumulateDelta({
+      changes,
+      instance,
+      energyKey: 'Ac/Energy/Forward',
+      oldPower: 1000,
+      lastTs: Date.now() - 3_600_000,
+      now: Date.now()
+    })
+    expect(changes['Ac/Energy/Forward']).toBeCloseTo(1.0, 2)
+  })
+
+  test('adds delta to existing accumulated energy', () => {
+    const changes = {}
+    const instance = { 'Ac/Energy/Forward': 5.0 }
+    accumulateDelta({
+      changes,
+      instance,
+      energyKey: 'Ac/Energy/Forward',
+      oldPower: 2000,
+      lastTs: Date.now() - 1_800_000,
+      now: Date.now()
+    })
+    expect(changes['Ac/Energy/Forward']).toBeCloseTo(6.0, 2)
+  })
+
+  test('skips when lastTs is null', () => {
+    const changes = {}
+    const instance = { 'Ac/Energy/Forward': 0 }
+    accumulateDelta({
+      changes,
+      instance,
+      energyKey: 'Ac/Energy/Forward',
+      oldPower: 1000,
+      lastTs: null,
+      now: Date.now()
+    })
+    expect(changes['Ac/Energy/Forward']).toBeUndefined()
+  })
+
+  test('skips when oldPower is null', () => {
+    const changes = {}
+    const instance = { 'Ac/Energy/Forward': 0 }
+    accumulateDelta({
+      changes,
+      instance,
+      energyKey: 'Ac/Energy/Forward',
+      oldPower: null,
+      lastTs: Date.now() - 3_600_000,
+      now: Date.now()
+    })
+    expect(changes['Ac/Energy/Forward']).toBeUndefined()
+  })
+
+  test('does not write to changes when power is zero', () => {
+    const changes = {}
+    const instance = { 'Ac/Energy/Forward': 2.0 }
+    accumulateDelta({
+      changes,
+      instance,
+      energyKey: 'Ac/Energy/Forward',
+      oldPower: 0,
+      lastTs: Date.now() - 3_600_000,
+      now: Date.now()
+    })
+    expect(changes['Ac/Energy/Forward']).toBeUndefined()
+  })
+
+  test('clamps negative power to zero', () => {
+    const changes = {}
+    const instance = { 'Ac/Energy/Forward': 2.0 }
+    accumulateDelta({
+      changes,
+      instance,
+      energyKey: 'Ac/Energy/Forward',
+      oldPower: -100,
+      lastTs: Date.now() - 3_600_000,
+      now: Date.now()
+    })
+    expect(changes['Ac/Energy/Forward']).toBeUndefined()
+  })
+
+  test('does not overwrite energyKey already present in changes', () => {
+    const changes = { 'Ac/Energy/Forward': 99 }
+    const instance = { 'Ac/Energy/Forward': 0 }
+    accumulateDelta({
+      changes,
+      instance,
+      energyKey: 'Ac/Energy/Forward',
+      oldPower: 1000,
+      lastTs: Date.now() - 3_600_000,
+      now: Date.now()
+    })
+    expect(changes['Ac/Energy/Forward']).toBe(99)
+  })
+})

--- a/test/victron-virtual-acload.test.js
+++ b/test/victron-virtual-acload.test.js
@@ -56,68 +56,6 @@ describe('acload device module', () => {
       expect(instance._lastPowerTimestamp).toBeGreaterThanOrEqual(before)
     })
 
-    test('accumulates energy on second power reading', () => {
-      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
-      instance._lastPowerTimestamp = Date.now() - 3_600_000 // 1 hour ago
-
-      const result = acload.onPropertiesChanged({
-        changes: { 'Ac/Power': 1000 },
-        instance,
-        config: { acload_auto_energy: true, acload_nrofphases: 1 }
-      })
-      // 1000 W for 1 hour = 1 kWh
-      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.0, 2)
-    })
-
-    test('adds delta to existing accumulated energy', () => {
-      const instance = { 'Ac/Power': 2000, 'Ac/Energy/Forward': 5.0 }
-      instance._lastPowerTimestamp = Date.now() - 1_800_000 // 30 minutes
-
-      const result = acload.onPropertiesChanged({
-        changes: { 'Ac/Power': 2000 },
-        instance,
-        config: { acload_auto_energy: true, acload_nrofphases: 1 }
-      })
-      // 2000 W for 0.5 h = 1 kWh; prior = 5.0; total ~= 6.0
-      expect(result['Ac/Energy/Forward']).toBeCloseTo(6.0, 2)
-    })
-
-    test('skips energy injection when power is zero', () => {
-      const instance = { 'Ac/Power': 0, 'Ac/Energy/Forward': 2.0 }
-      instance._lastPowerTimestamp = Date.now() - 3_600_000
-
-      const result = acload.onPropertiesChanged({
-        changes: { 'Ac/Power': 0 },
-        instance,
-        config: { acload_auto_energy: true, acload_nrofphases: 1 }
-      })
-      expect(result['Ac/Energy/Forward']).toBeUndefined()
-    })
-
-    test('clamps negative power to zero (no energy delta)', () => {
-      const instance = { 'Ac/Power': -100, 'Ac/Energy/Forward': 2.0 }
-      instance._lastPowerTimestamp = Date.now() - 3_600_000
-
-      const result = acload.onPropertiesChanged({
-        changes: { 'Ac/Power': -100 },
-        instance,
-        config: { acload_auto_energy: true, acload_nrofphases: 1 }
-      })
-      expect(result['Ac/Energy/Forward']).toBeUndefined()
-    })
-
-    test('skips energy injection when old power is null', () => {
-      const instance = { 'Ac/Power': null, 'Ac/Energy/Forward': 0 }
-      instance._lastPowerTimestamp = Date.now() - 3_600_000
-
-      const result = acload.onPropertiesChanged({
-        changes: { 'Ac/Power': 500 },
-        instance,
-        config: { acload_auto_energy: true, acload_nrofphases: 1 }
-      })
-      expect(result['Ac/Energy/Forward']).toBeUndefined()
-    })
-
     test('does not overwrite user-provided Ac/Energy/Forward in same payload', () => {
       const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
       instance._lastPowerTimestamp = Date.now() - 3_600_000

--- a/test/victron-virtual-acload.test.js
+++ b/test/victron-virtual-acload.test.js
@@ -1,0 +1,296 @@
+// test/victron-virtual-acload.test.js
+/* eslint-env jest */
+const acload = require('../src/nodes/victron-virtual/device-type/acload')
+
+describe('acload device module', () => {
+  test('exports required contract', () => {
+    expect(typeof acload.properties).toBe('object')
+    expect(typeof acload.initialize).toBe('function')
+    expect(typeof acload.onPropertiesChanged).toBe('function')
+  })
+
+  describe('onPropertiesChanged - auto_energy disabled', () => {
+    test('returns changes unmodified when acload_auto_energy is false', () => {
+      const instance = { 'Ac/Power': 500 }
+      const changes = { 'Ac/Power': 600 }
+      const result = acload.onPropertiesChanged({
+        changes,
+        instance,
+        config: { acload_auto_energy: false, acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+      expect(result['Ac/Power']).toBe(600)
+    })
+
+    test('does not set timestamp on instance when disabled', () => {
+      const instance = { 'Ac/Power': 500 }
+      acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 600 },
+        instance,
+        config: { acload_auto_energy: false, acload_nrofphases: 1 }
+      })
+      expect(instance._lastPowerTimestamp).toBeUndefined()
+    })
+
+    test('treats undefined acload_auto_energy as disabled (migration from older flows)', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+  })
+
+  describe('onPropertiesChanged - auto_energy enabled', () => {
+    test('sets timestamp on first power reading, does not inject energy', () => {
+      const instance = { 'Ac/Power': null }
+      const before = Date.now()
+      acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(instance._lastPowerTimestamp).toBeGreaterThanOrEqual(before)
+    })
+
+    test('accumulates energy on second power reading', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000 // 1 hour ago
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      // 1000 W for 1 hour = 1 kWh
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.0, 2)
+    })
+
+    test('adds delta to existing accumulated energy', () => {
+      const instance = { 'Ac/Power': 2000, 'Ac/Energy/Forward': 5.0 }
+      instance._lastPowerTimestamp = Date.now() - 1_800_000 // 30 minutes
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 2000 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      // 2000 W for 0.5 h = 1 kWh; prior = 5.0; total ~= 6.0
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(6.0, 2)
+    })
+
+    test('skips energy injection when power is zero', () => {
+      const instance = { 'Ac/Power': 0, 'Ac/Energy/Forward': 2.0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 0 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+
+    test('clamps negative power to zero (no energy delta)', () => {
+      const instance = { 'Ac/Power': -100, 'Ac/Energy/Forward': 2.0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': -100 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+
+    test('skips energy injection when old power is null', () => {
+      const instance = { 'Ac/Power': null, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 500 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+
+    test('does not overwrite user-provided Ac/Energy/Forward in same payload', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000, 'Ac/Energy/Forward': 99 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBe(99)
+    })
+
+    test('updates timestamp on every power change', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const before = Date.now()
+      acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(instance._lastPowerTimestamp).toBeGreaterThanOrEqual(before)
+    })
+  })
+
+  describe('onPropertiesChanged - per-phase energy', () => {
+    test('accumulates per-phase energy for L1 on second reading', () => {
+      const instance = { 'Ac/L1/Power': 500, 'Ac/L1/Energy/Forward': 0 }
+      instance._lastL1PowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/L1/Power': 500 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      // 500 W for 1 h = 0.5 kWh
+      expect(result['Ac/L1/Energy/Forward']).toBeCloseTo(0.5, 2)
+    })
+
+    test('sets Ac/Energy/Forward as sum of all phase energies', () => {
+      const instance = {
+        'Ac/L1/Power': 300,
+        'Ac/L2/Power': 600,
+        'Ac/L3/Power': 900,
+        'Ac/L1/Energy/Forward': 0,
+        'Ac/L2/Energy/Forward': 0,
+        'Ac/L3/Energy/Forward': 0
+      }
+      const oneHourAgo = Date.now() - 3_600_000
+      instance._lastL1PowerTimestamp = oneHourAgo
+      instance._lastL2PowerTimestamp = oneHourAgo
+      instance._lastL3PowerTimestamp = oneHourAgo
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/L1/Power': 300, 'Ac/L2/Power': 600, 'Ac/L3/Power': 900 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 3 }
+      })
+      expect(result['Ac/L1/Energy/Forward']).toBeCloseTo(0.3, 2)
+      expect(result['Ac/L2/Energy/Forward']).toBeCloseTo(0.6, 2)
+      expect(result['Ac/L3/Energy/Forward']).toBeCloseTo(0.9, 2)
+      // Total = 0.3 + 0.6 + 0.9 = 1.8 kWh
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.8, 2)
+    })
+
+    test('includes existing phase energy from instance when only some phases are updated', () => {
+      const instance = {
+        'Ac/L1/Power': 300,
+        'Ac/L1/Energy/Forward': 1.0,
+        'Ac/L2/Energy/Forward': 2.0,
+        'Ac/L3/Energy/Forward': 3.0
+      }
+      instance._lastL1PowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/L1/Power': 300 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 3 }
+      })
+      // L1 adds 0.3 kWh to existing 1.0 = 1.3; L2 and L3 unchanged at 2.0 and 3.0
+      expect(result['Ac/L1/Energy/Forward']).toBeCloseTo(1.3, 2)
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.3 + 2.0 + 3.0, 2)
+    })
+
+    test('does not accumulate phase energy beyond configured nrOfPhases', () => {
+      const instance = { 'Ac/L3/Power': 500 }
+      instance._lastL3PowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/L3/Power': 500 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      // 1-phase config - L3 should not be touched
+      expect(result['Ac/L3/Energy/Forward']).toBeUndefined()
+    })
+
+    test('does not overwrite user-provided Ac/Energy/Forward even when phases update', () => {
+      const instance = {
+        'Ac/L1/Power': 1000,
+        'Ac/L1/Energy/Forward': 0
+      }
+      instance._lastL1PowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/L1/Power': 1000, 'Ac/Energy/Forward': 99 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBe(99)
+    })
+  })
+
+  describe('onPropertiesChanged - Ac/Power fallback (no per-phase data)', () => {
+    test('uses Ac/Power when no phase powers are in changes', () => {
+      const instance = { 'Ac/Power': 1000, 'Ac/Energy/Forward': 0 }
+      instance._lastPowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.0, 2)
+    })
+
+    test('does not use Ac/Power fallback when phase powers are also in changes', () => {
+      const instance = {
+        'Ac/Power': 1000,
+        'Ac/L1/Power': 1000,
+        'Ac/Energy/Forward': 0,
+        'Ac/L1/Energy/Forward': 0
+      }
+      const oneHourAgo = Date.now() - 3_600_000
+      instance._lastPowerTimestamp = oneHourAgo
+      instance._lastL1PowerTimestamp = oneHourAgo
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 1000, 'Ac/L1/Power': 1000 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      // Energy comes from L1 phase sum (1.0 kWh), not double-counted from Ac/Power
+      expect(result['Ac/Energy/Forward']).toBeCloseTo(1.0, 2)
+    })
+
+    test('updates _lastPowerTimestamp even when per-phase data drives the update', () => {
+      const instance = {
+        'Ac/Power': 500,
+        'Ac/L1/Power': 500,
+        'Ac/Energy/Forward': 0,
+        'Ac/L1/Energy/Forward': 0
+      }
+      const tenHoursAgo = Date.now() - 36_000_000
+      instance._lastPowerTimestamp = tenHoursAgo
+      instance._lastL1PowerTimestamp = Date.now() - 3_600_000
+
+      acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 500, 'Ac/L1/Power': 500 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+
+      expect(instance._lastPowerTimestamp).toBeGreaterThan(tenHoursAgo)
+
+      // Now send Ac/Power only - must NOT produce a huge delta
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/Power': 500 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward'] ?? 0).toBeCloseTo(0, 3)
+    })
+  })
+})


### PR DESCRIPTION
Mirrors the pvinverter auto-energy feature for the virtual AC load. When enabled, integrates power over time (per-phase or total Ac/Power fallback) to accumulate Ac/Energy/Forward. Absent field treats as disabled for safe migration of existing flows.

Extracts accumulateDelta and WATT_MILLISECONDS_PER_KWH into a shared energy-utils.js module to avoid duplication between pvinverter and acload.