### PR TITLE
fix(nodes): restore legacy global context key for singleton services

### DIFF
--- a/src/nodes/victron-nodes.js
+++ b/src/nodes/victron-nodes.js
@@ -12,6 +12,10 @@ function mustRemoveDeviceInstanceFromService (service) {
   return serviceNamesWithoutDeviceInstance.includes(serviceNameBare)
 }
 
+// Logged at most once per process: see the legacy global context key fallback in
+// BaseInputNode's processMessage (issue #535).
+let hasWarnedAboutLegacyGlobalContextKey = false
+
 module.exports = function (RED) {
   const debug = require('debug')('node-red-contrib-victron:victron-nodes')
   const utils = require('../services/utils.js')
@@ -213,7 +217,28 @@ module.exports = function (RED) {
               })
             }
             const globalContext = this.node.context().global
-            globalContext.set(transform(`${this.service}${this.path}`), msg.value)
+            const key = transform(`${this.service}${this.path}`)
+            globalContext.set(key, msg.value)
+
+            // Singleton services (system, settings, platform, dynamicess) no longer carry
+            // a '/0' device instance suffix (see #518), so they no longer produce a '._0'
+            // segment here. Flows/dashboards built against the old key would silently stop
+            // updating, so we keep writing that legacy key alongside the new one (#535).
+            if (serviceNamesWithoutDeviceInstance.includes(this.service)) {
+              const legacyKey = transform(`${this.service}/0${this.path}`)
+              if (legacyKey !== key) {
+                globalContext.set(legacyKey, msg.value)
+                if (!hasWarnedAboutLegacyGlobalContextKey) {
+                  console.warn(
+                    `[DEPRECATED] Global context key '${legacyKey}' is only written for backward ` +
+                    'compatibility. If any of your flows/dashboards still read that key, switch them ' +
+                    `to '${key}' - the legacy key may be removed in a future release. ` +
+                    'Shown once per Node-RED run; safe to ignore if nothing reads the old key.'
+                  )
+                  hasWarnedAboutLegacyGlobalContextKey = true
+                }
+              }
+            }
           }
           this.node.previousvalue = msg.value
 

--- a/test/victron-nodes.test.js
+++ b/test/victron-nodes.test.js
@@ -1,7 +1,7 @@
 const victronNodesInitFunction = require('../src/nodes/victron-nodes')
 const { serviceNamesWithoutDeviceInstance } = require('../src/services/dbus-listener')
 
-function buildMockRED ({ services = {}, connected = true, hasConfigNode = true } = {}) {
+function buildMockRED ({ services = {}, connected = true, hasConfigNode = true, initFn = victronNodesInitFunction } = {}) {
   const subscribe = jest.fn()
   const publish = jest.fn()
   const mockRED = {
@@ -36,7 +36,7 @@ function buildMockRED ({ services = {}, connected = true, hasConfigNode = true }
       }
     }
   }
-  victronNodesInitFunction(mockRED)
+  initFn(mockRED)
   const BaseInputNode = mockRED.nodes.registerType.mock.calls[0][1]
   const outputCallIndex = mockRED.nodes.registerType.mock.calls.findIndex(c => c[0].startsWith('victron-output-'))
   const BaseOutputNode = mockRED.nodes.registerType.mock.calls[outputCallIndex][1]
@@ -297,5 +297,75 @@ describe('victron-nodes', () => {
     })
     expect(oldStyleSystemInputNode).toBeDefined()
     expect(oldStyleSystemInputNode.service).toEqual('com.victronenergy.system')
+  })
+})
+
+describe('victron-nodes global context regression (#535)', () => {
+  it('writes both the bare and legacy "_0" global context keys for singleton services', () => {
+    const { BaseInputNode, subscribe } = buildMockRED()
+
+    const node = new BaseInputNode({
+      name: 'Test',
+      service: 'com.victronenergy.system',
+      path: '/Serial',
+      serviceObj: { name: 'System' },
+      pathObj: { name: 'Serial' }
+    })
+
+    const globalContext = node.context().global
+    const processMessage = subscribe.mock.calls[0][2]
+    processMessage({ value: 'abc123' })
+
+    expect(globalContext.set).toHaveBeenCalledWith('victronenergy.system.Serial', 'abc123')
+    expect(globalContext.set).toHaveBeenCalledWith('victronenergy.system._0.Serial', 'abc123')
+  })
+
+  it('writes only a single global context key for non-singleton services', () => {
+    const { BaseInputNode, subscribe } = buildMockRED()
+
+    const node = new BaseInputNode({
+      name: 'Test',
+      service: 'com.victronenergy.battery/512',
+      path: '/Soc',
+      serviceObj: { name: 'Battery' },
+      pathObj: { name: 'SoC' }
+    })
+
+    const globalContext = node.context().global
+    const processMessage = subscribe.mock.calls[0][2]
+    processMessage({ value: 55 })
+
+    expect(globalContext.set).toHaveBeenCalledTimes(1)
+    expect(globalContext.set).toHaveBeenCalledWith('victronenergy.battery._512.Soc', 55)
+  })
+
+  it('logs the legacy key deprecation warning only once, even across multiple nodes', () => {
+    let freshInitFn
+    jest.isolateModules(() => {
+      freshInitFn = require('../src/nodes/victron-nodes')
+    })
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const emitOnce = (path) => {
+        const { BaseInputNode, subscribe } = buildMockRED({ initFn: freshInitFn })
+        new BaseInputNode({ // eslint-disable-line no-new
+          name: 'Test',
+          service: 'com.victronenergy.system',
+          path,
+          serviceObj: { name: 'System' },
+          pathObj: { name: path }
+        })
+        subscribe.mock.calls[0][2]({ value: 'x' })
+      }
+
+      emitOnce('/Serial')
+      emitOnce('/ProductName')
+
+      const legacyWarnings = warnSpy.mock.calls.filter(([msg]) => msg.includes('[DEPRECATED]'))
+      expect(legacyWarnings).toHaveLength(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
d6877cf dropped the device instance suffix for singleton services (system, settings, platform, dynamicess) to fix duplicate dropdown entries, but this also changed the global context key those nodes write to, e.g. `victronenergy.system._0.Serial` became `victronenergy.system.Serial`. Existing flows/dashboards reading the old key silently stopped updating.

Write both keys for these services going forward, with a one-time `console.warn` noting the legacy key is deprecated.

Closes https://github.com/victronenergy/node-red-contrib-victron/issues/535