### PR TITLE
Add /Position, /PhaseSetting to virtual AC-load-style devices (#544)

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1842,6 +1842,9 @@
 	  $('#battery-voltage-custom-label').toggle(preset === 'custom');
 	}
 
+	// Mirrors POSITION_CONFIGURABLE_ROLES in src/nodes/victron-virtual/device-type/energymeter.js
+	const ENERGYMETER_POSITION_CONFIGURABLE_ROLES = ['acload', 'evcharger', 'heatpump'];
+
 	function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
 	  [
 	    'acload', 'battery', 'ev', 'generator', 'gps', 'grid', 'e-drive',
@@ -1893,6 +1896,15 @@
 	      $('#pulsemeter-multiplier-row').toggle($(this).is(':checked'));
 	    });
 	    $('#pulsemeter-multiplier-row').toggle($('#node-input-auto_aggregate').is(':checked'));
+	  }
+
+	  if (selected === 'energymeter') {
+	    const updateEnergymeterPositionVisibility = () => {
+	      const role = $('#node-input-energymeter_role').val();
+	      $('#energymeter-position-row').toggle(ENERGYMETER_POSITION_CONFIGURABLE_ROLES.includes(role));
+	    };
+	    $('#node-input-energymeter_role').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility);
+	    updateEnergymeterPositionVisibility();
 	  }
 
 	  if (selected === 'generator') {

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1900,11 +1900,36 @@
 	  }
 
 	  if (selected === 'acload') {
+	    // Keeps the S2 Measurement dropdown consistent with the acload's actual phase(s): for a
+	    // single-phase config, only "3-phase symmetric" (reads the Ac/Power total) and the single
+	    // phase option matching the configured Phase are valid - the other single-phase options and
+	    // "Per phase" would read an Ac/L{n}/Power path that doesn't exist on the device.
+	    const updateAcloadS2MeasurementOptions = (isSinglePhase) => {
+	      const phaseSetting = $('#node-input-acload_phasesetting').val();
+	      const matchingSingleValue = 'L' + phaseSetting;
+	      const $select = $('#node-input-s2_measurement_type');
+
+	      $select.find('option').each(function () {
+	        const val = $(this).val();
+	        const isPerPhaseOption = val === 'L1_L2_L3';
+	        const isMismatchedSinglePhaseOption = ['L1', 'L2', 'L3'].includes(val) && val !== matchingSingleValue;
+	        $(this).toggle(!isSinglePhase || (!isPerPhaseOption && !isMismatchedSinglePhaseOption));
+	      });
+
+	      if (isSinglePhase && ['L1', 'L2', 'L3'].includes($select.val()) && $select.val() !== matchingSingleValue) {
+	        $select.val(matchingSingleValue);
+	      }
+	    };
+
 	    const updateAcloadPhaseSettingVisibility = () => {
-	      const nrOfPhases = $('#node-input-acload_nrofphases').val();
-	      $('#acload-phasesetting-row').toggle(nrOfPhases === '1');
+	      const isSinglePhase = $('#node-input-acload_nrofphases').val() === '1';
+	      $('#acload-phasesetting-row').toggle(isSinglePhase);
+	      updateAcloadS2MeasurementOptions(isSinglePhase);
 	    };
 	    $('#node-input-acload_nrofphases').off('change.acload-phasesetting').on('change.acload-phasesetting', updateAcloadPhaseSettingVisibility);
+	    $('#node-input-acload_phasesetting').off('change.acload-s2measurement').on('change.acload-s2measurement', () => {
+	      updateAcloadS2MeasurementOptions($('#node-input-acload_nrofphases').val() === '1');
+	    });
 	    updateAcloadPhaseSettingVisibility();
 	  }
 

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1842,7 +1842,8 @@
 	  $('#battery-voltage-custom-label').toggle(preset === 'custom');
 	}
 
-	// Mirrors POSITION_CONFIGURABLE_ROLES in src/nodes/victron-virtual/device-type/energymeter.js
+	// Mirrors POSITION_CONFIGURABLE_ROLES in src/nodes/victron-virtual/device-type/energymeter.js -
+	// gates both the Position and (for single-phase configs) PhaseSetting rows.
 	const ENERGYMETER_POSITION_CONFIGURABLE_ROLES = ['acload', 'evcharger', 'heatpump'];
 
 	function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
@@ -1898,12 +1899,25 @@
 	    $('#pulsemeter-multiplier-row').toggle($('#node-input-auto_aggregate').is(':checked'));
 	  }
 
+	  if (selected === 'acload') {
+	    const updateAcloadPhaseSettingVisibility = () => {
+	      const nrOfPhases = $('#node-input-acload_nrofphases').val();
+	      $('#acload-phasesetting-row').toggle(nrOfPhases === '1');
+	    };
+	    $('#node-input-acload_nrofphases').off('change.acload-phasesetting').on('change.acload-phasesetting', updateAcloadPhaseSettingVisibility);
+	    updateAcloadPhaseSettingVisibility();
+	  }
+
 	  if (selected === 'energymeter') {
 	    const updateEnergymeterPositionVisibility = () => {
 	      const role = $('#node-input-energymeter_role').val();
-	      $('#energymeter-position-row').toggle(ENERGYMETER_POSITION_CONFIGURABLE_ROLES.includes(role));
+	      const nrOfPhases = $('#node-input-energymeter_nrofphases').val();
+	      const isConfigurableRole = ENERGYMETER_POSITION_CONFIGURABLE_ROLES.includes(role);
+	      $('#energymeter-position-row').toggle(isConfigurableRole);
+	      $('#energymeter-phasesetting-row').toggle(isConfigurableRole && nrOfPhases === '1');
 	    };
 	    $('#node-input-energymeter_role').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility);
+	    $('#node-input-energymeter_nrofphases').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility);
 	    updateEnergymeterPositionVisibility();
 	  }
 

--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -425,6 +425,16 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code> Voltage (V AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code>/Voltage</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Is generic energy meter<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/IsGenericEnergyMeter</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Phase<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/PhaseSetting</b><span class="property-mode"></span>
+<ul>
+  <li>1 - L1</li>
+  <li>2 - L2</li>
+  <li>3 - L3</li>
+</ul></dd>
   <dt class="optional">Position<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Position</b><span class="property-mode"></span>
 <ul>

--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -425,6 +425,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code> Voltage (V AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code>/Voltage</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Position<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Position</b><span class="property-mode"></span>
+<ul>
+  <li>0 - AC output</li>
+  <li>1 - AC input</li>
+</ul></dd>
   <dt class="optional">Serial number<span class="property-type">string</span></dt>
   <dd>Dbus path: <b>/Serial</b><span class="property-mode"></span>
 </dd>

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1051,7 +1051,8 @@ export function updateBatteryVoltageVisibility () {
   $('#battery-voltage-custom-label').toggle(preset === 'custom')
 }
 
-// Mirrors POSITION_CONFIGURABLE_ROLES in src/nodes/victron-virtual/device-type/energymeter.js
+// Mirrors POSITION_CONFIGURABLE_ROLES in src/nodes/victron-virtual/device-type/energymeter.js -
+// gates both the Position and (for single-phase configs) PhaseSetting rows.
 const ENERGYMETER_POSITION_CONFIGURABLE_ROLES = ['acload', 'evcharger', 'heatpump']
 
 export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
@@ -1107,12 +1108,25 @@ export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
     $('#pulsemeter-multiplier-row').toggle($('#node-input-auto_aggregate').is(':checked'))
   }
 
+  if (selected === 'acload') {
+    const updateAcloadPhaseSettingVisibility = () => {
+      const nrOfPhases = $('#node-input-acload_nrofphases').val()
+      $('#acload-phasesetting-row').toggle(nrOfPhases === '1')
+    }
+    $('#node-input-acload_nrofphases').off('change.acload-phasesetting').on('change.acload-phasesetting', updateAcloadPhaseSettingVisibility)
+    updateAcloadPhaseSettingVisibility()
+  }
+
   if (selected === 'energymeter') {
     const updateEnergymeterPositionVisibility = () => {
       const role = $('#node-input-energymeter_role').val()
-      $('#energymeter-position-row').toggle(ENERGYMETER_POSITION_CONFIGURABLE_ROLES.includes(role))
+      const nrOfPhases = $('#node-input-energymeter_nrofphases').val()
+      const isConfigurableRole = ENERGYMETER_POSITION_CONFIGURABLE_ROLES.includes(role)
+      $('#energymeter-position-row').toggle(isConfigurableRole)
+      $('#energymeter-phasesetting-row').toggle(isConfigurableRole && nrOfPhases === '1')
     }
     $('#node-input-energymeter_role').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility)
+    $('#node-input-energymeter_nrofphases').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility)
     updateEnergymeterPositionVisibility()
   }
 

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1109,11 +1109,36 @@ export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
   }
 
   if (selected === 'acload') {
+    // Keeps the S2 Measurement dropdown consistent with the acload's actual phase(s): for a
+    // single-phase config, only "3-phase symmetric" (reads the Ac/Power total) and the single
+    // phase option matching the configured Phase are valid - the other single-phase options and
+    // "Per phase" would read an Ac/L{n}/Power path that doesn't exist on the device.
+    const updateAcloadS2MeasurementOptions = (isSinglePhase) => {
+      const phaseSetting = $('#node-input-acload_phasesetting').val()
+      const matchingSingleValue = 'L' + phaseSetting
+      const $select = $('#node-input-s2_measurement_type')
+
+      $select.find('option').each(function () {
+        const val = $(this).val()
+        const isPerPhaseOption = val === 'L1_L2_L3'
+        const isMismatchedSinglePhaseOption = ['L1', 'L2', 'L3'].includes(val) && val !== matchingSingleValue
+        $(this).toggle(!isSinglePhase || (!isPerPhaseOption && !isMismatchedSinglePhaseOption))
+      })
+
+      if (isSinglePhase && ['L1', 'L2', 'L3'].includes($select.val()) && $select.val() !== matchingSingleValue) {
+        $select.val(matchingSingleValue)
+      }
+    }
+
     const updateAcloadPhaseSettingVisibility = () => {
-      const nrOfPhases = $('#node-input-acload_nrofphases').val()
-      $('#acload-phasesetting-row').toggle(nrOfPhases === '1')
+      const isSinglePhase = $('#node-input-acload_nrofphases').val() === '1'
+      $('#acload-phasesetting-row').toggle(isSinglePhase)
+      updateAcloadS2MeasurementOptions(isSinglePhase)
     }
     $('#node-input-acload_nrofphases').off('change.acload-phasesetting').on('change.acload-phasesetting', updateAcloadPhaseSettingVisibility)
+    $('#node-input-acload_phasesetting').off('change.acload-s2measurement').on('change.acload-s2measurement', () => {
+      updateAcloadS2MeasurementOptions($('#node-input-acload_nrofphases').val() === '1')
+    })
     updateAcloadPhaseSettingVisibility()
   }
 

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1051,6 +1051,9 @@ export function updateBatteryVoltageVisibility () {
   $('#battery-voltage-custom-label').toggle(preset === 'custom')
 }
 
+// Mirrors POSITION_CONFIGURABLE_ROLES in src/nodes/victron-virtual/device-type/energymeter.js
+const ENERGYMETER_POSITION_CONFIGURABLE_ROLES = ['acload', 'evcharger', 'heatpump']
+
 export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
   [
     'acload', 'battery', 'ev', 'generator', 'gps', 'grid', 'e-drive',
@@ -1102,6 +1105,15 @@ export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
       $('#pulsemeter-multiplier-row').toggle($(this).is(':checked'))
     })
     $('#pulsemeter-multiplier-row').toggle($('#node-input-auto_aggregate').is(':checked'))
+  }
+
+  if (selected === 'energymeter') {
+    const updateEnergymeterPositionVisibility = () => {
+      const role = $('#node-input-energymeter_role').val()
+      $('#energymeter-position-row').toggle(ENERGYMETER_POSITION_CONFIGURABLE_ROLES.includes(role))
+    }
+    $('#node-input-energymeter_role').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility)
+    updateEnergymeterPositionVisibility()
   }
 
   if (selected === 'generator') {

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -10,6 +10,7 @@
             device: {value:"", required: true},
             default_values: {value: true, required: false},
             // acload
+            acload_position: {value: 0, required: false},
             acload_nrofphases: {value: 1, required: false},
             acload_auto_energy: {value: true, required: false},
             enable_s2support: {value: false, required: false},
@@ -271,6 +272,13 @@
         <div class="form-row">
             <label for="node-input-device"><i class="fa fa-microchip"></i> Device</label>
             <select id="node-input-device" required></select>
+        </div>
+        <div class="form-row input-acload" class="hidden-row">
+            <label for="node-input-acload_position"><i class="fa fa-sliders"></i> Position</label>
+            <select id="node-input-acload_position">
+                <option value="0">AC output</option>
+                <option value="1">AC input</option>
+            </select>
         </div>
         <div class="form-row input-acload" class="hidden-row">
             <label for="node-input-acload_nrofphases"><i class="fa fa-plug"></i> Number of phases</label>

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -12,6 +12,7 @@
             // acload
             acload_position: {value: 0, required: false},
             acload_nrofphases: {value: 1, required: false},
+            acload_phasesetting: {value: 1, required: false},
             acload_auto_energy: {value: true, required: false},
             enable_s2support: {value: false, required: false},
             s2_measurement_type: {value: '3_PHASE_SYMMETRIC', required: false},
@@ -32,6 +33,7 @@
             energymeter_nrofphases: {value: 1, required: false},
             energymeter_role: {value: "gridmeter", required: false},
             energymeter_position: {value: 0, required: false},
+            energymeter_phasesetting: {value: 1, required: false},
             // motordrive
             include_motor_temp: {value: false},
             include_controller_temp: {value: false},
@@ -289,6 +291,14 @@
                 <option value="3">3 phase</option>
             </select>
         </div>
+        <div class="form-row input-acload" id="acload-phasesetting-row" class="hidden-row">
+            <label for="node-input-acload_phasesetting"><i class="fa fa-plug"></i> Phase</label>
+            <select id="node-input-acload_phasesetting">
+                <option value="1">L1</option>
+                <option value="2">L2</option>
+                <option value="3">L3</option>
+            </select>
+        </div>
         <div class="form-row input-acload victron-checkbox" class="hidden-row">
             <input type="checkbox" id="node-input-acload_auto_energy">
             <label for="node-input-acload_auto_energy">Auto-calculate energy (Ac/Energy/Forward)
@@ -433,6 +443,14 @@
                     <option value="1">1</option>
                     <option value="2">2</option>
                     <option value="3">3</option>
+                </select>
+            </div>
+            <div class="form-row" id="energymeter-phasesetting-row">
+                <label for="node-input-energymeter_phasesetting"><i class="fa fa-plug"></i> Phase</label>
+                <select id="node-input-energymeter_phasesetting">
+                    <option value="1">L1</option>
+                    <option value="2">L2</option>
+                    <option value="3">L3</option>
                 </select>
             </div>
         </div>

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -31,6 +31,7 @@
             // energymeter
             energymeter_nrofphases: {value: 1, required: false},
             energymeter_role: {value: "gridmeter", required: false},
+            energymeter_position: {value: 0, required: false},
             // motordrive
             include_motor_temp: {value: false},
             include_controller_temp: {value: false},
@@ -417,6 +418,13 @@
                     <option value="acload">AC load</option>
                     <option value="evcharger">EV charger</option>
                     <option value="heatpump">Heat pump</option>
+                </select>
+            </div>
+            <div class="form-row" id="energymeter-position-row">
+                <label for="node-input-energymeter_position"><i class="fa fa-sliders"></i> Position</label>
+                <select id="node-input-energymeter_position">
+                    <option value="0">AC output</option>
+                    <option value="1">AC input</option>
                 </select>
             </div>
             <div class="form-row">

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -276,14 +276,14 @@
             <label for="node-input-device"><i class="fa fa-microchip"></i> Device</label>
             <select id="node-input-device" required></select>
         </div>
-        <div class="form-row input-acload" class="hidden-row">
+        <div class="form-row input-acload hidden-row">
             <label for="node-input-acload_position"><i class="fa fa-sliders"></i> Position</label>
             <select id="node-input-acload_position">
                 <option value="0">AC output</option>
                 <option value="1">AC input</option>
             </select>
         </div>
-        <div class="form-row input-acload" class="hidden-row">
+        <div class="form-row input-acload hidden-row">
             <label for="node-input-acload_nrofphases"><i class="fa fa-plug"></i> Number of phases</label>
             <select id="node-input-acload_nrofphases">
                 <option value="1">1 phase</option>
@@ -291,7 +291,7 @@
                 <option value="3">3 phase</option>
             </select>
         </div>
-        <div class="form-row input-acload" id="acload-phasesetting-row" class="hidden-row">
+        <div class="form-row input-acload hidden-row" id="acload-phasesetting-row">
             <label for="node-input-acload_phasesetting"><i class="fa fa-plug"></i> Phase</label>
             <select id="node-input-acload_phasesetting">
                 <option value="1">L1</option>
@@ -299,7 +299,7 @@
                 <option value="3">L3</option>
             </select>
         </div>
-        <div class="form-row input-acload victron-checkbox" class="hidden-row">
+        <div class="form-row input-acload victron-checkbox hidden-row">
             <input type="checkbox" id="node-input-acload_auto_energy">
             <label for="node-input-acload_auto_energy">Auto-calculate energy (Ac/Energy/Forward)
                 <i class="fa fa-info-circle tooltip-icon" data-tooltip="Integrates power over time to estimate energy. Precision improves with higher update frequency."></i>

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -14,6 +14,7 @@ const properties = {
   'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
   'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'Hz' : '' },
   Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 },
+  IsGenericEnergyMeter: { type: 'i', format: (v) => v != null ? v : '', value: 1 },
   Position: {
     type: 'i',
     format: (v) => ({
@@ -47,11 +48,34 @@ const S2_RESOURCE_DEFAULTS = {
   'S2/0/RmSettings/PowerSetting': 1000
 }
 
+// For a single-phase acload, the physical phase it's wired to is configurable (acload_phasesetting)
+// instead of always being L1. Multi-phase configs always start at L1.
+function resolvePhase (config, i) {
+  return Number(config.acload_nrofphases ?? 1) === 1 ? Number(config.acload_phasesetting ?? 1) : i
+}
+
 function initialize (config, ifaceDesc, iface, node) {
   iface.Position = Number(config.acload_position ?? 0)
   iface.NrOfPhases = Number(config.acload_nrofphases ?? 1)
+
+  const isSinglePhase = iface.NrOfPhases === 1
+  if (isSinglePhase) {
+    iface.PhaseSetting = resolvePhase(config, 1)
+    ifaceDesc.properties.PhaseSetting = { type: 'i', format: (v) => v != null ? 'L' + v : '' }
+
+    if (iface.PhaseSetting !== 1) {
+      // The static properties declare an L1 set by default; drop it so only the phase
+      // actually wired up is exposed, instead of leaving a phantom always-null L1 set behind.
+      phaseProperties.forEach(({ name }) => {
+        const staticKey = `Ac/L1/${name}`
+        delete ifaceDesc.properties[staticKey]
+        delete iface[staticKey]
+      })
+    }
+  }
+
   for (let i = 1; i <= iface.NrOfPhases; i++) {
-    const phase = `L${i}`
+    const phase = `L${resolvePhase(config, i)}`
     phaseProperties.forEach(({ name, unit, persist }) => {
       const key = `Ac/${phase}/${name}`
       const propDef = {
@@ -92,9 +116,10 @@ function onPropertiesChanged ({ changes, instance, config }) {
   let phaseTotal = 0
 
   for (let i = 1; i <= nrOfPhases; i++) {
-    const powerKey = `Ac/L${i}/Power`
-    const energyKey = `Ac/L${i}/Energy/Forward`
-    const tsKey = `_lastL${i}PowerTimestamp`
+    const phase = resolvePhase(config, i)
+    const powerKey = `Ac/L${phase}/Power`
+    const energyKey = `Ac/L${phase}/Energy/Forward`
+    const tsKey = `_lastL${phase}PowerTimestamp`
     if (powerKey in changes) {
       accumulateDelta({ changes, instance, energyKey, oldPower: instance[powerKey], lastTs: instance[tsKey], now })
       instance[tsKey] = now

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -13,7 +13,14 @@ const properties = {
   'Ac/L1/Voltage': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '' },
   'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
   'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'Hz' : '' },
-  Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
+  Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 },
+  Position: {
+    type: 'i',
+    format: (v) => ({
+      0: 'AC output',
+      1: 'AC input'
+    }[v] || 'unknown')
+  }
 }
 
 const phaseProperties = [
@@ -41,6 +48,7 @@ const S2_RESOURCE_DEFAULTS = {
 }
 
 function initialize (config, ifaceDesc, iface, node) {
+  iface.Position = Number(config.acload_position ?? 0)
   iface.NrOfPhases = Number(config.acload_nrofphases ?? 1)
   for (let i = 1; i <= iface.NrOfPhases; i++) {
     const phase = `L${i}`

--- a/src/nodes/victron-virtual/device-type/energymeter.js
+++ b/src/nodes/victron-virtual/device-type/energymeter.js
@@ -11,6 +11,13 @@ const ROLE_TO_SERVICE_TYPE = {
   heatpump: 'heatpump'
 }
 
+// Position is only meaningfully configurable for these roles: 0=AC output, 1=AC input.
+// - gridmeter/generator (grid/genset) stay fixed at 0 per the Venus OS dbus spec, "1=AC input" is
+//   only valid for acload.
+// - inverter (pvinverter) uses a different 3-value Position enum and is handled by the dedicated
+//   pvinverter device type; left untouched here for now.
+const POSITION_CONFIGURABLE_ROLES = ['acload', 'evcharger', 'heatpump']
+
 const sharedProperties = {
   'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
   'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
@@ -54,6 +61,9 @@ const phaseProperties = [
 ]
 
 function initialize (config, ifaceDesc, iface, node) {
+  if (POSITION_CONFIGURABLE_ROLES.includes(config.energymeter_role)) {
+    iface.Position = Number(config.energymeter_position ?? 0)
+  }
   iface.NrOfPhases = Number(config.energymeter_nrofphases ?? 1)
   for (let i = 1; i <= iface.NrOfPhases; i++) {
     const phase = `L${i}`

--- a/src/nodes/victron-virtual/device-type/energymeter.js
+++ b/src/nodes/victron-virtual/device-type/energymeter.js
@@ -11,7 +11,8 @@ const ROLE_TO_SERVICE_TYPE = {
   heatpump: 'heatpump'
 }
 
-// Position is only meaningfully configurable for these roles: 0=AC output, 1=AC input.
+// Position (0=AC output, 1=AC input) and, for single-phase configs, PhaseSetting (which physical
+// phase it's wired to) are only meaningfully configurable for these roles.
 // - gridmeter/generator (grid/genset) stay fixed at 0 per the Venus OS dbus spec, "1=AC input" is
 //   only valid for acload.
 // - inverter (pvinverter) uses a different 3-value Position enum and is handled by the dedicated
@@ -61,12 +62,22 @@ const phaseProperties = [
 ]
 
 function initialize (config, ifaceDesc, iface, node) {
-  if (POSITION_CONFIGURABLE_ROLES.includes(config.energymeter_role)) {
+  const isPositionConfigurableRole = POSITION_CONFIGURABLE_ROLES.includes(config.energymeter_role)
+  if (isPositionConfigurableRole) {
     iface.Position = Number(config.energymeter_position ?? 0)
   }
   iface.NrOfPhases = Number(config.energymeter_nrofphases ?? 1)
+
+  const isSinglePhase = iface.NrOfPhases === 1
+  let singlePhaseNumber = 1
+  if (isSinglePhase && isPositionConfigurableRole) {
+    singlePhaseNumber = Number(config.energymeter_phasesetting ?? 1)
+    iface.PhaseSetting = singlePhaseNumber
+    ifaceDesc.properties.PhaseSetting = { type: 'i', format: (v) => v != null ? 'L' + v : '' }
+  }
+
   for (let i = 1; i <= iface.NrOfPhases; i++) {
-    const phase = `L${i}`
+    const phase = `L${isSinglePhase ? singlePhaseNumber : i}`
     phaseProperties.forEach(({ name, unit, persist }) => {
       const key = `Ac/${phase}/${name}`
       const propDef = {

--- a/src/nodes/victron-virtual/device-type/energymeter.js
+++ b/src/nodes/victron-virtual/device-type/energymeter.js
@@ -15,8 +15,10 @@ const ROLE_TO_SERVICE_TYPE = {
 // phase it's wired to) are only meaningfully configurable for these roles.
 // - gridmeter/generator (grid/genset) stay fixed at 0 per the Venus OS dbus spec, "1=AC input" is
 //   only valid for acload.
-// - inverter (pvinverter) uses a different 3-value Position enum and is handled by the dedicated
-//   pvinverter device type; left untouched here for now.
+// - inverter (pvinverter) is intentionally excluded: buildProperties()'s "default" case below still
+//   gives it a Position property, but with this module's generic 2-value output/input format, not
+//   pvinverter's real 3-value enum (0=AC input 1, 1=AC output, 2=AC input 2, see the dedicated
+//   pvinverter device type). That mismatch predates this change and is left as-is for now.
 const POSITION_CONFIGURABLE_ROLES = ['acload', 'evcharger', 'heatpump']
 
 const sharedProperties = {

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -165,6 +165,15 @@
         "name": "{line} Voltage (V AC)"
       },
       {
+        "path": "/Position",
+        "type": "enum",
+        "name": "Position",
+        "enum": {
+          "0": "AC output",
+          "1": "AC input"
+        }
+      },
+      {
         "path": "/Serial",
         "type": "string",
         "name": "Serial number"

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -165,6 +165,21 @@
         "name": "{line} Voltage (V AC)"
       },
       {
+        "path": "/IsGenericEnergyMeter",
+        "type": "integer",
+        "name": "Is generic energy meter"
+      },
+      {
+        "path": "/PhaseSetting",
+        "type": "enum",
+        "name": "Phase",
+        "enum": {
+          "1": "L1",
+          "2": "L2",
+          "3": "L3"
+        }
+      },
+      {
         "path": "/Position",
         "type": "enum",
         "name": "Position",

--- a/test/victron-virtual-acload.test.js
+++ b/test/victron-virtual-acload.test.js
@@ -141,6 +141,20 @@ describe('acload device module', () => {
       expect(result['Ac/Energy/Forward']).toBeCloseTo(1.3 + 2.0 + 3.0, 2)
     })
 
+    test('accumulates energy on the relabeled phase for a single-phase config with acload_phasesetting', () => {
+      const instance = { 'Ac/L3/Power': 500 }
+      instance._lastL3PowerTimestamp = Date.now() - 3_600_000
+
+      const result = acload.onPropertiesChanged({
+        changes: { 'Ac/L3/Power': 500 },
+        instance,
+        config: { acload_auto_energy: true, acload_nrofphases: 1, acload_phasesetting: 3 }
+      })
+      // 500 W for 1 h = 0.5 kWh
+      expect(result['Ac/L3/Energy/Forward']).toBeCloseTo(0.5, 2)
+      expect(result['Ac/L1/Energy/Forward']).toBeUndefined()
+    })
+
     test('does not accumulate phase energy beyond configured nrOfPhases', () => {
       const instance = { 'Ac/L3/Power': 500 }
       instance._lastL3PowerTimestamp = Date.now() - 3_600_000

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -47,6 +47,18 @@ describe('acload', () => {
       expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
     })
 
+    test('sets Position from config', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 1, acload_position: 1 }, ifaceDesc, iface, node)
+      expect(iface.Position).toBe(1)
+    })
+
+    test('defaults Position to 0 when not set', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 1 }, ifaceDesc, iface, node)
+      expect(iface.Position).toBe(0)
+    })
+
     test('sets default values when enabled', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       acload.initialize({ acload_nrofphases: 1, default_values: true }, ifaceDesc, iface, node)
@@ -161,6 +173,16 @@ describe('acload', () => {
       expect(node.send).toHaveBeenCalledWith([null, {
         payload: { command: 'Disconnect', cemId: 'cem-1' }
       }])
+    })
+  })
+
+  describe('format', () => {
+    test.each([
+      [0, 'AC output'],
+      [1, 'AC input'],
+      [99, 'unknown']
+    ])('Position %i -> %s', (v, expected) => {
+      expect(acload.properties.Position.format(v)).toBe(expected)
     })
   })
 })

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -47,6 +47,47 @@ describe('acload', () => {
       expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
     })
 
+    test('labels single-phase properties with the configured PhaseSetting', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 1, acload_phasesetting: 3 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
+      expect(iface['Ac/L3/Current']).toBe(0)
+      expect(iface.PhaseSetting).toBe(3)
+    })
+
+    test('defaults PhaseSetting to 1 (L1) when not set', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 1 }, ifaceDesc, iface, node)
+      expect(iface.PhaseSetting).toBe(1)
+      expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
+    })
+
+    test('removes the stale static L1 property set when relabeled to a different phase', () => {
+      const { iface, node } = makeFixtures()
+      const ifaceDesc = { properties: { 'Ac/L1/Current': { type: 'd' }, 'Ac/L1/Power': { type: 'd' } } }
+      iface['Ac/L1/Current'] = 0
+
+      acload.initialize({ acload_nrofphases: 1, acload_phasesetting: 2 }, ifaceDesc, iface, node)
+
+      expect(ifaceDesc.properties['Ac/L1/Current']).toBeUndefined()
+      expect(iface['Ac/L1/Current']).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/L2/Current']).toBeDefined()
+    })
+
+    test('does not add PhaseSetting for multi-phase configs, and phases are labeled L1-L3 in order', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      acload.initialize({ acload_nrofphases: 3, acload_phasesetting: 2 }, ifaceDesc, iface, node)
+      expect(iface.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.properties.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Current']).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
+    })
+
+    test('static properties declare IsGenericEnergyMeter as 1', () => {
+      expect(acload.properties.IsGenericEnergyMeter.value).toBe(1)
+    })
+
     test('sets Position from config', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       acload.initialize({ acload_nrofphases: 1, acload_position: 1 }, ifaceDesc, iface, node)
@@ -1169,6 +1210,39 @@ describe('energymeter', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       energymeter.initialize({ energymeter_role: role, energymeter_position: 1 }, ifaceDesc, iface, node)
       expect(iface.Position).toBeUndefined()
+    })
+
+    it.each(['acload', 'evcharger', 'heatpump'])('labels single-phase properties with the configured phasesetting for role "%s"', (role) => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_role: role, energymeter_nrofphases: 1, energymeter_phasesetting: 3 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L1/Current']).toBeUndefined()
+      expect(iface.PhaseSetting).toBe(3)
+    })
+
+    it.each(['acload', 'evcharger', 'heatpump'])('defaults phasesetting to 1 (L1) for role "%s" when not set', (role) => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_role: role, energymeter_nrofphases: 1 }, ifaceDesc, iface, node)
+      expect(iface.PhaseSetting).toBe(1)
+      expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
+    })
+
+    it.each(['gridmeter', 'generator', 'inverter'])('ignores energymeter_phasesetting for role "%s"', (role) => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_role: role, energymeter_nrofphases: 1, energymeter_phasesetting: 3 }, ifaceDesc, iface, node)
+      expect(iface.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.properties.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
+    })
+
+    it('does not add PhaseSetting for multi-phase acload role', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_role: 'acload', energymeter_nrofphases: 3, energymeter_phasesetting: 2 }, ifaceDesc, iface, node)
+      expect(iface.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.properties.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Current']).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
     })
   })
 })

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -1152,5 +1152,23 @@ describe('energymeter', () => {
       expect(ifaceDesc.properties['Ac/L2/Energy/Forward'].persist).toBeDefined()
       expect(ifaceDesc.properties['Ac/L2/Energy/Reverse'].persist).toBeDefined()
     })
+
+    it.each(['acload', 'evcharger', 'heatpump'])('sets Position from config for role "%s"', (role) => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_role: role, energymeter_position: 1 }, ifaceDesc, iface, node)
+      expect(iface.Position).toBe(1)
+    })
+
+    it.each(['acload', 'evcharger', 'heatpump'])('defaults Position to 0 for role "%s" when not set', (role) => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_role: role }, ifaceDesc, iface, node)
+      expect(iface.Position).toBe(0)
+    })
+
+    it.each(['gridmeter', 'generator', 'inverter'])('ignores energymeter_position for role "%s"', (role) => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      energymeter.initialize({ energymeter_role: role, energymeter_position: 1 }, ifaceDesc, iface, node)
+      expect(iface.Position).toBeUndefined()
+    })
   })
 })

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -244,6 +244,58 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockBatteryRow.toggle).toHaveBeenCalledWith(true)
     })
 
+    test('shows energymeter Position row for a role where it is configurable', () => {
+      const mockRoleSelect = createMockElement({ val: 'acload' })
+      const mockPositionRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'energymeter' })
+        }
+        if (selector === '#node-input-energymeter_role') {
+          return mockRoleSelect
+        }
+        if (selector === '#energymeter-position-row') {
+          return mockPositionRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockRoleSelect.off).toHaveBeenCalledWith('change.energymeter-position')
+      expect(mockRoleSelect.on).toHaveBeenCalledWith('change.energymeter-position', expect.any(Function))
+      expect(mockPositionRow.toggle).toHaveBeenCalledWith(true)
+    })
+
+    test('hides energymeter Position row for a role where it is fixed', () => {
+      const mockRoleSelect = createMockElement({ val: 'gridmeter' })
+      const mockPositionRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'energymeter' })
+        }
+        if (selector === '#node-input-energymeter_role') {
+          return mockRoleSelect
+        }
+        if (selector === '#energymeter-position-row') {
+          return mockPositionRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockPositionRow.toggle).toHaveBeenCalledWith(false)
+    })
+
     test('handles generator device selection', () => {
       const mockDCElements = createMockElement()
       const mockACElements = createMockElement()

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -32,8 +32,45 @@ function createMockElement (customValues = {}) {
     remove: jest.fn().mockReturnThis(),
     closest: jest.fn().mockReturnThis(),
     after: jest.fn().mockReturnThis(),
+    find: jest.fn().mockReturnValue({ each: jest.fn().mockReturnThis() }),
     length: customValues.length !== undefined ? customValues.length : 1,
     0: mockDOMElement
+  }
+}
+
+// Builds a mock for #node-input-s2_measurement_type that behaves closely enough to a real jQuery
+// <select> for updateAcloadS2MeasurementOptions(): .val() acts as getter/setter, and
+// .find('option').each(fn) invokes fn with `this` bound to a stand-in option element that the
+// test's global.$ mock must route back to wrapMockS2Option() (see usages below).
+const S2_MEASUREMENT_OPTION_VALUES = ['3_PHASE_SYMMETRIC', 'L1_L2_L3', 'L1', 'L2', 'L3']
+
+function createMockS2MeasurementSelect (initialValue) {
+  let currentValue = initialValue
+  const toggleCallsByValue = {}
+  S2_MEASUREMENT_OPTION_VALUES.forEach((v) => { toggleCallsByValue[v] = [] })
+  const optionElements = S2_MEASUREMENT_OPTION_VALUES.map((value) => ({ __mockOptionValue: value }))
+
+  const mockS2Select = {
+    val: jest.fn((newValue) => {
+      if (newValue === undefined) return currentValue
+      currentValue = newValue
+      return mockS2Select
+    }),
+    find: jest.fn().mockReturnValue({
+      each: jest.fn((fn) => {
+        optionElements.forEach((el) => fn.call(el))
+      })
+    })
+  }
+
+  return { mockS2Select, toggleCallsByValue }
+}
+
+function wrapMockS2Option (element, toggleCallsByValue) {
+  const value = element.__mockOptionValue
+  return {
+    val: jest.fn().mockReturnValue(value),
+    toggle: jest.fn((visible) => { toggleCallsByValue[value].push(visible) })
   }
 }
 
@@ -269,6 +306,127 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockNrOfPhasesSelect.off).toHaveBeenCalledWith('change.acload-phasesetting')
       expect(mockNrOfPhasesSelect.on).toHaveBeenCalledWith('change.acload-phasesetting', expect.any(Function))
       expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
+    })
+
+    test('filters S2 Measurement to 3-phase-symmetric and the matching single phase, auto-syncing an out-of-date single-phase selection', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingSelect = createMockElement({ val: '2' })
+      const mockPhaseSettingRow = createMockElement()
+      const { mockS2Select, toggleCallsByValue } = createMockS2MeasurementSelect('L1')
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '#node-input-acload_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#node-input-acload_phasesetting') {
+          return mockPhaseSettingSelect
+        }
+        if (selector === '#acload-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector === '#node-input-s2_measurement_type') {
+          return mockS2Select
+        }
+        if (typeof selector === 'object') {
+          return wrapMockS2Option(selector, toggleCallsByValue)
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      // Per-phase reporting and the two non-matching single-phase options are hidden; the total
+      // (3-phase symmetric) and the phase actually wired (L2) stay visible.
+      expect(toggleCallsByValue['3_PHASE_SYMMETRIC']).toEqual([true])
+      expect(toggleCallsByValue.L1_L2_L3).toEqual([false])
+      expect(toggleCallsByValue.L1).toEqual([false])
+      expect(toggleCallsByValue.L2).toEqual([true])
+      expect(toggleCallsByValue.L3).toEqual([false])
+      // The previously-selected "Single phase L1" no longer matches Phase=L2, so it's auto-synced.
+      expect(mockS2Select.val()).toBe('L2')
+    })
+
+    test('leaves 3-phase-symmetric S2 Measurement selection untouched for a single-phase config', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingSelect = createMockElement({ val: '2' })
+      const mockPhaseSettingRow = createMockElement()
+      const { mockS2Select, toggleCallsByValue } = createMockS2MeasurementSelect('3_PHASE_SYMMETRIC')
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '#node-input-acload_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#node-input-acload_phasesetting') {
+          return mockPhaseSettingSelect
+        }
+        if (selector === '#acload-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector === '#node-input-s2_measurement_type') {
+          return mockS2Select
+        }
+        if (typeof selector === 'object') {
+          return wrapMockS2Option(selector, toggleCallsByValue)
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockS2Select.val()).toBe('3_PHASE_SYMMETRIC')
+    })
+
+    test('does not filter S2 Measurement options for a multi-phase config', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '3' })
+      const mockPhaseSettingSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingRow = createMockElement()
+      const { mockS2Select, toggleCallsByValue } = createMockS2MeasurementSelect('L1')
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '#node-input-acload_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#node-input-acload_phasesetting') {
+          return mockPhaseSettingSelect
+        }
+        if (selector === '#acload-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector === '#node-input-s2_measurement_type') {
+          return mockS2Select
+        }
+        if (typeof selector === 'object') {
+          return wrapMockS2Option(selector, toggleCallsByValue)
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(toggleCallsByValue['3_PHASE_SYMMETRIC']).toEqual([true])
+      expect(toggleCallsByValue.L1_L2_L3).toEqual([true])
+      expect(toggleCallsByValue.L1).toEqual([true])
+      expect(toggleCallsByValue.L2).toEqual([true])
+      expect(toggleCallsByValue.L3).toEqual([true])
+      expect(mockS2Select.val()).toBe('L1')
     })
 
     test('hides acload PhaseSetting row for a multi-phase config', () => {

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -244,6 +244,58 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockBatteryRow.toggle).toHaveBeenCalledWith(true)
     })
 
+    test('shows acload PhaseSetting row for a 1-phase config', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '#node-input-acload_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#acload-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockNrOfPhasesSelect.off).toHaveBeenCalledWith('change.acload-phasesetting')
+      expect(mockNrOfPhasesSelect.on).toHaveBeenCalledWith('change.acload-phasesetting', expect.any(Function))
+      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
+    })
+
+    test('hides acload PhaseSetting row for a multi-phase config', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '3' })
+      const mockPhaseSettingRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '#node-input-acload_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#acload-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
+    })
+
     test('shows energymeter Position row for a role where it is configurable', () => {
       const mockRoleSelect = createMockElement({ val: 'acload' })
       const mockPositionRow = createMockElement()
@@ -294,6 +346,93 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       checkSelectedVirtualDevice()
 
       expect(mockPositionRow.toggle).toHaveBeenCalledWith(false)
+    })
+
+    test('shows energymeter PhaseSetting row for a configurable role with 1 phase', () => {
+      const mockRoleSelect = createMockElement({ val: 'acload' })
+      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'energymeter' })
+        }
+        if (selector === '#node-input-energymeter_role') {
+          return mockRoleSelect
+        }
+        if (selector === '#node-input-energymeter_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#energymeter-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
+    })
+
+    test('hides energymeter PhaseSetting row for a configurable role with 3 phases', () => {
+      const mockRoleSelect = createMockElement({ val: 'acload' })
+      const mockNrOfPhasesSelect = createMockElement({ val: '3' })
+      const mockPhaseSettingRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'energymeter' })
+        }
+        if (selector === '#node-input-energymeter_role') {
+          return mockRoleSelect
+        }
+        if (selector === '#node-input-energymeter_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#energymeter-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
+    })
+
+    test('hides energymeter PhaseSetting row for a role where Position is not configurable', () => {
+      const mockRoleSelect = createMockElement({ val: 'gridmeter' })
+      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'energymeter' })
+        }
+        if (selector === '#node-input-energymeter_role') {
+          return mockRoleSelect
+        }
+        if (selector === '#node-input-energymeter_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#energymeter-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
     })
 
     test('handles generator device selection', () => {


### PR DESCRIPTION
Adds `/Position` (0=AC output, 1=AC input) to the virtual AC load device and the regular acload node, configurable from the edit dialog. Also adds `/PhaseSetting` for single-phase configs, so `/Ac/L[X]/*` reflects the phase the load is actually wired to instead of always defaulting to L1, plus /IsGenericEnergyMeter=1 to match real driver behavior (e.g. dbus-shelly).

The same `Position/PhaseSetting` support is extended to the energy meter device type's acload/evcharger/heatpump roles for consistency.