### PR TITLE
fix(virtual-switch): respect httpNodeRoot for the switch name/group cache lookup (#471)

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1795,12 +1795,12 @@
 	    .then(response => response.json())
 	}
 
-	function fetchSwitchNodeNameAndGroupFromCache (id) {
+	function fetchSwitchNodeNameAndGroupFromCache (id, baseUrl) {
 	  if (!id) {
 	    return Promise.reject(new Error('id is required'))
 	  }
 
-	  return fetch(`/victron/cache?filter_by_serial=${id}`)
+	  return fetch(`${baseUrl || ''}/victron/cache?filter_by_serial=${id}`)
 	    .then(response => response.json())
 	    .then(data => {
 	      for (const key in data) {

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1004,12 +1004,12 @@ export function fetchDeviceCapabilities (baseUrl) {
     .then(response => response.json())
 }
 
-export function fetchSwitchNodeNameAndGroupFromCache (id) {
+export function fetchSwitchNodeNameAndGroupFromCache (id, baseUrl) {
   if (!id) {
     return Promise.reject(new Error('id is required'))
   }
 
-  return fetch(`/victron/cache?filter_by_serial=${id}`)
+  return fetch(`${baseUrl || ''}/victron/cache?filter_by_serial=${id}`)
     .then(response => response.json())
     .then(data => {
       for (const key in data) {

--- a/src/nodes/victron-virtual-switch.html
+++ b/src/nodes/victron-virtual-switch.html
@@ -97,7 +97,8 @@
                 initializeTooltips();
             }
 
-            fetchSwitchNodeNameAndGroupFromCache(this.id).then(({name, group}) => {
+            const baseUrl = (RED.settings.httpNodeRoot || RED.settings.httpAdminRoot || "").replace(/\/$/, "");
+            fetchSwitchNodeNameAndGroupFromCache(this.id, baseUrl).then(({name, group}) => {
                 if (name) {
                     $(`#node-input-switch_1_customname`).val(name);
                 }

--- a/test/victron-virtual-functions.switch.test.js
+++ b/test/victron-virtual-functions.switch.test.js
@@ -96,6 +96,60 @@ describe('fetchSwitchNodeNameAndGroupFromCache', () => {
       expect(e.message).toBeDefined()
     }
   })
+
+  // Regression coverage for #471.
+  //
+  // The /victron/cache endpoint is registered on RED.httpNode (see config-client.js), so
+  // when the user configures an httpNodeRoot (e.g. '/local-dev') Node-RED serves it at
+  // '/local-dev/victron/cache' - NOT at '/victron/cache'. The original code fetched the
+  // bare '/victron/cache', which 404s and returns Node-RED's HTML error page; calling
+  // response.json() on that HTML throws "SyntaxError: Unexpected token '<'" - the exact
+  // error reported in #471. The fix threads the editor's httpNodeRoot base URL through the
+  // request, matching the sibling fetchEvChargers()/fetchDeviceCapabilities() helpers.
+  describe('#471 - respects httpNodeRoot when requesting the cache', () => {
+    // A real node id from the bug report, to keep the reproduction concrete.
+    const NODE_ID = '2cdd7d25339e162f'
+
+    function mockCacheResponse (body) {
+      global.fetch = jest.fn(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(body)
+      }))
+    }
+
+    test('SOLVES #471: prefixes the httpNodeRoot base URL so the request reaches the real endpoint', async () => {
+      mockCacheResponse({})
+
+      await fetchSwitchNodeNameAndGroupFromCache(NODE_ID, '/local-dev')
+
+      // Requests the path where httpNodeRoot actually serves the endpoint...
+      expect(global.fetch).toHaveBeenCalledWith(`/local-dev/victron/cache?filter_by_serial=${NODE_ID}`)
+      // ...and never the bare path that 404s once httpNodeRoot is non-default.
+      expect(global.fetch).not.toHaveBeenCalledWith(`/victron/cache?filter_by_serial=${NODE_ID}`)
+    })
+
+    test('default httpNodeRoot: with no base URL, keeps the root-relative path (unchanged behaviour)', async () => {
+      mockCacheResponse({})
+
+      await fetchSwitchNodeNameAndGroupFromCache(NODE_ID)
+
+      expect(global.fetch).toHaveBeenCalledWith(`/victron/cache?filter_by_serial=${NODE_ID}`)
+    })
+
+    test('RECREATES #471: a 404 HTML response (the pre-fix symptom) rejects the lookup', async () => {
+      // Before the fix, the un-prefixed request 404'd and returned Node-RED's HTML error
+      // page; response.json() on HTML rejects with a SyntaxError, which surfaced as the
+      // console error in the bug report. Assert that failure path explicitly.
+      global.fetch = jest.fn(() => Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.reject(new SyntaxError("Unexpected token '<'"))
+      }))
+
+      await expect(fetchSwitchNodeNameAndGroupFromCache(NODE_ID, '/local-dev'))
+        .rejects.toThrow(/Unexpected token '<'/)
+    })
+  })
 })
 
 describe('Switch Configuration Tests', () => {


### PR DESCRIPTION
## Problem
If you set `httpNodeRoot` in Node-RED, opening a deployed Virtual Switch node
shows an error in the browser console:

    GET .../victron/cache?filter_by_serial=… 404 (Not Found)
    Error fetching name and group from cache for switch node:
      SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON

The switch node asks for `/victron/cache`, but that path is wrong when
`httpNodeRoot` is set. The cache route is added to `RED.httpNode`, so Node-RED
serves it under `httpNodeRoot` (for example `/local-dev/victron/cache`). The old
code left the prefix off, so the request hit the wrong path and got a 404. The
404 page is HTML, and the code then tried to read that HTML as JSON, which is
what throws the error.

Two other functions in the same file (`fetchEvChargers` and
`fetchDeviceCapabilities`) already add the prefix. This one did not.

## Fix
Add the `httpNodeRoot` prefix to the request, the same way those two functions
do. It is one line in the function and one line in the caller
(`victron-virtual-switch.html`).

## Tests
Added tests to `victron-virtual-functions.switch.test.js`:
- The request now includes the prefix, and never uses the old wrong path.
- With no prefix set, the path stays the same as before (nothing else changes).
- A 404 HTML response still produces the same error from the bug report, so the
  failure is covered.

`npm test` passes (1151 tests).

## Verified
Tested on a local Node-RED with `httpNodeRoot: '/local-dev/'`.

Before — the request goes to the wrong path and fails:

<img width="2000" height="270" alt="image-1787362700056" src="https://github.com/user-attachments/assets/b5bebb5d-bdb4-4979-982f-6c1f75bc6fa2" />


After — the request goes to the correct path and reaches the endpoint:

    GET /local-dev/victron/cache?filter_by_serial=…  ->  reaches the endpoint

(This test machine has no GX connected, so the endpoint returns 503. A real GX
returns the cache as JSON.)

Fixes #471
