### PR TITLE
feat(virtual): generalize S2 protocol support beyond acload

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1784,6 +1784,28 @@
 	    })
 	}
 
+	let deviceCapabilitiesCache = {};
+
+	/**
+	 * Cache device-type capability metadata (e.g. { value, label, supportsS2 }) fetched from
+	 * GET /victron/virtual-device-types, keyed by device value. Lets editor logic (output count,
+	 * output labels, S2 section visibility) generalize to any device-type module without
+	 * hardcoding device names.
+	 */
+	function setDeviceCapabilities (list) {
+	  deviceCapabilitiesCache = {}
+	  ;(list || []).forEach(dt => { deviceCapabilitiesCache[dt.value] = dt; });
+	}
+
+	function getDeviceCapabilities () {
+	  return deviceCapabilitiesCache
+	}
+
+	function fetchDeviceCapabilities (baseUrl) {
+	  return fetch((baseUrl || '') + '/victron/virtual-device-types')
+	    .then(response => response.json())
+	}
+
 	function fetchSwitchNodeNameAndGroupFromCache (id) {
 	  if (!id) {
 	    return Promise.reject(new Error('id is required'))
@@ -1831,7 +1853,7 @@
 	  $('#battery-voltage-custom-label').toggle(preset === 'custom');
 	}
 
-	function checkSelectedVirtualDevice (context) {
+	function checkSelectedVirtualDevice (context, deviceCapabilities = getDeviceCapabilities()) {
 	  [
 	    'acload', 'battery', 'ev', 'generator', 'gps', 'grid', 'e-drive',
 	    'pvinverter', 'switch', 'tank', 'temperature', 'energymeter', 'pulsemeter'
@@ -1840,17 +1862,21 @@
 	  const selected = $('select#node-input-device').val();
 	  $('.input-' + selected).show();
 
-	  if (selected === 'acload') {
+	  if (deviceCapabilities[selected]?.supportsS2) {
 	    function updateS2SectionVisibility () {
 	      const s2enabled = $('#node-input-enable_s2support').is(':checked');
-	      $('.input-acload-s2').toggle(s2enabled);
+	      $('.input-s2support-measurement').toggle(s2enabled);
 	    }
+	    $('.input-s2support').show();
 	    $('#node-input-enable_s2support').off('change.s2support').on('change.s2support', function () {
 	      context.enable_s2support = $(this).is(':checked');
 	      updateOutputs(context);
 	      updateS2SectionVisibility();
 	    });
 	    updateS2SectionVisibility();
+	  } else {
+	    $('.input-s2support').hide();
+	    $('.input-s2support-measurement').hide();
 	  }
 
 	  if (selected === 'battery') {
@@ -2442,12 +2468,6 @@ ${labels.join('\n')}`
 	    // Look up outputs from config, default to 2 (passthrough + state)
 	    return victronVirtualConstantsExports.SWITCH_OUTPUT_CONFIG[typeKey] || 2
 	  },
-	  acload: (config) => {
-	    if (config.enable_s2support) {
-	      return 2 // passthrough + signals
-	    }
-	    return 1
-	  },
 	  pulsemeter: () => 2
 	};
 
@@ -2455,14 +2475,17 @@ ${labels.join('\n')}`
 	 * Calculate the number of outputs for a virtual device
 	 * @param {string} device - Device type (e.g., 'battery', 'switch', 'gps')
 	 * @param {object} config - Device configuration object
+	 * @param {object} [deviceCapabilities] - Capability metadata keyed by device value (defaults to the shared cache)
 	 * @returns {number} Number of outputs (minimum 1)
 	 */
-	function calculateOutputs (device, config) {
+	function calculateOutputs (device, config, deviceCapabilities = getDeviceCapabilities()) {
 	  if (DEVICE_TYPE_TO_NUM_OUTPUTS[device]) {
 	    return DEVICE_TYPE_TO_NUM_OUTPUTS[device](config)
-	  } else {
-	    return 1
 	  }
+	  if (deviceCapabilities[device]?.supportsS2 && config?.enable_s2support) {
+	    return 2 // passthrough + S2 signals
+	  }
+	  return 1
 	}
 
 	/**
@@ -2487,16 +2510,17 @@ ${labels.join('\n')}`
 	 * Return the label for a single output port of a virtual device node.
 	 * @param {{ device?: string, enable_s2support?: boolean, switch_1_type?: number|string }} node
 	 * @param {number} index - Zero-based output index
+	 * @param {object} [deviceCapabilities] - Capability metadata keyed by device value (defaults to the shared cache)
 	 * @returns {string}
 	 */
-	function determineOutputLabel (node, index) {
+	function determineOutputLabel (node, index, deviceCapabilities = getDeviceCapabilities()) {
 	  if (index === 0) return 'Passthrough'
 
 	  if (node.device === 'pulsemeter') {
 	    return 'Aggregate'
 	  }
 
-	  if (node.device === 'acload' && node.enable_s2support) {
+	  if (deviceCapabilities[node.device]?.supportsS2 && node.enable_s2support) {
 	    return 'S2 communication'
 	  }
 
@@ -2551,7 +2575,21 @@ ${labels.join('\n')}`
 	  getShowUIValue,
 	  initializeTooltips,
 	  getVirtualNodeLabel,
-	  determineOutputLabel
+	  determineOutputLabel,
+	  setDeviceCapabilities,
+	  getDeviceCapabilities,
+	  fetchDeviceCapabilities
 	};
+
+	// Node-RED can call a node's outputLabels(index) (-> determineOutputLabel) to draw port
+	// tooltips for any node already on the canvas, independent of whether its edit dialog has
+	// ever been opened - so warm the device-capability cache as soon as this script loads rather
+	// than waiting for oneditprepare. If this hasn't resolved yet when a label/output-count is
+	// requested, calculateOutputs/determineOutputLabel fall back to their non-S2 defaults and
+	// self-correct on the next render once the fetch completes.
+	try {
+	  const baseUrl = (window.RED?.settings?.httpNodeRoot || window.RED?.settings?.httpAdminRoot || '').replace(/\/$/, '');
+	  fetchDeviceCapabilities(baseUrl).then(setDeviceCapabilities).catch(() => {});
+	} catch (e) { /* RED not ready yet; oneditprepare's fetch will populate the cache */ }
 
 })();

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1784,23 +1784,12 @@
 	    })
 	}
 
-	let deviceCapabilitiesCache = {};
-
 	/**
-	 * Cache device-type capability metadata (e.g. { value, label, supportsS2 }) fetched from
-	 * GET /victron/virtual-device-types, keyed by device value. Lets editor logic (output count,
-	 * output labels, S2 section visibility) generalize to any device-type module without
-	 * hardcoding device names.
+	 * Fetch device-type capability metadata (e.g. { value, label, supportsS2 }) from
+	 * GET /victron/virtual-device-types. Callers are responsible for keying the result by device
+	 * value and threading it into checkSelectedVirtualDevice/calculateOutputs/determineOutputLabel -
+	 * this module holds no capability state of its own.
 	 */
-	function setDeviceCapabilities (list) {
-	  deviceCapabilitiesCache = {}
-	  ;(list || []).forEach(dt => { deviceCapabilitiesCache[dt.value] = dt; });
-	}
-
-	function getDeviceCapabilities () {
-	  return deviceCapabilitiesCache
-	}
-
 	function fetchDeviceCapabilities (baseUrl) {
 	  return fetch((baseUrl || '') + '/victron/virtual-device-types')
 	    .then(response => response.json())
@@ -1853,7 +1842,7 @@
 	  $('#battery-voltage-custom-label').toggle(preset === 'custom');
 	}
 
-	function checkSelectedVirtualDevice (context, deviceCapabilities = getDeviceCapabilities()) {
+	function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
 	  [
 	    'acload', 'battery', 'ev', 'generator', 'gps', 'grid', 'e-drive',
 	    'pvinverter', 'switch', 'tank', 'temperature', 'energymeter', 'pulsemeter'
@@ -1870,7 +1859,7 @@
 	    $('.input-s2support').show();
 	    $('#node-input-enable_s2support').off('change.s2support').on('change.s2support', function () {
 	      context.enable_s2support = $(this).is(':checked');
-	      updateOutputs(context);
+	      updateOutputs(context, deviceCapabilities);
 	      updateS2SectionVisibility();
 	    });
 	    updateS2SectionVisibility();
@@ -2475,10 +2464,10 @@ ${labels.join('\n')}`
 	 * Calculate the number of outputs for a virtual device
 	 * @param {string} device - Device type (e.g., 'battery', 'switch', 'gps')
 	 * @param {object} config - Device configuration object
-	 * @param {object} [deviceCapabilities] - Capability metadata keyed by device value (defaults to the shared cache)
+	 * @param {object} [deviceCapabilities] - Capability metadata keyed by device value
 	 * @returns {number} Number of outputs (minimum 1)
 	 */
-	function calculateOutputs (device, config, deviceCapabilities = getDeviceCapabilities()) {
+	function calculateOutputs (device, config, deviceCapabilities = {}) {
 	  if (DEVICE_TYPE_TO_NUM_OUTPUTS[device]) {
 	    return DEVICE_TYPE_TO_NUM_OUTPUTS[device](config)
 	  }
@@ -2492,14 +2481,15 @@ ${labels.join('\n')}`
 	 * Update the outputs property in the Node-RED editor context
 	 * This is a thin wrapper around calculateOutputs that handles DOM manipulation
 	 * @param {object} context - Node-RED editor context (this)
+	 * @param {object} [deviceCapabilities] - Capability metadata keyed by device value
 	 */
-	function updateOutputs (context) {
+	function updateOutputs (context, deviceCapabilities = {}) {
 	  const device = context.device;
 	  const config = {
 	    switch_1_type: context.switch_1_type,
 	    enable_s2support: context.enable_s2support
 	  };
-	  const outputs = calculateOutputs(device, config);
+	  const outputs = calculateOutputs(device, config, deviceCapabilities);
 
 	  // Update BOTH the context AND the hidden input field
 	  context.outputs = outputs;
@@ -2510,10 +2500,10 @@ ${labels.join('\n')}`
 	 * Return the label for a single output port of a virtual device node.
 	 * @param {{ device?: string, enable_s2support?: boolean, switch_1_type?: number|string }} node
 	 * @param {number} index - Zero-based output index
-	 * @param {object} [deviceCapabilities] - Capability metadata keyed by device value (defaults to the shared cache)
+	 * @param {object} [deviceCapabilities] - Capability metadata keyed by device value
 	 * @returns {string}
 	 */
-	function determineOutputLabel (node, index, deviceCapabilities = getDeviceCapabilities()) {
+	function determineOutputLabel (node, index, deviceCapabilities = {}) {
 	  if (index === 0) return 'Passthrough'
 
 	  if (node.device === 'pulsemeter') {
@@ -2556,6 +2546,15 @@ ${labels.join('\n')}`
 
 	// src/nodes/victron-virtual-browser.js
 
+	// Node-RED can call a node's outputLabels(index) (-> determineOutputLabel) to draw port
+	// tooltips for any node already on the canvas, independent of whether its edit dialog has
+	// ever been opened. That callback only receives an index, so there is no call site through
+	// which fresh capability data could be threaded in - it must be readable synchronously from
+	// somewhere. This object is that one place; every other call site (oneditprepare,
+	// checkSelectedVirtualDevice, updateOutputs) fetches its own copy and threads it through
+	// explicitly instead of reading from here.
+	const canvasDeviceCapabilities = {};
+
 	window.__victron = {
 	  checkGeneratorType,
 	  SWITCH_TYPE_CONFIGS,
@@ -2575,21 +2574,20 @@ ${labels.join('\n')}`
 	  getShowUIValue,
 	  initializeTooltips,
 	  getVirtualNodeLabel,
-	  determineOutputLabel,
-	  setDeviceCapabilities,
-	  getDeviceCapabilities,
+	  determineOutputLabel: (node, index) => determineOutputLabel(node, index, canvasDeviceCapabilities),
 	  fetchDeviceCapabilities
 	};
 
-	// Node-RED can call a node's outputLabels(index) (-> determineOutputLabel) to draw port
-	// tooltips for any node already on the canvas, independent of whether its edit dialog has
-	// ever been opened - so warm the device-capability cache as soon as this script loads rather
-	// than waiting for oneditprepare. If this hasn't resolved yet when a label/output-count is
-	// requested, calculateOutputs/determineOutputLabel fall back to their non-S2 defaults and
-	// self-correct on the next render once the fetch completes.
+	// Warm canvasDeviceCapabilities as soon as this script loads rather than waiting for
+	// oneditprepare, so outputLabels() has S2 capability data available for nodes whose dialog
+	// hasn't been opened this session. If this hasn't resolved yet when a label is requested,
+	// determineOutputLabel falls back to its non-S2 default and self-corrects on the next render
+	// once the fetch completes.
 	try {
 	  const baseUrl = (window.RED?.settings?.httpNodeRoot || window.RED?.settings?.httpAdminRoot || '').replace(/\/$/, '');
-	  fetchDeviceCapabilities(baseUrl).then(setDeviceCapabilities).catch(() => {});
-	} catch (e) { /* RED not ready yet; oneditprepare's fetch will populate the cache */ }
+	  fetchDeviceCapabilities(baseUrl)
+	    .then(list => { (list || []).forEach(dt => { canvasDeviceCapabilities[dt.value] = dt; }); })
+	    .catch(() => {});
+	} catch (e) { /* RED not ready yet; outputLabels falls back to non-S2 defaults until this resolves */ }
 
 })();

--- a/src/nodes/victron-virtual-browser.js
+++ b/src/nodes/victron-virtual-browser.js
@@ -18,11 +18,18 @@ import {
   getShowUIValue,
   getVirtualNodeLabel,
   determineOutputLabel,
-  setDeviceCapabilities,
-  getDeviceCapabilities,
   fetchDeviceCapabilities
 } from './victron-virtual-functions.js'
 import { initializeTooltips } from './victron-common.js'
+
+// Node-RED can call a node's outputLabels(index) (-> determineOutputLabel) to draw port
+// tooltips for any node already on the canvas, independent of whether its edit dialog has
+// ever been opened. That callback only receives an index, so there is no call site through
+// which fresh capability data could be threaded in - it must be readable synchronously from
+// somewhere. This object is that one place; every other call site (oneditprepare,
+// checkSelectedVirtualDevice, updateOutputs) fetches its own copy and threads it through
+// explicitly instead of reading from here.
+const canvasDeviceCapabilities = {}
 
 window.__victron = {
   checkGeneratorType,
@@ -43,19 +50,18 @@ window.__victron = {
   getShowUIValue,
   initializeTooltips,
   getVirtualNodeLabel,
-  determineOutputLabel,
-  setDeviceCapabilities,
-  getDeviceCapabilities,
+  determineOutputLabel: (node, index) => determineOutputLabel(node, index, canvasDeviceCapabilities),
   fetchDeviceCapabilities
 }
 
-// Node-RED can call a node's outputLabels(index) (-> determineOutputLabel) to draw port
-// tooltips for any node already on the canvas, independent of whether its edit dialog has
-// ever been opened - so warm the device-capability cache as soon as this script loads rather
-// than waiting for oneditprepare. If this hasn't resolved yet when a label/output-count is
-// requested, calculateOutputs/determineOutputLabel fall back to their non-S2 defaults and
-// self-correct on the next render once the fetch completes.
+// Warm canvasDeviceCapabilities as soon as this script loads rather than waiting for
+// oneditprepare, so outputLabels() has S2 capability data available for nodes whose dialog
+// hasn't been opened this session. If this hasn't resolved yet when a label is requested,
+// determineOutputLabel falls back to its non-S2 default and self-corrects on the next render
+// once the fetch completes.
 try {
   const baseUrl = (window.RED?.settings?.httpNodeRoot || window.RED?.settings?.httpAdminRoot || '').replace(/\/$/, '')
-  fetchDeviceCapabilities(baseUrl).then(setDeviceCapabilities).catch(() => {})
-} catch (e) { /* RED not ready yet; oneditprepare's fetch will populate the cache */ }
+  fetchDeviceCapabilities(baseUrl)
+    .then(list => { (list || []).forEach(dt => { canvasDeviceCapabilities[dt.value] = dt }) })
+    .catch(() => {})
+} catch (e) { /* RED not ready yet; outputLabels falls back to non-S2 defaults until this resolves */ }

--- a/src/nodes/victron-virtual-browser.js
+++ b/src/nodes/victron-virtual-browser.js
@@ -17,7 +17,10 @@ import {
   renderShowInUICheckboxes,
   getShowUIValue,
   getVirtualNodeLabel,
-  determineOutputLabel
+  determineOutputLabel,
+  setDeviceCapabilities,
+  getDeviceCapabilities,
+  fetchDeviceCapabilities
 } from './victron-virtual-functions.js'
 import { initializeTooltips } from './victron-common.js'
 
@@ -40,5 +43,19 @@ window.__victron = {
   getShowUIValue,
   initializeTooltips,
   getVirtualNodeLabel,
-  determineOutputLabel
+  determineOutputLabel,
+  setDeviceCapabilities,
+  getDeviceCapabilities,
+  fetchDeviceCapabilities
 }
+
+// Node-RED can call a node's outputLabels(index) (-> determineOutputLabel) to draw port
+// tooltips for any node already on the canvas, independent of whether its edit dialog has
+// ever been opened - so warm the device-capability cache as soon as this script loads rather
+// than waiting for oneditprepare. If this hasn't resolved yet when a label/output-count is
+// requested, calculateOutputs/determineOutputLabel fall back to their non-S2 defaults and
+// self-correct on the next render once the fetch completes.
+try {
+  const baseUrl = (window.RED?.settings?.httpNodeRoot || window.RED?.settings?.httpAdminRoot || '').replace(/\/$/, '')
+  fetchDeviceCapabilities(baseUrl).then(setDeviceCapabilities).catch(() => {})
+} catch (e) { /* RED not ready yet; oneditprepare's fetch will populate the cache */ }

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -993,23 +993,12 @@ export function fetchEvChargers (baseUrl) {
     })
 }
 
-let deviceCapabilitiesCache = {}
-
 /**
- * Cache device-type capability metadata (e.g. { value, label, supportsS2 }) fetched from
- * GET /victron/virtual-device-types, keyed by device value. Lets editor logic (output count,
- * output labels, S2 section visibility) generalize to any device-type module without
- * hardcoding device names.
+ * Fetch device-type capability metadata (e.g. { value, label, supportsS2 }) from
+ * GET /victron/virtual-device-types. Callers are responsible for keying the result by device
+ * value and threading it into checkSelectedVirtualDevice/calculateOutputs/determineOutputLabel -
+ * this module holds no capability state of its own.
  */
-export function setDeviceCapabilities (list) {
-  deviceCapabilitiesCache = {}
-  ;(list || []).forEach(dt => { deviceCapabilitiesCache[dt.value] = dt })
-}
-
-export function getDeviceCapabilities () {
-  return deviceCapabilitiesCache
-}
-
 export function fetchDeviceCapabilities (baseUrl) {
   return fetch((baseUrl || '') + '/victron/virtual-device-types')
     .then(response => response.json())
@@ -1062,7 +1051,7 @@ export function updateBatteryVoltageVisibility () {
   $('#battery-voltage-custom-label').toggle(preset === 'custom')
 }
 
-export function checkSelectedVirtualDevice (context, deviceCapabilities = getDeviceCapabilities()) {
+export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
   [
     'acload', 'battery', 'ev', 'generator', 'gps', 'grid', 'e-drive',
     'pvinverter', 'switch', 'tank', 'temperature', 'energymeter', 'pulsemeter'
@@ -1079,7 +1068,7 @@ export function checkSelectedVirtualDevice (context, deviceCapabilities = getDev
     $('.input-s2support').show()
     $('#node-input-enable_s2support').off('change.s2support').on('change.s2support', function () {
       context.enable_s2support = $(this).is(':checked')
-      updateOutputs(context)
+      updateOutputs(context, deviceCapabilities)
       updateS2SectionVisibility()
     })
     updateS2SectionVisibility()
@@ -1685,10 +1674,10 @@ const DEVICE_TYPE_TO_NUM_OUTPUTS = {
  * Calculate the number of outputs for a virtual device
  * @param {string} device - Device type (e.g., 'battery', 'switch', 'gps')
  * @param {object} config - Device configuration object
- * @param {object} [deviceCapabilities] - Capability metadata keyed by device value (defaults to the shared cache)
+ * @param {object} [deviceCapabilities] - Capability metadata keyed by device value
  * @returns {number} Number of outputs (minimum 1)
  */
-export function calculateOutputs (device, config, deviceCapabilities = getDeviceCapabilities()) {
+export function calculateOutputs (device, config, deviceCapabilities = {}) {
   if (DEVICE_TYPE_TO_NUM_OUTPUTS[device]) {
     return DEVICE_TYPE_TO_NUM_OUTPUTS[device](config)
   }
@@ -1702,14 +1691,15 @@ export function calculateOutputs (device, config, deviceCapabilities = getDevice
  * Update the outputs property in the Node-RED editor context
  * This is a thin wrapper around calculateOutputs that handles DOM manipulation
  * @param {object} context - Node-RED editor context (this)
+ * @param {object} [deviceCapabilities] - Capability metadata keyed by device value
  */
-export function updateOutputs (context) {
+export function updateOutputs (context, deviceCapabilities = {}) {
   const device = context.device
   const config = {
     switch_1_type: context.switch_1_type,
     enable_s2support: context.enable_s2support
   }
-  const outputs = calculateOutputs(device, config)
+  const outputs = calculateOutputs(device, config, deviceCapabilities)
 
   // Update BOTH the context AND the hidden input field
   context.outputs = outputs
@@ -1720,10 +1710,10 @@ export function updateOutputs (context) {
  * Return the label for a single output port of a virtual device node.
  * @param {{ device?: string, enable_s2support?: boolean, switch_1_type?: number|string }} node
  * @param {number} index - Zero-based output index
- * @param {object} [deviceCapabilities] - Capability metadata keyed by device value (defaults to the shared cache)
+ * @param {object} [deviceCapabilities] - Capability metadata keyed by device value
  * @returns {string}
  */
-export function determineOutputLabel (node, index, deviceCapabilities = getDeviceCapabilities()) {
+export function determineOutputLabel (node, index, deviceCapabilities = {}) {
   if (index === 0) return 'Passthrough'
 
   if (node.device === 'pulsemeter') {

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -993,6 +993,28 @@ export function fetchEvChargers (baseUrl) {
     })
 }
 
+let deviceCapabilitiesCache = {}
+
+/**
+ * Cache device-type capability metadata (e.g. { value, label, supportsS2 }) fetched from
+ * GET /victron/virtual-device-types, keyed by device value. Lets editor logic (output count,
+ * output labels, S2 section visibility) generalize to any device-type module without
+ * hardcoding device names.
+ */
+export function setDeviceCapabilities (list) {
+  deviceCapabilitiesCache = {}
+  ;(list || []).forEach(dt => { deviceCapabilitiesCache[dt.value] = dt })
+}
+
+export function getDeviceCapabilities () {
+  return deviceCapabilitiesCache
+}
+
+export function fetchDeviceCapabilities (baseUrl) {
+  return fetch((baseUrl || '') + '/victron/virtual-device-types')
+    .then(response => response.json())
+}
+
 export function fetchSwitchNodeNameAndGroupFromCache (id) {
   if (!id) {
     return Promise.reject(new Error('id is required'))
@@ -1040,7 +1062,7 @@ export function updateBatteryVoltageVisibility () {
   $('#battery-voltage-custom-label').toggle(preset === 'custom')
 }
 
-export function checkSelectedVirtualDevice (context) {
+export function checkSelectedVirtualDevice (context, deviceCapabilities = getDeviceCapabilities()) {
   [
     'acload', 'battery', 'ev', 'generator', 'gps', 'grid', 'e-drive',
     'pvinverter', 'switch', 'tank', 'temperature', 'energymeter', 'pulsemeter'
@@ -1049,17 +1071,21 @@ export function checkSelectedVirtualDevice (context) {
   const selected = $('select#node-input-device').val()
   $('.input-' + selected).show()
 
-  if (selected === 'acload') {
+  if (deviceCapabilities[selected]?.supportsS2) {
     function updateS2SectionVisibility () {
       const s2enabled = $('#node-input-enable_s2support').is(':checked')
-      $('.input-acload-s2').toggle(s2enabled)
+      $('.input-s2support-measurement').toggle(s2enabled)
     }
+    $('.input-s2support').show()
     $('#node-input-enable_s2support').off('change.s2support').on('change.s2support', function () {
       context.enable_s2support = $(this).is(':checked')
       updateOutputs(context)
       updateS2SectionVisibility()
     })
     updateS2SectionVisibility()
+  } else {
+    $('.input-s2support').hide()
+    $('.input-s2support-measurement').hide()
   }
 
   if (selected === 'battery') {
@@ -1652,12 +1678,6 @@ const DEVICE_TYPE_TO_NUM_OUTPUTS = {
     // Look up outputs from config, default to 2 (passthrough + state)
     return SWITCH_OUTPUT_CONFIG[typeKey] || 2
   },
-  acload: (config) => {
-    if (config.enable_s2support) {
-      return 2 // passthrough + signals
-    }
-    return 1
-  },
   pulsemeter: () => 2
 }
 
@@ -1665,14 +1685,17 @@ const DEVICE_TYPE_TO_NUM_OUTPUTS = {
  * Calculate the number of outputs for a virtual device
  * @param {string} device - Device type (e.g., 'battery', 'switch', 'gps')
  * @param {object} config - Device configuration object
+ * @param {object} [deviceCapabilities] - Capability metadata keyed by device value (defaults to the shared cache)
  * @returns {number} Number of outputs (minimum 1)
  */
-export function calculateOutputs (device, config) {
+export function calculateOutputs (device, config, deviceCapabilities = getDeviceCapabilities()) {
   if (DEVICE_TYPE_TO_NUM_OUTPUTS[device]) {
     return DEVICE_TYPE_TO_NUM_OUTPUTS[device](config)
-  } else {
-    return 1
   }
+  if (deviceCapabilities[device]?.supportsS2 && config?.enable_s2support) {
+    return 2 // passthrough + S2 signals
+  }
+  return 1
 }
 
 /**
@@ -1697,16 +1720,17 @@ export function updateOutputs (context) {
  * Return the label for a single output port of a virtual device node.
  * @param {{ device?: string, enable_s2support?: boolean, switch_1_type?: number|string }} node
  * @param {number} index - Zero-based output index
+ * @param {object} [deviceCapabilities] - Capability metadata keyed by device value (defaults to the shared cache)
  * @returns {string}
  */
-export function determineOutputLabel (node, index) {
+export function determineOutputLabel (node, index, deviceCapabilities = getDeviceCapabilities()) {
   if (index === 0) return 'Passthrough'
 
   if (node.device === 'pulsemeter') {
     return 'Aggregate'
   }
 
-  if (node.device === 'acload' && node.enable_s2support) {
+  if (deviceCapabilities[node.device]?.supportsS2 && node.enable_s2support) {
     return 'S2 communication'
   }
 

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -97,6 +97,11 @@
         oneditprepare: function oneditprepare() {
             const self = this;
             const { checkSelectedVirtualDevice, updateOutputs, initializeTooltips } = window.__victron;
+            // Keyed by device value, e.g. { acload: { value: 'acload', label: 'AC Load', supportsS2: true } }.
+            // Populated once the device-types fetch below resolves; stashed on self so oneditsave
+            // (a separate function, not sharing this closure) can thread the same data through too.
+            const deviceCapabilities = {};
+            self.__deviceCapabilities = deviceCapabilities;
 
             if (self.device === 'motordrive') {
                 self.device = 'e-drive';
@@ -109,9 +114,9 @@
                     $select.empty();
                     deviceTypes.forEach(function(dt) {
                         $select.append($('<option>', { value: dt.value, text: dt.label }));
+                        deviceCapabilities[dt.value] = dt;
                     });
                     if (self.device) $select.val(self.device);
-                    window.__victron.setDeviceCapabilities(deviceTypes);
                 })
                 .fail(function() {
                     console.error('Failed to load virtual device types');
@@ -124,9 +129,9 @@
                     }
 
                     $('#node-input-device').on('change', (v) => {
-                        checkSelectedVirtualDevice(self);
+                        checkSelectedVirtualDevice(self, deviceCapabilities);
                         self.device = v.target.value;
-                        updateOutputs(self);
+                        updateOutputs(self, deviceCapabilities);
                     });
 
                     if (self.default_values === true) {
@@ -135,8 +140,8 @@
                         $('#node-input-default_values-no').prop('checked', true);
                     }
 
-                    updateOutputs(self);
-                    checkSelectedVirtualDevice(self);
+                    updateOutputs(self, deviceCapabilities);
+                    checkSelectedVirtualDevice(self, deviceCapabilities);
 
                     // Populate EV charger dropdown from live D-Bus cache
                     window.__victron.fetchEvChargers(baseUrl)
@@ -244,7 +249,7 @@
                 this.ev_evcs_device_instance = (evcsVal !== '' && evcsVal != null) ? parseInt(evcsVal, 10) : null;
             }
 
-            updateOutputs(this);
+            updateOutputs(this, this.__deviceCapabilities || {});
         }
     });
 

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -111,6 +111,7 @@
                         $select.append($('<option>', { value: dt.value, text: dt.label }));
                     });
                     if (self.device) $select.val(self.device);
+                    window.__victron.setDeviceCapabilities(deviceTypes);
                 })
                 .fail(function() {
                     console.error('Failed to load virtual device types');
@@ -280,14 +281,14 @@
                 <i class="fa fa-info-circle tooltip-icon" data-tooltip="Integrates power over time to estimate energy. Precision improves with higher update frequency."></i>
             </label>
         </div>
-        <div class="form-row input-acload victron-checkbox" class="hidden-row">
+        <div class="form-row input-s2support victron-checkbox" style="display:none">
             <input type="checkbox" id="node-input-enable_s2support" class="s2-checkbox">
             <label for="node-input-enable_s2support">
                 S2 support
                 <i class="fa fa-info-circle tooltip-icon" data-tooltip="Enable Victron S2 protocol support for smart charging"></i>
             </label>
         </div>
-        <div class="form-row input-acload input-acload-s2" style="display:none">
+        <div class="form-row input-s2support input-s2support-measurement" style="display:none">
             <label for="node-input-s2_measurement_type"><i class="fa fa-bar-chart"></i> S2 Measurement
                 <i class="fa fa-info-circle tooltip-icon" data-tooltip="How power is reported to the CEM. Must match the RM's Power Measurement setting."></i>
             </label>

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -1,4 +1,5 @@
 const { accumulateDelta } = require('../energy-utils')
+const { enableS2Support } = require('../s2-support')
 const ENERGY_PERSIST_SECONDS = 60
 
 const properties = {
@@ -24,21 +25,19 @@ const phaseProperties = [
   { name: 'PowerFactor', unit: '' }
 ]
 
-const additionalS2Properties = {
-  'S2/0/Active': { type: 'i' },
+// acload's S2 resource settings: a simple on/off consumer controlled by hysteresis thresholds
+// around a power setpoint. Other resource types (a producer's curtailment limit, storage's
+// charge/discharge bounds) would define their own shape and pass it to enableS2Support.
+const S2_RESOURCE_PROPERTIES = {
   'S2/0/RmSettings/OffHysteresis': { type: 'i' },
   'S2/0/RmSettings/OnHysteresis': { type: 'i' },
-  'S2/0/RmSettings/PowerSetting': { type: 'i' },
-  'S2/0/Rm': { type: 's', format: (v) => v != null ? v : '' }
+  'S2/0/RmSettings/PowerSetting': { type: 'i' }
 }
 
-const s2Defaults = {
-  'S2/0/Active': 0,
+const S2_RESOURCE_DEFAULTS = {
   'S2/0/RmSettings/OffHysteresis': 30,
   'S2/0/RmSettings/OnHysteresis': 30,
-  'S2/0/RmSettings/PowerSetting': 1000,
-  'S2/0/Priority': null,
-  'S2/0/Rm': ''
+  'S2/0/RmSettings/PowerSetting': 1000
 }
 
 function initialize (config, ifaceDesc, iface, node) {
@@ -63,88 +62,15 @@ function initialize (config, ifaceDesc, iface, node) {
     iface['Ac/Energy/Reverse'] = 0
   }
 
-  if (config.enable_s2support) {
-    console.warn('S2 support for acload virtual device is experimental.')
-
-    Object.entries(additionalS2Properties).forEach(([key, desc]) => {
-      ifaceDesc.properties[key] = desc
-      iface[key] = s2Defaults[key]
-    })
-
-    ifaceDesc.__enableS2 = true
-    // Maps D-Bus property names to S2 CommodityQuantity values for power measurement reporting
-    const measurementType = config.s2_measurement_type || '3_PHASE_SYMMETRIC'
-    const measurementPropsMap = {
-      '3_PHASE_SYMMETRIC': { 'Ac/Power': 'ELECTRIC.POWER.3_PHASE_SYMMETRIC' },
-      L1_L2_L3: {
-        'Ac/L1/Power': 'ELECTRIC.POWER.L1',
-        'Ac/L2/Power': 'ELECTRIC.POWER.L2',
-        'Ac/L3/Power': 'ELECTRIC.POWER.L3'
-      },
-      L1: { 'Ac/L1/Power': 'ELECTRIC.POWER.L1' },
-      L2: { 'Ac/L2/Power': 'ELECTRIC.POWER.L2' },
-      L3: { 'Ac/L3/Power': 'ELECTRIC.POWER.L3' }
-    }
-    ifaceDesc.__s2PowerMeasurementProps = measurementPropsMap[measurementType]
-    ifaceDesc.__s2Handlers = {
-      Connect: function (cemId, timeout) {
-        node._s2PowerMeasurementActive = false
-        node._s2PowerMeasurementCemId = null
-        node.setValuesLocally({ 'S2/0/Active': 1, 'S2/0/Rm': 'CEM: ' + cemId })
-        console.log('Connect received for CEM ID:', cemId, 'timeout', timeout)
-        node.send([
-          null,
-          {
-            payload: {
-              command: 'Connect',
-              cemId,
-              keepAliveInterval: timeout
-            }
-          }
-        ])
-      },
-      Disconnect: function (cemId) {
-        node._s2PowerMeasurementActive = false
-        node._s2PowerMeasurementCemId = null
-        node.setValuesLocally({ 'S2/0/Active': 0, 'S2/0/Rm': '' })
-        node.send([
-          null,
-          {
-            payload: {
-              command: 'Disconnect',
-              cemId
-            }
-          }
-        ])
-      },
-      Message: function (cemId, message) {
-        node.send([
-          null,
-          {
-            payload: {
-              command: 'Message',
-              cemId,
-              message
-            }
-          }
-        ])
-      },
-      KeepAlive: function (cemId) {
-        console.log('KeepAlive received for CEM ID:', cemId)
-        node.send([
-          null,
-          {
-            payload: {
-              command: 'KeepAlive',
-              cemId
-            }
-          }
-        ])
-        // D-Bus method must return a value - return true to indicate RM is alive
-        return true
-      }
-    }
-  }
+  enableS2Support({
+    config,
+    ifaceDesc,
+    iface,
+    node,
+    deviceLabel: 'acload',
+    resourceProperties: S2_RESOURCE_PROPERTIES,
+    resourceDefaults: S2_RESOURCE_DEFAULTS
+  })
 
   return `Virtual ${iface.NrOfPhases}-phase AC load`
 }
@@ -184,4 +110,4 @@ function onPropertiesChanged ({ changes, instance, config }) {
   return changes
 }
 
-module.exports = { properties, initialize, onPropertiesChanged, label: 'AC Load' }
+module.exports = { properties, initialize, onPropertiesChanged, label: 'AC Load', supportsS2: true }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -101,6 +101,14 @@ try {
   console.error('Failed to load virtual device types:', err)
 }
 
+// Annotates DEVICE_TYPES with capability flags declared by each module (e.g. supportsS2), so the
+// editor can generalize S2-support UI/output wiring without hardcoding device names.
+function annotateDeviceTypesWithCapabilities (deviceTypes, modules) {
+  deviceTypes.forEach(dt => { dt.supportsS2 = modules[dt.value]?.supportsS2 === true })
+  return deviceTypes
+}
+annotateDeviceTypesWithCapabilities(DEVICE_TYPES, deviceModules)
+
 function getActualDeviceType (type, subtype) {
   if (type === 'generator') return subtype === 'dc' ? 'dcgenset' : 'genset'
   if (type === 'e-drive') return 'motordrive'
@@ -905,3 +913,6 @@ module.exports = function (RED) {
 
   RED.nodes.registerType('victron-virtual', VictronVirtualNode)
 }
+
+// Exported for direct unit testing without needing a full RED/D-Bus mock.
+module.exports.annotateDeviceTypesWithCapabilities = annotateDeviceTypesWithCapabilities

--- a/src/nodes/victron-virtual/s2-support.js
+++ b/src/nodes/victron-virtual/s2-support.js
@@ -1,0 +1,125 @@
+// Maps D-Bus AC power property names to S2 CommodityQuantity values for power
+// measurement reporting. Generic for any AC-phased device exposing
+// Ac/Power / Ac/L{n}/Power paths - not specific to any one device-type module.
+const MEASUREMENT_TYPE_TO_PROPS = {
+  '3_PHASE_SYMMETRIC': { 'Ac/Power': 'ELECTRIC.POWER.3_PHASE_SYMMETRIC' },
+  L1_L2_L3: {
+    'Ac/L1/Power': 'ELECTRIC.POWER.L1',
+    'Ac/L2/Power': 'ELECTRIC.POWER.L2',
+    'Ac/L3/Power': 'ELECTRIC.POWER.L3'
+  },
+  L1: { 'Ac/L1/Power': 'ELECTRIC.POWER.L1' },
+  L2: { 'Ac/L2/Power': 'ELECTRIC.POWER.L2' },
+  L3: { 'Ac/L3/Power': 'ELECTRIC.POWER.L3' }
+}
+
+// Generic S2 transport-state properties, present for any S2-capable device regardless of
+// whether it's a consumer, producer, or storage resource.
+const TRANSPORT_PROPERTIES = {
+  'S2/0/Active': { type: 'i' },
+  'S2/0/Rm': { type: 's', format: (v) => v != null ? v : '' }
+}
+
+const TRANSPORT_DEFAULTS = {
+  'S2/0/Active': 0,
+  'S2/0/Rm': ''
+}
+
+/**
+ * Wires up S2 protocol support onto a D-Bus AC-power-measuring virtual device.
+ * Call unconditionally from a device-type module's initialize(config, ifaceDesc, iface, node) -
+ * it is a no-op unless config.enable_s2support is truthy.
+ *
+ * The S2 transport (Connect/Disconnect/Message/KeepAlive, power measurement) is generic across
+ * consumer/producer/storage resources. Resource-specific settings (e.g. an on/off load's
+ * hysteresis thresholds, a PV inverter's curtailment limit, a battery's charge/discharge bounds)
+ * are NOT defined here - pass them via resourceProperties/resourceDefaults so each device-type
+ * module owns its own S2 resource-settings shape while sharing this transport.
+ *
+ * @param {object} params
+ * @param {object} params.config - Node-RED node config
+ * @param {object} params.ifaceDesc - D-Bus interface description being built (has .properties)
+ * @param {object} params.iface - D-Bus interface implementation object (property values)
+ * @param {object} params.node - Node-RED runtime node (needs .send()/.setValuesLocally())
+ * @param {string} [params.deviceLabel] - Used only in the startup console.warn message
+ * @param {object} [params.resourceProperties] - ifaceDesc property definitions for this
+ *   device's S2 resource settings, merged in alongside the generic S2/0/Active and S2/0/Rm
+ *   transport properties.
+ * @param {object} [params.resourceDefaults] - initial iface values for resourceProperties' keys.
+ */
+function enableS2Support ({ config, ifaceDesc, iface, node, deviceLabel, resourceProperties = {}, resourceDefaults = {} }) {
+  if (!config.enable_s2support) return
+
+  console.warn(`S2 support for ${deviceLabel || 'this'} virtual device is experimental.`)
+
+  Object.entries({ ...TRANSPORT_PROPERTIES, ...resourceProperties }).forEach(([key, desc]) => {
+    ifaceDesc.properties[key] = desc
+    iface[key] = key in resourceDefaults ? resourceDefaults[key] : TRANSPORT_DEFAULTS[key]
+  })
+
+  ifaceDesc.__enableS2 = true
+  // Maps D-Bus property names to S2 CommodityQuantity values for power measurement reporting
+  const measurementType = config.s2_measurement_type || '3_PHASE_SYMMETRIC'
+  ifaceDesc.__s2PowerMeasurementProps = MEASUREMENT_TYPE_TO_PROPS[measurementType]
+
+  ifaceDesc.__s2Handlers = {
+    Connect: function (cemId, timeout) {
+      node._s2PowerMeasurementActive = false
+      node._s2PowerMeasurementCemId = null
+      node.setValuesLocally({ 'S2/0/Active': 1, 'S2/0/Rm': 'CEM: ' + cemId })
+      console.log('Connect received for CEM ID:', cemId, 'timeout', timeout)
+      node.send([
+        null,
+        {
+          payload: {
+            command: 'Connect',
+            cemId,
+            keepAliveInterval: timeout
+          }
+        }
+      ])
+    },
+    Disconnect: function (cemId) {
+      node._s2PowerMeasurementActive = false
+      node._s2PowerMeasurementCemId = null
+      node.setValuesLocally({ 'S2/0/Active': 0, 'S2/0/Rm': '' })
+      node.send([
+        null,
+        {
+          payload: {
+            command: 'Disconnect',
+            cemId
+          }
+        }
+      ])
+    },
+    Message: function (cemId, message) {
+      node.send([
+        null,
+        {
+          payload: {
+            command: 'Message',
+            cemId,
+            message
+          }
+        }
+      ])
+    },
+    KeepAlive: function (cemId) {
+      console.log('KeepAlive received for CEM ID:', cemId)
+      node.send([
+        null,
+        {
+          payload: {
+            command: 'KeepAlive',
+            cemId
+          }
+        }
+      ])
+      // D-Bus method must return a value - return true to indicate RM is alive
+      return true
+    }
+  }
+}
+
+module.exports = { enableS2Support, MEASUREMENT_TYPE_TO_PROPS }

--- a/test/victron-virtual-device-annotate.test.js
+++ b/test/victron-virtual-device-annotate.test.js
@@ -1,0 +1,27 @@
+// test/victron-virtual-device-annotate.test.js
+/* eslint-env jest */
+
+const { annotateDeviceTypesWithCapabilities } = require('../src/nodes/victron-virtual/index.js')
+
+describe('annotateDeviceTypesWithCapabilities', () => {
+  test('sets supportsS2 true for modules that declare it', () => {
+    const deviceTypes = [{ value: 'acload', label: 'AC Load' }, { value: 'battery', label: 'Battery' }]
+    const modules = { acload: { supportsS2: true }, battery: {} }
+    const result = annotateDeviceTypesWithCapabilities(deviceTypes, modules)
+    expect(result).toBe(deviceTypes)
+    expect(deviceTypes).toEqual([
+      { value: 'acload', label: 'AC Load', supportsS2: true },
+      { value: 'battery', label: 'Battery', supportsS2: false }
+    ])
+  })
+
+  test('defaults supportsS2 to false when the module is missing or has a truthy-but-not-true value', () => {
+    const deviceTypes = [{ value: 'unknown' }, { value: 'weird' }]
+    const modules = { weird: { supportsS2: 'yes' } }
+    annotateDeviceTypesWithCapabilities(deviceTypes, modules)
+    expect(deviceTypes).toEqual([
+      { value: 'unknown', supportsS2: false },
+      { value: 'weird', supportsS2: false }
+    ])
+  })
+})

--- a/test/victron-virtual-functions.switch.test.js
+++ b/test/victron-virtual-functions.switch.test.js
@@ -585,12 +585,24 @@ describe('determineOutputLabel', () => {
   })
 
   test('acload with s2 index 1 is S2 communication', () => {
-    expect(determineOutputLabel({ device: 'acload', enable_s2support: true }, 1)).toBe('S2 communication')
+    const caps = { acload: { supportsS2: true } }
+    expect(determineOutputLabel({ device: 'acload', enable_s2support: true }, 1, caps)).toBe('S2 communication')
   })
 
   test('acload without s2 index 1 falls back to Output 2', () => {
-    expect(determineOutputLabel({ device: 'acload', enable_s2support: false }, 1)).toBe('Output 2')
-    expect(determineOutputLabel({ device: 'acload' }, 1)).toBe('Output 2')
+    const caps = { acload: { supportsS2: true } }
+    expect(determineOutputLabel({ device: 'acload', enable_s2support: false }, 1, caps)).toBe('Output 2')
+    expect(determineOutputLabel({ device: 'acload' }, 1, caps)).toBe('Output 2')
+  })
+
+  test('a non-acload device with declared supportsS2 capability also gets S2 communication', () => {
+    const caps = { 'my-custom-acload': { supportsS2: true } }
+    expect(determineOutputLabel({ device: 'my-custom-acload', enable_s2support: true }, 1, caps)).toBe('S2 communication')
+  })
+
+  test('a device without a declared supportsS2 capability falls back to generic label even with enable_s2support set', () => {
+    expect(determineOutputLabel({ device: 'my-custom-acload', enable_s2support: true }, 1, { 'my-custom-acload': { supportsS2: false } })).toBe('Output 2')
+    expect(determineOutputLabel({ device: 'unknown-device', enable_s2support: true }, 1, {})).toBe('Output 2')
   })
 
   test('generic device index > 0 returns Output N+1', () => {

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -343,6 +343,66 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       // Only check that the switch config container is emptied for a switch device
       expect(mockContainer.empty).toHaveBeenCalled()
     })
+
+    test('shows S2 section and wires the change handler for a device with supportsS2 capability', () => {
+      const mockS2Section = createMockElement()
+      const mockS2Checkbox = createMockElement({ is: false })
+      const context = {}
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '.input-s2support') {
+          return mockS2Section
+        }
+        if (selector === '#node-input-enable_s2support') {
+          return mockS2Checkbox
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice(context, { acload: { supportsS2: true } })
+
+      expect(mockS2Section.show).toHaveBeenCalled()
+      expect(mockS2Checkbox.off).toHaveBeenCalledWith('change.s2support')
+      expect(mockS2Checkbox.on).toHaveBeenCalledWith('change.s2support', expect.any(Function))
+    })
+
+    test('hides S2 section and does not wire the change handler for a device without supportsS2 capability', () => {
+      const mockS2Section = createMockElement()
+      const mockS2Measurement = createMockElement()
+      const mockS2Checkbox = createMockElement({ is: false })
+      const context = {}
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'battery' })
+        }
+        if (selector === '.input-s2support') {
+          return mockS2Section
+        }
+        if (selector === '.input-s2support-measurement') {
+          return mockS2Measurement
+        }
+        if (selector === '#node-input-enable_s2support') {
+          return mockS2Checkbox
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice(context, { acload: { supportsS2: true } })
+
+      expect(mockS2Section.hide).toHaveBeenCalled()
+      expect(mockS2Measurement.hide).toHaveBeenCalled()
+      expect(mockS2Checkbox.off).not.toHaveBeenCalledWith('change.s2support')
+    })
   })
 
   describe('updateSwitchConfig', () => {

--- a/test/victron-virtual-outputs.test.js
+++ b/test/victron-virtual-outputs.test.js
@@ -124,6 +124,27 @@ describe('calculateOutputs', () => {
       })
     })
   })
+
+  describe('S2-capable devices (generic, capability-driven)', () => {
+    test('device with supportsS2 capability and enable_s2support has 2 outputs', () => {
+      const caps = { acload: { supportsS2: true } }
+      expect(calculateOutputs('acload', { enable_s2support: true }, caps)).toBe(2)
+    })
+
+    test('device with supportsS2 capability but enable_s2support false has 1 output', () => {
+      const caps = { acload: { supportsS2: true } }
+      expect(calculateOutputs('acload', { enable_s2support: false }, caps)).toBe(1)
+    })
+
+    test('an external device type with supportsS2 gets 2 outputs generically', () => {
+      const caps = { 'my-custom-acload': { supportsS2: true } }
+      expect(calculateOutputs('my-custom-acload', { enable_s2support: true }, caps)).toBe(2)
+    })
+
+    test('a device without a capabilities entry defaults to 1 output regardless of enable_s2support', () => {
+      expect(calculateOutputs('unknown-device', { enable_s2support: true }, {})).toBe(1)
+    })
+  })
 })
 
 describe('getOutputLabels', () => {

--- a/test/victron-virtual-s2-support.test.js
+++ b/test/victron-virtual-s2-support.test.js
@@ -1,0 +1,137 @@
+// test/victron-virtual-s2-support.test.js
+/* eslint-env jest */
+
+const { enableS2Support } = require('../src/nodes/victron-virtual/s2-support')
+
+function makeFixtures () {
+  return {
+    ifaceDesc: { properties: {} },
+    iface: {},
+    node: { send: jest.fn(), setValuesLocally: jest.fn() }
+  }
+}
+
+describe('enableS2Support', () => {
+  test('is a no-op when config.enable_s2support is falsy', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: {}, ifaceDesc, iface, node })
+    expect(ifaceDesc.__enableS2).toBeUndefined()
+    expect(ifaceDesc.__s2PowerMeasurementProps).toBeUndefined()
+    expect(ifaceDesc.__s2Handlers).toBeUndefined()
+    expect(ifaceDesc.properties).toEqual({})
+    expect(iface).toEqual({})
+  })
+
+  test('sets __enableS2 and the generic transport properties/defaults when enabled, with no resource settings by default', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node })
+    expect(ifaceDesc.__enableS2).toBe(true)
+    expect(ifaceDesc.properties['S2/0/Active']).toEqual({ type: 'i' })
+    expect(ifaceDesc.properties['S2/0/Rm']).toBeDefined()
+    expect(iface['S2/0/Active']).toBe(0)
+    expect(iface['S2/0/Rm']).toBe('')
+    expect(Object.keys(ifaceDesc.properties)).toEqual(['S2/0/Active', 'S2/0/Rm'])
+  })
+
+  test('merges caller-supplied resourceProperties/resourceDefaults alongside the transport properties', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    // A stand-in for a non-load resource shape (e.g. a producer's curtailment limit) - proves
+    // enableS2Support doesn't assume any particular resource-settings schema.
+    const resourceProperties = {
+      'S2/0/RmSettings/CurtailmentLimit': { type: 'i' }
+    }
+    const resourceDefaults = {
+      'S2/0/RmSettings/CurtailmentLimit': 500
+    }
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node, resourceProperties, resourceDefaults })
+    expect(ifaceDesc.properties['S2/0/Active']).toEqual({ type: 'i' })
+    expect(ifaceDesc.properties['S2/0/Rm']).toBeDefined()
+    expect(ifaceDesc.properties['S2/0/RmSettings/CurtailmentLimit']).toEqual({ type: 'i' })
+    expect(iface['S2/0/Active']).toBe(0)
+    expect(iface['S2/0/Rm']).toBe('')
+    expect(iface['S2/0/RmSettings/CurtailmentLimit']).toBe(500)
+  })
+
+  test('defaults to 3_PHASE_SYMMETRIC measurement props when s2_measurement_type is absent', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node })
+    expect(ifaceDesc.__s2PowerMeasurementProps).toEqual({
+      'Ac/Power': 'ELECTRIC.POWER.3_PHASE_SYMMETRIC'
+    })
+  })
+
+  test.each([
+    ['L1_L2_L3', { 'Ac/L1/Power': 'ELECTRIC.POWER.L1', 'Ac/L2/Power': 'ELECTRIC.POWER.L2', 'Ac/L3/Power': 'ELECTRIC.POWER.L3' }],
+    ['L1', { 'Ac/L1/Power': 'ELECTRIC.POWER.L1' }],
+    ['L2', { 'Ac/L2/Power': 'ELECTRIC.POWER.L2' }],
+    ['L3', { 'Ac/L3/Power': 'ELECTRIC.POWER.L3' }]
+  ])('uses correct measurement props when s2_measurement_type is %s', (type, expected) => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true, s2_measurement_type: type }, ifaceDesc, iface, node })
+    expect(ifaceDesc.__s2PowerMeasurementProps).toEqual(expected)
+  })
+
+  test('sets __s2Handlers with all four methods', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node })
+    expect(typeof ifaceDesc.__s2Handlers.Connect).toBe('function')
+    expect(typeof ifaceDesc.__s2Handlers.Disconnect).toBe('function')
+    expect(typeof ifaceDesc.__s2Handlers.Message).toBe('function')
+    expect(typeof ifaceDesc.__s2Handlers.KeepAlive).toBe('function')
+  })
+
+  test('Connect handler updates S2 active/rm and sends command on port 2', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node })
+    node._s2PowerMeasurementActive = true
+    node._s2PowerMeasurementCemId = 'old-cem'
+    ifaceDesc.__s2Handlers.Connect('cem-1', 30)
+    expect(node._s2PowerMeasurementActive).toBe(false)
+    expect(node._s2PowerMeasurementCemId).toBeNull()
+    expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Active': 1, 'S2/0/Rm': 'CEM: cem-1' })
+    expect(node.send).toHaveBeenCalledWith([null, {
+      payload: { command: 'Connect', cemId: 'cem-1', keepAliveInterval: 30 }
+    }])
+  })
+
+  test('Disconnect handler clears S2 active/rm and sends command on port 2', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node })
+    node._s2PowerMeasurementActive = true
+    node._s2PowerMeasurementCemId = 'cem-1'
+    ifaceDesc.__s2Handlers.Disconnect('cem-1')
+    expect(node._s2PowerMeasurementActive).toBe(false)
+    expect(node._s2PowerMeasurementCemId).toBeNull()
+    expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Active': 0, 'S2/0/Rm': '' })
+    expect(node.send).toHaveBeenCalledWith([null, {
+      payload: { command: 'Disconnect', cemId: 'cem-1' }
+    }])
+  })
+
+  test('Message handler sends command on port 2 with the message payload', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node })
+    ifaceDesc.__s2Handlers.Message('cem-1', { foo: 'bar' })
+    expect(node.send).toHaveBeenCalledWith([null, {
+      payload: { command: 'Message', cemId: 'cem-1', message: { foo: 'bar' } }
+    }])
+  })
+
+  test('KeepAlive handler sends command on port 2 and returns true', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node })
+    const result = ifaceDesc.__s2Handlers.KeepAlive('cem-1')
+    expect(node.send).toHaveBeenCalledWith([null, {
+      payload: { command: 'KeepAlive', cemId: 'cem-1' }
+    }])
+    expect(result).toBe(true)
+  })
+
+  test('reflects deviceLabel in the startup console.warn', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const { ifaceDesc, iface, node } = makeFixtures()
+    enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node, deviceLabel: 'my-custom-acload' })
+    expect(warnSpy).toHaveBeenCalledWith('S2 support for my-custom-acload virtual device is experimental.')
+    warnSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
Extract the S2 transport (CEM Connect/Disconnect/Message/KeepAlive, power-measurement broadcast) into a shared enableS2Support() helper so any device-type module can opt in via a supportsS2 export instead of the editor/backend hardcoding the 'acload' device name. Device-type modules own their own S2 resource-settings shape (e.g. acload's on/off hysteresis thresholds) and pass it into the shared transport, so future consumer/producer/storage resource types can define their own shape without touching shared code.

Behavior for existing acload flows is unchanged.