### PR TITLE
feat(virtual): streamline meter device selection, retire Energy meter picker

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1922,8 +1922,9 @@
 	  };
 
 	  const updatePhaseSetting = () => {
+	    const gridMeterOnly = $(`#node-input-${prefix}_grid_meter_only`).is(':checked');
 	    const isSinglePhase = $(`#node-input-${prefix}_nrofphases`).val() === '1';
-	    $(`#${prefix}-phasesetting-row`).toggle(isSinglePhase);
+	    $(`#${prefix}-phasesetting-row`).toggle(isSinglePhase && !gridMeterOnly);
 	    updateS2MeasurementOptions(isSinglePhase);
 	  };
 	  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', updatePhaseSetting);
@@ -1949,6 +1950,8 @@
 	      return
 	    }
 
+	    $(`#node-input-${prefix}_position`).closest('.form-row').toggle(!gridMeterOnly);
+	    $(`#node-input-${prefix}_nrofphases`).trigger('change.phasesetting');
 	    $(`#node-input-${prefix}_auto_energy`).closest('.form-row').toggle(!gridMeterOnly);
 	    if (gridMeterOnly) {
 	      $('.input-s2support').hide();

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1376,6 +1376,62 @@
   `,
 	    img: null
 	  },
+	  heatpump: {
+	    label: 'Heat pump',
+	    text: `
+    ${INPUT_DOCS}
+    <div>
+      <div><strong>Most relevant paths:</strong>
+        <ul>
+          <li><code>/Ac/{line}/Power</code> &mdash; Power per phase in watts, where <code>{line}</code> is <code>L1</code>, <code>L2</code>, or <code>L3</code>.</li>
+          <li><code>/Ac/{line}/Voltage</code> &mdash; Voltage per phase in volts.</li>
+          <li><code>/Ac/{line}/Current</code> &mdash; Current per phase in amperes.</li>
+          <li><code>/Ac/{line}/Energy/Forward</code> &mdash; Energy consumed per phase in kWh.</li>
+          <li><code>/Ac/Frequency</code> &mdash; AC frequency in Hz.</li>
+          <li><code>/Ac/PowerFactor</code> &mdash; Overall power factor.</li>
+          <li><code>/Ac/{line}/PowerFactor</code> &mdash; Power factor per phase.</li>
+        </ul>
+        <p>For more information on available paths, see the <a href="https://github.com/victronenergy/venus/wiki/dbus" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS dbus specification</a>.</p>
+      </div>
+    </div>
+    <div>
+      <div><strong>Output:</strong>
+        <ol>
+          <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
+        </ol>
+      </div>
+    </div>
+  `,
+	    img: null
+	  },
+	  evcs: {
+	    label: 'EV charger',
+	    text: `
+    ${INPUT_DOCS}
+    <div>
+      <div><strong>Most relevant paths:</strong>
+        <ul>
+          <li><code>/Ac/Power</code> &mdash; Total AC power in watts.</li>
+          <li><code>/Ac/{line}/Power</code> &mdash; Power per phase in watts, where <code>{line}</code> is <code>L1</code>, <code>L2</code>, or <code>L3</code>.</li>
+          <li><code>/Ac/{line}/Voltage</code> &mdash; Voltage per phase in volts.</li>
+          <li><code>/Ac/{line}/Current</code> &mdash; Current per phase in amperes.</li>
+          <li><code>/Ac/{line}/Energy/Forward</code> &mdash; Energy consumed per phase in kWh.</li>
+          <li><code>/Ac/Frequency</code> &mdash; AC frequency in Hz.</li>
+        </ul>
+        <p>Measurement-only - does not simulate a full EVSE (no charging session or connector state). Registers as <code>com.victronenergy.evcharger</code>.</p>
+        <p>For more information on available paths, see the <a href="https://github.com/victronenergy/venus/wiki/dbus" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS dbus specification</a>.</p>
+      </div>
+    </div>
+    <div>
+      <div><strong>Output:</strong>
+        <ol>
+          <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
+        </ol>
+      </div>
+    </div>
+  `,
+	    img: null
+	  },
 	  pulsemeter: {
 	    label: 'Pulse meter',
 	    text: `
@@ -1842,14 +1898,75 @@
 	  $('#battery-voltage-custom-label').toggle(preset === 'custom');
 	}
 
-	// Mirrors POSITION_CONFIGURABLE_ROLES in src/nodes/victron-virtual/device-type/energymeter.js -
-	// gates both the Position and (for single-phase configs) PhaseSetting rows.
-	const ENERGYMETER_POSITION_CONFIGURABLE_ROLES = ['acload', 'evcharger', 'heatpump'];
+	// Keeps the S2 Measurement dropdown consistent with the device's actual phase(s): for a
+	// single-phase config, only "3-phase symmetric" (reads the Ac/Power total) and the single
+	// phase option matching the configured Phase are valid - the other single-phase options and
+	// "Per phase" would read an Ac/L{n}/Power path that doesn't exist on the device. Shared by
+	// acload and heatpump, which have identical phase/position config shapes.
+	function updatePhaseSettingVisibility (prefix) {
+	  const updateS2MeasurementOptions = (isSinglePhase) => {
+	    const phaseSetting = $(`#node-input-${prefix}_phasesetting`).val();
+	    const matchingSingleValue = 'L' + phaseSetting;
+	    const $select = $('#node-input-s2_measurement_type');
+
+	    $select.find('option').each(function () {
+	      const val = $(this).val();
+	      const isPerPhaseOption = val === 'L1_L2_L3';
+	      const isMismatchedSinglePhaseOption = ['L1', 'L2', 'L3'].includes(val) && val !== matchingSingleValue;
+	      $(this).toggle(!isSinglePhase || (!isPerPhaseOption && !isMismatchedSinglePhaseOption));
+	    });
+
+	    if (isSinglePhase && ['L1', 'L2', 'L3'].includes($select.val()) && $select.val() !== matchingSingleValue) {
+	      $select.val(matchingSingleValue);
+	    }
+	  };
+
+	  const updatePhaseSetting = () => {
+	    const isSinglePhase = $(`#node-input-${prefix}_nrofphases`).val() === '1';
+	    $(`#${prefix}-phasesetting-row`).toggle(isSinglePhase);
+	    updateS2MeasurementOptions(isSinglePhase);
+	  };
+	  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', updatePhaseSetting);
+	  $(`#node-input-${prefix}_phasesetting`).off('change.s2measurement').on('change.s2measurement', () => {
+	    updateS2MeasurementOptions($(`#node-input-${prefix}_nrofphases`).val() === '1');
+	  });
+	  updatePhaseSetting();
+	}
+
+	// AC Load, Heat pump, and Generator can optionally present as a plain measurement-only "grid
+	// meter" shape (still under their own dbus service type - see minimal-meter.js). When checked,
+	// hide the options that don't apply to that minimal shape: S2 support for acload/heatpump,
+	// engine/starter monitoring for generator.
+	function updateGridMeterOnlyVisibility (prefix) {
+	  const $checkbox = $(`#node-input-${prefix}_grid_meter_only`);
+
+	  const apply = () => {
+	    const gridMeterOnly = $checkbox.is(':checked');
+
+	    if (prefix === 'generator') {
+	      $('#node-input-include_engine_hours').closest('.form-row').toggle(!gridMeterOnly);
+	      $('#node-input-include_starter_voltage').closest('.form-row').toggle(!gridMeterOnly);
+	      return
+	    }
+
+	    $(`#node-input-${prefix}_auto_energy`).closest('.form-row').toggle(!gridMeterOnly);
+	    if (gridMeterOnly) {
+	      $('.input-s2support').hide();
+	      $('.input-s2support-measurement').hide();
+	    } else {
+	      $('.input-s2support').show();
+	      $('.input-s2support-measurement').toggle($('#node-input-enable_s2support').is(':checked'));
+	    }
+	  };
+
+	  $checkbox.off('change.grid-meter-only').on('change.grid-meter-only', apply);
+	  apply();
+	}
 
 	function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
 	  [
 	    'acload', 'battery', 'ev', 'generator', 'gps', 'grid', 'e-drive',
-	    'pvinverter', 'switch', 'tank', 'temperature', 'energymeter', 'pulsemeter'
+	    'pvinverter', 'switch', 'tank', 'temperature', 'heatpump', 'evcs', 'pulsemeter'
 	  ].forEach(x => { $('.input-' + x).hide(); });
 
 	  const selected = $('select#node-input-device').val();
@@ -1899,55 +2016,14 @@
 	    $('#pulsemeter-multiplier-row').toggle($('#node-input-auto_aggregate').is(':checked'));
 	  }
 
-	  if (selected === 'acload') {
-	    // Keeps the S2 Measurement dropdown consistent with the acload's actual phase(s): for a
-	    // single-phase config, only "3-phase symmetric" (reads the Ac/Power total) and the single
-	    // phase option matching the configured Phase are valid - the other single-phase options and
-	    // "Per phase" would read an Ac/L{n}/Power path that doesn't exist on the device.
-	    const updateAcloadS2MeasurementOptions = (isSinglePhase) => {
-	      const phaseSetting = $('#node-input-acload_phasesetting').val();
-	      const matchingSingleValue = 'L' + phaseSetting;
-	      const $select = $('#node-input-s2_measurement_type');
-
-	      $select.find('option').each(function () {
-	        const val = $(this).val();
-	        const isPerPhaseOption = val === 'L1_L2_L3';
-	        const isMismatchedSinglePhaseOption = ['L1', 'L2', 'L3'].includes(val) && val !== matchingSingleValue;
-	        $(this).toggle(!isSinglePhase || (!isPerPhaseOption && !isMismatchedSinglePhaseOption));
-	      });
-
-	      if (isSinglePhase && ['L1', 'L2', 'L3'].includes($select.val()) && $select.val() !== matchingSingleValue) {
-	        $select.val(matchingSingleValue);
-	      }
-	    };
-
-	    const updateAcloadPhaseSettingVisibility = () => {
-	      const isSinglePhase = $('#node-input-acload_nrofphases').val() === '1';
-	      $('#acload-phasesetting-row').toggle(isSinglePhase);
-	      updateAcloadS2MeasurementOptions(isSinglePhase);
-	    };
-	    $('#node-input-acload_nrofphases').off('change.acload-phasesetting').on('change.acload-phasesetting', updateAcloadPhaseSettingVisibility);
-	    $('#node-input-acload_phasesetting').off('change.acload-s2measurement').on('change.acload-s2measurement', () => {
-	      updateAcloadS2MeasurementOptions($('#node-input-acload_nrofphases').val() === '1');
-	    });
-	    updateAcloadPhaseSettingVisibility();
-	  }
-
-	  if (selected === 'energymeter') {
-	    const updateEnergymeterPositionVisibility = () => {
-	      const role = $('#node-input-energymeter_role').val();
-	      const nrOfPhases = $('#node-input-energymeter_nrofphases').val();
-	      const isConfigurableRole = ENERGYMETER_POSITION_CONFIGURABLE_ROLES.includes(role);
-	      $('#energymeter-position-row').toggle(isConfigurableRole);
-	      $('#energymeter-phasesetting-row').toggle(isConfigurableRole && nrOfPhases === '1');
-	    };
-	    $('#node-input-energymeter_role').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility);
-	    $('#node-input-energymeter_nrofphases').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility);
-	    updateEnergymeterPositionVisibility();
+	  if (selected === 'acload' || selected === 'heatpump') {
+	    updatePhaseSettingVisibility(selected);
+	    updateGridMeterOnlyVisibility(selected);
 	  }
 
 	  if (selected === 'generator') {
 	    checkGeneratorType();
+	    updateGridMeterOnlyVisibility('generator');
 	  }
 
 	  if (selected === 'gps') {

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1898,11 +1898,14 @@
 	  $('#battery-voltage-custom-label').toggle(preset === 'custom');
 	}
 
-	// Keeps the S2 Measurement dropdown consistent with the device's actual phase(s), so the
-	// phase info already given via Number of phases/Phase doesn't need re-confirming: a 1-phase
-	// config is locked to the single matching phase, a 3-phase config offers only "3-phase
-	// symmetric"/"Per phase" (no single-phase reading applies), split phase leaves all options
-	// open. Shared by acload and heatpump, which have identical phase/position config shapes.
+	// Keeps Position/Phase and the S2 Measurement dropdown consistent with the device's actual
+	// configuration for acload/heatpump: enabling S2 support is what promotes the device from a
+	// plain generic energy meter to its own full type, adding Position (and, for a 1-phase
+	// config, which phase it's wired to) - see acload.js/heatpump.js isFullDevice(). The S2
+	// Measurement dropdown mirrors Number of phases/Phase so that info doesn't need
+	// re-confirming: a 1-phase config is locked to the single matching phase, a 3-phase config
+	// offers only "3-phase symmetric"/"Per phase" (no single-phase reading applies), split phase
+	// leaves all options open.
 	function updatePhaseSettingVisibility (prefix) {
 	  const updateS2MeasurementOptions = (nrOfPhases) => {
 	    const phaseSetting = $(`#node-input-${prefix}_phasesetting`).val();
@@ -1929,45 +1932,31 @@
 	    }
 	  };
 
-	  const updatePhaseSetting = () => {
-	    const gridMeterOnly = $(`#node-input-${prefix}_grid_meter_only`).is(':checked');
+	  const update = () => {
+	    const isFull = $('#node-input-enable_s2support').is(':checked');
 	    const nrOfPhases = Number($(`#node-input-${prefix}_nrofphases`).val());
-	    $(`#${prefix}-phasesetting-row`).toggle(nrOfPhases === 1 && !gridMeterOnly);
+	    $(`#node-input-${prefix}_position`).closest('.form-row').toggle(isFull);
+	    $(`#${prefix}-phasesetting-row`).toggle(isFull && nrOfPhases === 1);
 	    updateS2MeasurementOptions(nrOfPhases);
 	  };
-	  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', updatePhaseSetting);
+	  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', update);
 	  $(`#node-input-${prefix}_phasesetting`).off('change.s2measurement').on('change.s2measurement', () => {
 	    updateS2MeasurementOptions(Number($(`#node-input-${prefix}_nrofphases`).val()));
 	  });
-	  updatePhaseSetting();
+	  $('#node-input-enable_s2support').off(`change.${prefix}-full`).on(`change.${prefix}-full`, update);
+	  update();
 	}
 
-	// AC Load, Heat pump, and Generator can optionally present as a plain measurement-only "grid
-	// meter" shape (still under their own dbus service type - see minimal-meter.js). When checked,
-	// hide the options that don't apply to that minimal shape: S2 support for acload/heatpump,
-	// engine/starter monitoring for generator.
+	// Generator (AC) can optionally present as a plain measurement-only "generic energy meter"
+	// shape, still under com.victronenergy.genset (see minimal-meter.js). When checked, hide the
+	// engine/starter monitoring options that don't apply to that minimal shape.
 	function updateGridMeterOnlyVisibility (prefix) {
 	  const $checkbox = $(`#node-input-${prefix}_grid_meter_only`);
 
 	  const apply = () => {
 	    const gridMeterOnly = $checkbox.is(':checked');
-
-	    if (prefix === 'generator') {
-	      $('#node-input-include_engine_hours').closest('.form-row').toggle(!gridMeterOnly);
-	      $('#node-input-include_starter_voltage').closest('.form-row').toggle(!gridMeterOnly);
-	      return
-	    }
-
-	    $(`#node-input-${prefix}_position`).closest('.form-row').toggle(!gridMeterOnly);
-	    $(`#node-input-${prefix}_nrofphases`).trigger('change.phasesetting');
-	    $(`#node-input-${prefix}_auto_energy`).closest('.form-row').toggle(!gridMeterOnly);
-	    if (gridMeterOnly) {
-	      $('.input-s2support').hide();
-	      $('.input-s2support-measurement').hide();
-	    } else {
-	      $('.input-s2support').show();
-	      $('.input-s2support-measurement').toggle($('#node-input-enable_s2support').is(':checked'));
-	    }
+	    $('#node-input-include_engine_hours').closest('.form-row').toggle(!gridMeterOnly);
+	    $('#node-input-include_starter_voltage').closest('.form-row').toggle(!gridMeterOnly);
 	  };
 
 	  $checkbox.off('change.grid-meter-only').on('change.grid-meter-only', apply);
@@ -2029,7 +2018,6 @@
 
 	  if (selected === 'acload' || selected === 'heatpump') {
 	    updatePhaseSettingVisibility(selected);
-	    updateGridMeterOnlyVisibility(selected);
 	  }
 
 	  if (selected === 'generator') {

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1898,38 +1898,46 @@
 	  $('#battery-voltage-custom-label').toggle(preset === 'custom');
 	}
 
-	// Keeps the S2 Measurement dropdown consistent with the device's actual phase(s): for a
-	// single-phase config, only "3-phase symmetric" (reads the Ac/Power total) and the single
-	// phase option matching the configured Phase are valid - the other single-phase options and
-	// "Per phase" would read an Ac/L{n}/Power path that doesn't exist on the device. Shared by
-	// acload and heatpump, which have identical phase/position config shapes.
+	// Keeps the S2 Measurement dropdown consistent with the device's actual phase(s), so the
+	// phase info already given via Number of phases/Phase doesn't need re-confirming: a 1-phase
+	// config is locked to the single matching phase, a 3-phase config offers only "3-phase
+	// symmetric"/"Per phase" (no single-phase reading applies), split phase leaves all options
+	// open. Shared by acload and heatpump, which have identical phase/position config shapes.
 	function updatePhaseSettingVisibility (prefix) {
-	  const updateS2MeasurementOptions = (isSinglePhase) => {
+	  const updateS2MeasurementOptions = (nrOfPhases) => {
 	    const phaseSetting = $(`#node-input-${prefix}_phasesetting`).val();
 	    const matchingSingleValue = 'L' + phaseSetting;
 	    const $select = $('#node-input-s2_measurement_type');
 
 	    $select.find('option').each(function () {
 	      const val = $(this).val();
+	      const isSymmetricOption = val === '3_PHASE_SYMMETRIC';
 	      const isPerPhaseOption = val === 'L1_L2_L3';
-	      const isMismatchedSinglePhaseOption = ['L1', 'L2', 'L3'].includes(val) && val !== matchingSingleValue;
-	      $(this).toggle(!isSinglePhase || (!isPerPhaseOption && !isMismatchedSinglePhaseOption));
+
+	      const visible = nrOfPhases === 1
+	        ? val === matchingSingleValue
+	        : nrOfPhases === 3
+	          ? (isSymmetricOption || isPerPhaseOption)
+	          : true;
+	      $(this).toggle(visible);
 	    });
 
-	    if (isSinglePhase && ['L1', 'L2', 'L3'].includes($select.val()) && $select.val() !== matchingSingleValue) {
+	    if (nrOfPhases === 1) {
 	      $select.val(matchingSingleValue);
+	    } else if (nrOfPhases === 3 && ['L1', 'L2', 'L3'].includes($select.val())) {
+	      $select.val('3_PHASE_SYMMETRIC');
 	    }
 	  };
 
 	  const updatePhaseSetting = () => {
 	    const gridMeterOnly = $(`#node-input-${prefix}_grid_meter_only`).is(':checked');
-	    const isSinglePhase = $(`#node-input-${prefix}_nrofphases`).val() === '1';
-	    $(`#${prefix}-phasesetting-row`).toggle(isSinglePhase && !gridMeterOnly);
-	    updateS2MeasurementOptions(isSinglePhase);
+	    const nrOfPhases = Number($(`#node-input-${prefix}_nrofphases`).val());
+	    $(`#${prefix}-phasesetting-row`).toggle(nrOfPhases === 1 && !gridMeterOnly);
+	    updateS2MeasurementOptions(nrOfPhases);
 	  };
 	  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', updatePhaseSetting);
 	  $(`#node-input-${prefix}_phasesetting`).off('change.s2measurement').on('change.s2measurement', () => {
-	    updateS2MeasurementOptions($(`#node-input-${prefix}_nrofphases`).val() === '1');
+	    updateS2MeasurementOptions(Number($(`#node-input-${prefix}_nrofphases`).val()));
 	  });
 	  updatePhaseSetting();
 	}

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1107,38 +1107,46 @@ export function updateBatteryVoltageVisibility () {
   $('#battery-voltage-custom-label').toggle(preset === 'custom')
 }
 
-// Keeps the S2 Measurement dropdown consistent with the device's actual phase(s): for a
-// single-phase config, only "3-phase symmetric" (reads the Ac/Power total) and the single
-// phase option matching the configured Phase are valid - the other single-phase options and
-// "Per phase" would read an Ac/L{n}/Power path that doesn't exist on the device. Shared by
-// acload and heatpump, which have identical phase/position config shapes.
+// Keeps the S2 Measurement dropdown consistent with the device's actual phase(s), so the
+// phase info already given via Number of phases/Phase doesn't need re-confirming: a 1-phase
+// config is locked to the single matching phase, a 3-phase config offers only "3-phase
+// symmetric"/"Per phase" (no single-phase reading applies), split phase leaves all options
+// open. Shared by acload and heatpump, which have identical phase/position config shapes.
 function updatePhaseSettingVisibility (prefix) {
-  const updateS2MeasurementOptions = (isSinglePhase) => {
+  const updateS2MeasurementOptions = (nrOfPhases) => {
     const phaseSetting = $(`#node-input-${prefix}_phasesetting`).val()
     const matchingSingleValue = 'L' + phaseSetting
     const $select = $('#node-input-s2_measurement_type')
 
     $select.find('option').each(function () {
       const val = $(this).val()
+      const isSymmetricOption = val === '3_PHASE_SYMMETRIC'
       const isPerPhaseOption = val === 'L1_L2_L3'
-      const isMismatchedSinglePhaseOption = ['L1', 'L2', 'L3'].includes(val) && val !== matchingSingleValue
-      $(this).toggle(!isSinglePhase || (!isPerPhaseOption && !isMismatchedSinglePhaseOption))
+
+      const visible = nrOfPhases === 1
+        ? val === matchingSingleValue
+        : nrOfPhases === 3
+          ? (isSymmetricOption || isPerPhaseOption)
+          : true
+      $(this).toggle(visible)
     })
 
-    if (isSinglePhase && ['L1', 'L2', 'L3'].includes($select.val()) && $select.val() !== matchingSingleValue) {
+    if (nrOfPhases === 1) {
       $select.val(matchingSingleValue)
+    } else if (nrOfPhases === 3 && ['L1', 'L2', 'L3'].includes($select.val())) {
+      $select.val('3_PHASE_SYMMETRIC')
     }
   }
 
   const updatePhaseSetting = () => {
     const gridMeterOnly = $(`#node-input-${prefix}_grid_meter_only`).is(':checked')
-    const isSinglePhase = $(`#node-input-${prefix}_nrofphases`).val() === '1'
-    $(`#${prefix}-phasesetting-row`).toggle(isSinglePhase && !gridMeterOnly)
-    updateS2MeasurementOptions(isSinglePhase)
+    const nrOfPhases = Number($(`#node-input-${prefix}_nrofphases`).val())
+    $(`#${prefix}-phasesetting-row`).toggle(nrOfPhases === 1 && !gridMeterOnly)
+    updateS2MeasurementOptions(nrOfPhases)
   }
   $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', updatePhaseSetting)
   $(`#node-input-${prefix}_phasesetting`).off('change.s2measurement').on('change.s2measurement', () => {
-    updateS2MeasurementOptions($(`#node-input-${prefix}_nrofphases`).val() === '1')
+    updateS2MeasurementOptions(Number($(`#node-input-${prefix}_nrofphases`).val()))
   })
   updatePhaseSetting()
 }

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -585,6 +585,62 @@ export const DEVICE_TYPE_DOCS = {
   `,
     img: null
   },
+  heatpump: {
+    label: 'Heat pump',
+    text: `
+    ${INPUT_DOCS}
+    <div>
+      <div><strong>Most relevant paths:</strong>
+        <ul>
+          <li><code>/Ac/{line}/Power</code> &mdash; Power per phase in watts, where <code>{line}</code> is <code>L1</code>, <code>L2</code>, or <code>L3</code>.</li>
+          <li><code>/Ac/{line}/Voltage</code> &mdash; Voltage per phase in volts.</li>
+          <li><code>/Ac/{line}/Current</code> &mdash; Current per phase in amperes.</li>
+          <li><code>/Ac/{line}/Energy/Forward</code> &mdash; Energy consumed per phase in kWh.</li>
+          <li><code>/Ac/Frequency</code> &mdash; AC frequency in Hz.</li>
+          <li><code>/Ac/PowerFactor</code> &mdash; Overall power factor.</li>
+          <li><code>/Ac/{line}/PowerFactor</code> &mdash; Power factor per phase.</li>
+        </ul>
+        <p>For more information on available paths, see the <a href="https://github.com/victronenergy/venus/wiki/dbus" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS dbus specification</a>.</p>
+      </div>
+    </div>
+    <div>
+      <div><strong>Output:</strong>
+        <ol>
+          <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
+        </ol>
+      </div>
+    </div>
+  `,
+    img: null
+  },
+  evcs: {
+    label: 'EV charger',
+    text: `
+    ${INPUT_DOCS}
+    <div>
+      <div><strong>Most relevant paths:</strong>
+        <ul>
+          <li><code>/Ac/Power</code> &mdash; Total AC power in watts.</li>
+          <li><code>/Ac/{line}/Power</code> &mdash; Power per phase in watts, where <code>{line}</code> is <code>L1</code>, <code>L2</code>, or <code>L3</code>.</li>
+          <li><code>/Ac/{line}/Voltage</code> &mdash; Voltage per phase in volts.</li>
+          <li><code>/Ac/{line}/Current</code> &mdash; Current per phase in amperes.</li>
+          <li><code>/Ac/{line}/Energy/Forward</code> &mdash; Energy consumed per phase in kWh.</li>
+          <li><code>/Ac/Frequency</code> &mdash; AC frequency in Hz.</li>
+        </ul>
+        <p>Measurement-only - does not simulate a full EVSE (no charging session or connector state). Registers as <code>com.victronenergy.evcharger</code>.</p>
+        <p>For more information on available paths, see the <a href="https://github.com/victronenergy/venus/wiki/dbus" target="_blank" rel="noopener noreferrer" class="blue-link">Venus OS dbus specification</a>.</p>
+      </div>
+    </div>
+    <div>
+      <div><strong>Output:</strong>
+        <ol>
+          <li><code>Passthrough</code> &mdash; Outputs the original <tt>msg.payload</tt> without modification</li>
+        </ol>
+      </div>
+    </div>
+  `,
+    img: null
+  },
   pulsemeter: {
     label: 'Pulse meter',
     text: `
@@ -1051,14 +1107,75 @@ export function updateBatteryVoltageVisibility () {
   $('#battery-voltage-custom-label').toggle(preset === 'custom')
 }
 
-// Mirrors POSITION_CONFIGURABLE_ROLES in src/nodes/victron-virtual/device-type/energymeter.js -
-// gates both the Position and (for single-phase configs) PhaseSetting rows.
-const ENERGYMETER_POSITION_CONFIGURABLE_ROLES = ['acload', 'evcharger', 'heatpump']
+// Keeps the S2 Measurement dropdown consistent with the device's actual phase(s): for a
+// single-phase config, only "3-phase symmetric" (reads the Ac/Power total) and the single
+// phase option matching the configured Phase are valid - the other single-phase options and
+// "Per phase" would read an Ac/L{n}/Power path that doesn't exist on the device. Shared by
+// acload and heatpump, which have identical phase/position config shapes.
+function updatePhaseSettingVisibility (prefix) {
+  const updateS2MeasurementOptions = (isSinglePhase) => {
+    const phaseSetting = $(`#node-input-${prefix}_phasesetting`).val()
+    const matchingSingleValue = 'L' + phaseSetting
+    const $select = $('#node-input-s2_measurement_type')
+
+    $select.find('option').each(function () {
+      const val = $(this).val()
+      const isPerPhaseOption = val === 'L1_L2_L3'
+      const isMismatchedSinglePhaseOption = ['L1', 'L2', 'L3'].includes(val) && val !== matchingSingleValue
+      $(this).toggle(!isSinglePhase || (!isPerPhaseOption && !isMismatchedSinglePhaseOption))
+    })
+
+    if (isSinglePhase && ['L1', 'L2', 'L3'].includes($select.val()) && $select.val() !== matchingSingleValue) {
+      $select.val(matchingSingleValue)
+    }
+  }
+
+  const updatePhaseSetting = () => {
+    const isSinglePhase = $(`#node-input-${prefix}_nrofphases`).val() === '1'
+    $(`#${prefix}-phasesetting-row`).toggle(isSinglePhase)
+    updateS2MeasurementOptions(isSinglePhase)
+  }
+  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', updatePhaseSetting)
+  $(`#node-input-${prefix}_phasesetting`).off('change.s2measurement').on('change.s2measurement', () => {
+    updateS2MeasurementOptions($(`#node-input-${prefix}_nrofphases`).val() === '1')
+  })
+  updatePhaseSetting()
+}
+
+// AC Load, Heat pump, and Generator can optionally present as a plain measurement-only "grid
+// meter" shape (still under their own dbus service type - see minimal-meter.js). When checked,
+// hide the options that don't apply to that minimal shape: S2 support for acload/heatpump,
+// engine/starter monitoring for generator.
+function updateGridMeterOnlyVisibility (prefix) {
+  const $checkbox = $(`#node-input-${prefix}_grid_meter_only`)
+
+  const apply = () => {
+    const gridMeterOnly = $checkbox.is(':checked')
+
+    if (prefix === 'generator') {
+      $('#node-input-include_engine_hours').closest('.form-row').toggle(!gridMeterOnly)
+      $('#node-input-include_starter_voltage').closest('.form-row').toggle(!gridMeterOnly)
+      return
+    }
+
+    $(`#node-input-${prefix}_auto_energy`).closest('.form-row').toggle(!gridMeterOnly)
+    if (gridMeterOnly) {
+      $('.input-s2support').hide()
+      $('.input-s2support-measurement').hide()
+    } else {
+      $('.input-s2support').show()
+      $('.input-s2support-measurement').toggle($('#node-input-enable_s2support').is(':checked'))
+    }
+  }
+
+  $checkbox.off('change.grid-meter-only').on('change.grid-meter-only', apply)
+  apply()
+}
 
 export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
   [
     'acload', 'battery', 'ev', 'generator', 'gps', 'grid', 'e-drive',
-    'pvinverter', 'switch', 'tank', 'temperature', 'energymeter', 'pulsemeter'
+    'pvinverter', 'switch', 'tank', 'temperature', 'heatpump', 'evcs', 'pulsemeter'
   ].forEach(x => { $('.input-' + x).hide() })
 
   const selected = $('select#node-input-device').val()
@@ -1108,55 +1225,14 @@ export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
     $('#pulsemeter-multiplier-row').toggle($('#node-input-auto_aggregate').is(':checked'))
   }
 
-  if (selected === 'acload') {
-    // Keeps the S2 Measurement dropdown consistent with the acload's actual phase(s): for a
-    // single-phase config, only "3-phase symmetric" (reads the Ac/Power total) and the single
-    // phase option matching the configured Phase are valid - the other single-phase options and
-    // "Per phase" would read an Ac/L{n}/Power path that doesn't exist on the device.
-    const updateAcloadS2MeasurementOptions = (isSinglePhase) => {
-      const phaseSetting = $('#node-input-acload_phasesetting').val()
-      const matchingSingleValue = 'L' + phaseSetting
-      const $select = $('#node-input-s2_measurement_type')
-
-      $select.find('option').each(function () {
-        const val = $(this).val()
-        const isPerPhaseOption = val === 'L1_L2_L3'
-        const isMismatchedSinglePhaseOption = ['L1', 'L2', 'L3'].includes(val) && val !== matchingSingleValue
-        $(this).toggle(!isSinglePhase || (!isPerPhaseOption && !isMismatchedSinglePhaseOption))
-      })
-
-      if (isSinglePhase && ['L1', 'L2', 'L3'].includes($select.val()) && $select.val() !== matchingSingleValue) {
-        $select.val(matchingSingleValue)
-      }
-    }
-
-    const updateAcloadPhaseSettingVisibility = () => {
-      const isSinglePhase = $('#node-input-acload_nrofphases').val() === '1'
-      $('#acload-phasesetting-row').toggle(isSinglePhase)
-      updateAcloadS2MeasurementOptions(isSinglePhase)
-    }
-    $('#node-input-acload_nrofphases').off('change.acload-phasesetting').on('change.acload-phasesetting', updateAcloadPhaseSettingVisibility)
-    $('#node-input-acload_phasesetting').off('change.acload-s2measurement').on('change.acload-s2measurement', () => {
-      updateAcloadS2MeasurementOptions($('#node-input-acload_nrofphases').val() === '1')
-    })
-    updateAcloadPhaseSettingVisibility()
-  }
-
-  if (selected === 'energymeter') {
-    const updateEnergymeterPositionVisibility = () => {
-      const role = $('#node-input-energymeter_role').val()
-      const nrOfPhases = $('#node-input-energymeter_nrofphases').val()
-      const isConfigurableRole = ENERGYMETER_POSITION_CONFIGURABLE_ROLES.includes(role)
-      $('#energymeter-position-row').toggle(isConfigurableRole)
-      $('#energymeter-phasesetting-row').toggle(isConfigurableRole && nrOfPhases === '1')
-    }
-    $('#node-input-energymeter_role').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility)
-    $('#node-input-energymeter_nrofphases').off('change.energymeter-position').on('change.energymeter-position', updateEnergymeterPositionVisibility)
-    updateEnergymeterPositionVisibility()
+  if (selected === 'acload' || selected === 'heatpump') {
+    updatePhaseSettingVisibility(selected)
+    updateGridMeterOnlyVisibility(selected)
   }
 
   if (selected === 'generator') {
     checkGeneratorType()
+    updateGridMeterOnlyVisibility('generator')
   }
 
   if (selected === 'gps') {

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1107,11 +1107,14 @@ export function updateBatteryVoltageVisibility () {
   $('#battery-voltage-custom-label').toggle(preset === 'custom')
 }
 
-// Keeps the S2 Measurement dropdown consistent with the device's actual phase(s), so the
-// phase info already given via Number of phases/Phase doesn't need re-confirming: a 1-phase
-// config is locked to the single matching phase, a 3-phase config offers only "3-phase
-// symmetric"/"Per phase" (no single-phase reading applies), split phase leaves all options
-// open. Shared by acload and heatpump, which have identical phase/position config shapes.
+// Keeps Position/Phase and the S2 Measurement dropdown consistent with the device's actual
+// configuration for acload/heatpump: enabling S2 support is what promotes the device from a
+// plain generic energy meter to its own full type, adding Position (and, for a 1-phase
+// config, which phase it's wired to) - see acload.js/heatpump.js isFullDevice(). The S2
+// Measurement dropdown mirrors Number of phases/Phase so that info doesn't need
+// re-confirming: a 1-phase config is locked to the single matching phase, a 3-phase config
+// offers only "3-phase symmetric"/"Per phase" (no single-phase reading applies), split phase
+// leaves all options open.
 function updatePhaseSettingVisibility (prefix) {
   const updateS2MeasurementOptions = (nrOfPhases) => {
     const phaseSetting = $(`#node-input-${prefix}_phasesetting`).val()
@@ -1138,45 +1141,31 @@ function updatePhaseSettingVisibility (prefix) {
     }
   }
 
-  const updatePhaseSetting = () => {
-    const gridMeterOnly = $(`#node-input-${prefix}_grid_meter_only`).is(':checked')
+  const update = () => {
+    const isFull = $('#node-input-enable_s2support').is(':checked')
     const nrOfPhases = Number($(`#node-input-${prefix}_nrofphases`).val())
-    $(`#${prefix}-phasesetting-row`).toggle(nrOfPhases === 1 && !gridMeterOnly)
+    $(`#node-input-${prefix}_position`).closest('.form-row').toggle(isFull)
+    $(`#${prefix}-phasesetting-row`).toggle(isFull && nrOfPhases === 1)
     updateS2MeasurementOptions(nrOfPhases)
   }
-  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', updatePhaseSetting)
+  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', update)
   $(`#node-input-${prefix}_phasesetting`).off('change.s2measurement').on('change.s2measurement', () => {
     updateS2MeasurementOptions(Number($(`#node-input-${prefix}_nrofphases`).val()))
   })
-  updatePhaseSetting()
+  $('#node-input-enable_s2support').off(`change.${prefix}-full`).on(`change.${prefix}-full`, update)
+  update()
 }
 
-// AC Load, Heat pump, and Generator can optionally present as a plain measurement-only "grid
-// meter" shape (still under their own dbus service type - see minimal-meter.js). When checked,
-// hide the options that don't apply to that minimal shape: S2 support for acload/heatpump,
-// engine/starter monitoring for generator.
+// Generator (AC) can optionally present as a plain measurement-only "generic energy meter"
+// shape, still under com.victronenergy.genset (see minimal-meter.js). When checked, hide the
+// engine/starter monitoring options that don't apply to that minimal shape.
 function updateGridMeterOnlyVisibility (prefix) {
   const $checkbox = $(`#node-input-${prefix}_grid_meter_only`)
 
   const apply = () => {
     const gridMeterOnly = $checkbox.is(':checked')
-
-    if (prefix === 'generator') {
-      $('#node-input-include_engine_hours').closest('.form-row').toggle(!gridMeterOnly)
-      $('#node-input-include_starter_voltage').closest('.form-row').toggle(!gridMeterOnly)
-      return
-    }
-
-    $(`#node-input-${prefix}_position`).closest('.form-row').toggle(!gridMeterOnly)
-    $(`#node-input-${prefix}_nrofphases`).trigger('change.phasesetting')
-    $(`#node-input-${prefix}_auto_energy`).closest('.form-row').toggle(!gridMeterOnly)
-    if (gridMeterOnly) {
-      $('.input-s2support').hide()
-      $('.input-s2support-measurement').hide()
-    } else {
-      $('.input-s2support').show()
-      $('.input-s2support-measurement').toggle($('#node-input-enable_s2support').is(':checked'))
-    }
+    $('#node-input-include_engine_hours').closest('.form-row').toggle(!gridMeterOnly)
+    $('#node-input-include_starter_voltage').closest('.form-row').toggle(!gridMeterOnly)
   }
 
   $checkbox.off('change.grid-meter-only').on('change.grid-meter-only', apply)
@@ -1238,7 +1227,6 @@ export function checkSelectedVirtualDevice (context, deviceCapabilities = {}) {
 
   if (selected === 'acload' || selected === 'heatpump') {
     updatePhaseSettingVisibility(selected)
-    updateGridMeterOnlyVisibility(selected)
   }
 
   if (selected === 'generator') {

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1131,8 +1131,9 @@ function updatePhaseSettingVisibility (prefix) {
   }
 
   const updatePhaseSetting = () => {
+    const gridMeterOnly = $(`#node-input-${prefix}_grid_meter_only`).is(':checked')
     const isSinglePhase = $(`#node-input-${prefix}_nrofphases`).val() === '1'
-    $(`#${prefix}-phasesetting-row`).toggle(isSinglePhase)
+    $(`#${prefix}-phasesetting-row`).toggle(isSinglePhase && !gridMeterOnly)
     updateS2MeasurementOptions(isSinglePhase)
   }
   $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', updatePhaseSetting)
@@ -1158,6 +1159,8 @@ function updateGridMeterOnlyVisibility (prefix) {
       return
     }
 
+    $(`#node-input-${prefix}_position`).closest('.form-row').toggle(!gridMeterOnly)
+    $(`#node-input-${prefix}_nrofphases`).trigger('change.phasesetting')
     $(`#node-input-${prefix}_auto_energy`).closest('.form-row').toggle(!gridMeterOnly)
     if (gridMeterOnly) {
       $('.input-s2support').hide()

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -122,6 +122,11 @@
                     const $select = $('#node-input-device');
                     $select.empty();
                     deviceTypes.forEach(function(dt) {
+                        // Legacy-only types (e.g. retired "Energy meter") aren't offered for new
+                        // nodes, but still need to appear as an option so an existing node using
+                        // one resolves/displays correctly instead of silently falling back to
+                        // whatever option happens to be first in the list.
+                        if (dt.legacyOnly && dt.value !== self.device) return;
                         $select.append($('<option>', { value: dt.value, text: dt.label }));
                         deviceCapabilities[dt.value] = dt;
                     });

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -14,8 +14,17 @@
             acload_nrofphases: {value: 1, required: false},
             acload_phasesetting: {value: 1, required: false},
             acload_auto_energy: {value: true, required: false},
+            acload_grid_meter_only: {value: false, required: false},
             enable_s2support: {value: false, required: false},
             s2_measurement_type: {value: '3_PHASE_SYMMETRIC', required: false},
+            // heatpump
+            heatpump_position: {value: 0, required: false},
+            heatpump_nrofphases: {value: 1, required: false},
+            heatpump_phasesetting: {value: 1, required: false},
+            heatpump_auto_energy: {value: true, required: false},
+            heatpump_grid_meter_only: {value: false, required: false},
+            // evcs
+            evcs_nrofphases: {value: 1, required: false},
             // battery
             battery_capacity: {value: 25, required: false},
             include_battery_temperature: {value: false},
@@ -27,13 +36,9 @@
             include_engine_hours: {value: false},
             include_starter_voltage: {value: false},
             include_history_energy: {value: false},
+            generator_grid_meter_only: {value: false, required: false},
             // grid
             grid_nrofphases: {value: 1, required: false},
-            // energymeter
-            energymeter_nrofphases: {value: 1, required: false},
-            energymeter_role: {value: "gridmeter", required: false},
-            energymeter_position: {value: 0, required: false},
-            energymeter_phasesetting: {value: 1, required: false},
             // motordrive
             include_motor_temp: {value: false},
             include_controller_temp: {value: false},
@@ -300,16 +305,69 @@
             </select>
         </div>
         <div class="form-row input-acload victron-checkbox hidden-row">
+            <input type="checkbox" id="node-input-acload_grid_meter_only">
+            <label for="node-input-acload_grid_meter_only">Use as grid meter only
+                <i class="fa fa-info-circle tooltip-icon" data-tooltip="Reports minimal measurements only (no S2, no auto-energy), for use as a grid meter. Stays registered as com.victronenergy.acload on D-Bus."></i>
+            </label>
+        </div>
+        <div class="form-row input-acload victron-checkbox hidden-row">
             <input type="checkbox" id="node-input-acload_auto_energy">
             <label for="node-input-acload_auto_energy">Auto-calculate energy (Ac/Energy/Forward)
                 <i class="fa fa-info-circle tooltip-icon" data-tooltip="Integrates power over time to estimate energy. Precision improves with higher update frequency."></i>
             </label>
         </div>
+        <div class="input-heatpump">
+            <div class="form-row hidden-row">
+                <label for="node-input-heatpump_position"><i class="fa fa-sliders"></i> Position</label>
+                <select id="node-input-heatpump_position">
+                    <option value="0">AC output</option>
+                    <option value="1">AC input</option>
+                </select>
+            </div>
+            <div class="form-row hidden-row">
+                <label for="node-input-heatpump_nrofphases"><i class="fa fa-plug"></i> Number of phases</label>
+                <select id="node-input-heatpump_nrofphases">
+                    <option value="1">1 phase</option>
+                    <option value="2">Split phase</option>
+                    <option value="3">3 phase</option>
+                </select>
+            </div>
+            <div class="form-row hidden-row" id="heatpump-phasesetting-row">
+                <label for="node-input-heatpump_phasesetting"><i class="fa fa-plug"></i> Phase</label>
+                <select id="node-input-heatpump_phasesetting">
+                    <option value="1">L1</option>
+                    <option value="2">L2</option>
+                    <option value="3">L3</option>
+                </select>
+            </div>
+            <div class="form-row victron-checkbox hidden-row">
+                <input type="checkbox" id="node-input-heatpump_grid_meter_only">
+                <label for="node-input-heatpump_grid_meter_only">Use as grid meter only
+                    <i class="fa fa-info-circle tooltip-icon" data-tooltip="Reports minimal measurements only (no S2, no auto-energy), for use as a grid meter. Stays registered as com.victronenergy.heatpump on D-Bus."></i>
+                </label>
+            </div>
+            <div class="form-row victron-checkbox hidden-row">
+                <input type="checkbox" id="node-input-heatpump_auto_energy">
+                <label for="node-input-heatpump_auto_energy">Auto-calculate energy (Ac/Energy/Forward)
+                    <i class="fa fa-info-circle tooltip-icon" data-tooltip="Integrates power over time to estimate energy. Precision improves with higher update frequency."></i>
+                </label>
+            </div>
+        </div>
+        <div class="input-evcs">
+            <div class="form-row">
+                <label for="node-input-evcs_nrofphases"><i class="fa fa-plug"></i> Nr of phases</label>
+                <select id="node-input-evcs_nrofphases">
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                </select>
+            </div>
+        </div>
         <div class="form-row input-s2support victron-checkbox" style="display:none">
             <input type="checkbox" id="node-input-enable_s2support" class="s2-checkbox">
             <label for="node-input-enable_s2support">
                 S2 support
-                <i class="fa fa-info-circle tooltip-icon" data-tooltip="Enable Victron S2 protocol support for smart charging"></i>
+                <i class="fa fa-info-circle tooltip-icon" data-tooltip="Enable Victron S2 protocol support for smart control"></i>
             </label>
         </div>
         <div class="form-row input-s2support input-s2support-measurement" style="display:none">
@@ -390,6 +448,12 @@
                     <option value="3">3</option>
                 </select>
             </div>
+            <div class="form-row victron-checkbox ac-generator-only">
+                <input type="checkbox" id="node-input-generator_grid_meter_only">
+                <label for="node-input-generator_grid_meter_only">Use as grid meter only
+                    <i class="fa fa-info-circle tooltip-icon" data-tooltip="Reports minimal measurements only (no engine/alarm data), for use as a grid meter. Stays registered as com.victronenergy.genset on D-Bus."></i>
+                </label>
+            </div>
             <div class="form-row victron-checkbox">
                 <input type="checkbox" id="node-input-include_engine_hours">
                 <label for="node-input-include_engine_hours">Include engine hours</label>
@@ -414,43 +478,6 @@
                     <option value="1">1</option>
                     <option value="2">2</option>
                     <option value="3">3</option>
-                </select>
-            </div>
-        </div>
-
-        <div class="input-energymeter">
-            <div class="form-row">
-                <label for="node-input-energymeter_role"><i class="fa fa-cog"></i> Role</label>
-                <select id="node-input-energymeter_role">
-                    <option value="gridmeter">Grid meter</option>
-                    <option value="inverter">PV inverter</option>
-                    <option value="generator">Generator</option>
-                    <option value="acload">AC load</option>
-                    <option value="evcharger">EV charger</option>
-                    <option value="heatpump">Heat pump</option>
-                </select>
-            </div>
-            <div class="form-row" id="energymeter-position-row">
-                <label for="node-input-energymeter_position"><i class="fa fa-sliders"></i> Position</label>
-                <select id="node-input-energymeter_position">
-                    <option value="0">AC output</option>
-                    <option value="1">AC input</option>
-                </select>
-            </div>
-            <div class="form-row">
-                <label for="node-input-energymeter_nrofphases"><i class="fa fa-plug"></i> Nr of phases</label>
-                <select id="node-input-energymeter_nrofphases">
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                </select>
-            </div>
-            <div class="form-row" id="energymeter-phasesetting-row">
-                <label for="node-input-energymeter_phasesetting"><i class="fa fa-plug"></i> Phase</label>
-                <select id="node-input-energymeter_phasesetting">
-                    <option value="1">L1</option>
-                    <option value="2">L2</option>
-                    <option value="3">L3</option>
                 </select>
             </div>
         </div>
@@ -651,9 +678,11 @@ device type needs to be selected. At the moment the system supports:
 - AC Load
 - Battery
 - E-drive
+- EV charger
 - Generator
 - GPS
 - Grid meter
+- Heat pump
 - Meteo
 - PV inverter
 - Tank sensor
@@ -735,7 +764,11 @@ The AC Load device can be configured by selecting the number of phases (1 or 3)
 that are available on the device.
 
 Note that the S2 support is experimental and subject to change. Only enable it
-if you really know what you are doing.
+if you know what you are doing.
+
+_Use as grid meter only_ reports minimal measurements only (no S2, no
+auto-energy), for use as a grid meter. It stays registered as
+com.victronenergy.acload on D-Bus.
 
 ### Battery
 
@@ -760,6 +793,10 @@ Optional monitoring parameters include:
 
 The device includes alarm monitoring for temperature, oil pressure, coolant level, fuel level, and other critical parameters. Status codes indicate the current operational state from standby through startup phases to running or error conditions.
 
+_Use as grid meter only_ (AC generators only) drops all of the above for
+minimal measurements only (no engine/alarm data), for use as a grid meter.
+It stays registered as com.victronenergy.genset on D-Bus.
+
 ### GPS
 
 The GPS device does not have any specific configuration options. It is used to
@@ -781,6 +818,21 @@ There are multiple [officially supported
 meters](https://www.victronenergy.com/meters-and-sensors/energy-meter) that can
 be used in a Victron ESS system. Using other meters has proven too often to
 lead to issues related with stability.
+
+### EV charger
+
+The EV charger device is measurement-only - it does not simulate a full EVSE
+(no charging session or connector state), with just the number of phases to
+configure. It registers as com.victronenergy.evcharger on D-Bus.
+
+### Heat pump
+
+The Heat pump device is configured the same way as the AC Load device: number
+of phases (1 or 3), position, optional S2 support, and a _use as grid meter
+only_ checkbox.
+
+Note that the S2 support is experimental and subject to change. Only enable it
+if you know what you are doing.
 
 ### Meteo
 

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -114,27 +114,35 @@
                 self.device = 'e-drive';
             }
 
+            // Once deployed, the device type can't be changed (see the disabled-select
+            // handling below) - so a deployed node only ever needs its own entry resolved,
+            // legacy or not, rather than the full new-node list with legacy types filtered out.
+            const isDeployed = !!(self.id && self.changed === false && self.device);
+
             var baseUrl = (RED.settings.httpNodeRoot || RED.settings.httpAdminRoot || "").replace(/\/$/, "");
             $.getJSON(baseUrl + '/victron/virtual-device-types')
                 .done(function(deviceTypes) {
                     const $select = $('#node-input-device');
                     $select.empty();
-                    deviceTypes.forEach(function(dt) {
-                        // Legacy-only types (e.g. retired "Energy meter") aren't offered for new
-                        // nodes, but still need to appear as an option so an existing node using
-                        // one resolves/displays correctly instead of silently falling back to
-                        // whatever option happens to be first in the list.
-                        if (dt.legacyOnly && dt.value !== self.device) return;
-                        $select.append($('<option>', { value: dt.value, text: dt.label }));
-                        deviceCapabilities[dt.value] = dt;
-                    });
+                    if (isDeployed) {
+                        const current = deviceTypes.find(dt => dt.value === self.device) ||
+                            { value: self.device, label: self.device };
+                        deviceCapabilities[current.value] = current;
+                        $select.append($('<option>', { value: current.value, text: current.label }));
+                    } else {
+                        deviceTypes.forEach(function(dt) {
+                            if (dt.legacyOnly) return;
+                            $select.append($('<option>', { value: dt.value, text: dt.label }));
+                            deviceCapabilities[dt.value] = dt;
+                        });
+                    }
                     if (self.device) $select.val(self.device);
                 })
                 .fail(function() {
                     console.error('Failed to load virtual device types');
                 })
                 .always(function() {
-                    if (self.id && self.changed === false && self.device && self.device !== '') {
+                    if (isDeployed) {
                         $('#node-input-device')
                             .prop('disabled', true)
                             .attr('title', 'Device type cannot be changed after deployment.');

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -14,7 +14,6 @@
             acload_nrofphases: {value: 1, required: false},
             acload_phasesetting: {value: 1, required: false},
             acload_auto_energy: {value: true, required: false},
-            acload_grid_meter_only: {value: false, required: false},
             enable_s2support: {value: false, required: false},
             s2_measurement_type: {value: '3_PHASE_SYMMETRIC', required: false},
             // heatpump
@@ -22,7 +21,6 @@
             heatpump_nrofphases: {value: 1, required: false},
             heatpump_phasesetting: {value: 1, required: false},
             heatpump_auto_energy: {value: true, required: false},
-            heatpump_grid_meter_only: {value: false, required: false},
             // evcs
             evcs_nrofphases: {value: 1, required: false},
             // battery
@@ -310,12 +308,6 @@
             </select>
         </div>
         <div class="form-row input-acload victron-checkbox hidden-row">
-            <input type="checkbox" id="node-input-acload_grid_meter_only">
-            <label for="node-input-acload_grid_meter_only">Use as grid meter only
-                <i class="fa fa-info-circle tooltip-icon" data-tooltip="Reports minimal measurements only (no S2, no auto-energy), for use as a grid meter. Stays registered as com.victronenergy.acload on D-Bus."></i>
-            </label>
-        </div>
-        <div class="form-row input-acload victron-checkbox hidden-row">
             <input type="checkbox" id="node-input-acload_auto_energy">
             <label for="node-input-acload_auto_energy">Auto-calculate energy (Ac/Energy/Forward)
                 <i class="fa fa-info-circle tooltip-icon" data-tooltip="Integrates power over time to estimate energy. Precision improves with higher update frequency."></i>
@@ -344,12 +336,6 @@
                     <option value="2">L2</option>
                     <option value="3">L3</option>
                 </select>
-            </div>
-            <div class="form-row victron-checkbox hidden-row">
-                <input type="checkbox" id="node-input-heatpump_grid_meter_only">
-                <label for="node-input-heatpump_grid_meter_only">Use as grid meter only
-                    <i class="fa fa-info-circle tooltip-icon" data-tooltip="Reports minimal measurements only (no S2, no auto-energy), for use as a grid meter. Stays registered as com.victronenergy.heatpump on D-Bus."></i>
-                </label>
             </div>
             <div class="form-row victron-checkbox hidden-row">
                 <input type="checkbox" id="node-input-heatpump_auto_energy">
@@ -455,8 +441,8 @@
             </div>
             <div class="form-row victron-checkbox ac-generator-only">
                 <input type="checkbox" id="node-input-generator_grid_meter_only">
-                <label for="node-input-generator_grid_meter_only">Use as grid meter only
-                    <i class="fa fa-info-circle tooltip-icon" data-tooltip="Reports minimal measurements only (no engine/alarm data), for use as a grid meter. Stays registered as com.victronenergy.genset on D-Bus."></i>
+                <label for="node-input-generator_grid_meter_only">Use as generic energy meter only
+                    <i class="fa fa-info-circle tooltip-icon" data-tooltip="Reports minimal measurements only (no engine/alarm data). Stays registered as com.victronenergy.genset on D-Bus."></i>
                 </label>
             </div>
             <div class="form-row victron-checkbox">
@@ -768,12 +754,13 @@ The _Start disconnected_ option in the edit dialog causes the device to remain i
 The AC Load device can be configured by selecting the number of phases (1 or 3)
 that are available on the device.
 
+By default it presents as a plain generic energy meter (minimal measurements
+only, no Position). Enabling S2 support is what turns it into its own full
+AC Load device, adding Position (and, for a 1-phase config, which phase it's
+wired to). It always registers as com.victronenergy.acload on D-Bus.
+
 Note that the S2 support is experimental and subject to change. Only enable it
 if you know what you are doing.
-
-_Use as grid meter only_ reports minimal measurements only (no S2, no
-auto-energy), for use as a grid meter. It stays registered as
-com.victronenergy.acload on D-Bus.
 
 ### Battery
 
@@ -798,9 +785,9 @@ Optional monitoring parameters include:
 
 The device includes alarm monitoring for temperature, oil pressure, coolant level, fuel level, and other critical parameters. Status codes indicate the current operational state from standby through startup phases to running or error conditions.
 
-_Use as grid meter only_ (AC generators only) drops all of the above for
-minimal measurements only (no engine/alarm data), for use as a grid meter.
-It stays registered as com.victronenergy.genset on D-Bus.
+_Use as generic energy meter only_ (AC generators only) drops all of the
+above for minimal measurements only (no engine/alarm data). It stays
+registered as com.victronenergy.genset on D-Bus.
 
 ### GPS
 
@@ -833,8 +820,8 @@ configure. It registers as com.victronenergy.evcharger on D-Bus.
 ### Heat pump
 
 The Heat pump device is configured the same way as the AC Load device: number
-of phases (1 or 3), position, optional S2 support, and a _use as grid meter
-only_ checkbox.
+of phases (1 or 3) and optional S2 support, which is what adds Position and
+turns it into its own full Heat pump device (see AC Load above).
 
 Note that the S2 support is experimental and subject to change. Only enable it
 if you know what you are doing.

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -2,13 +2,18 @@ const { accumulateDelta } = require('../energy-utils')
 const { enableS2Support } = require('../s2-support')
 const { buildMinimalMeterProperties, initializeMinimalMeter } = require('./shared/minimal-meter')
 
-// "Use as grid meter only" reports a minimal measurement set (see minimal-meter.js) for use as
-// the system's grid meter, but stays registered as com.victronenergy.acload on D-Bus rather than
-// switching to com.victronenergy.grid.
+// Presents as a plain generic energy meter by default (see minimal-meter.js). Enabling S2
+// support is the only thing that adds extra paths (Position/PhaseSetting plus the S2 paths
+// themselves), promoting it to its own full AC load device.
+function isFullDevice (config) {
+  return !!config.enable_s2support
+}
+
 function properties (config) {
+  const isFull = isFullDevice(config)
   return buildMinimalMeterProperties({
-    includePosition: !config.acload_grid_meter_only,
-    isGenericEnergyMeter: !!config.acload_grid_meter_only
+    includePosition: isFull,
+    isGenericEnergyMeter: !isFull
   })
 }
 
@@ -18,9 +23,9 @@ function getServiceType () {
 
 // The D-Bus service stays com.victronenergy.acload (see getServiceType above), but the
 // ProductId/ProductName dbus-victron-virtual reports on it should still reflect a grid meter
-// when used as one.
+// when presenting as a plain generic energy meter.
 function productType (config) {
-  return config.acload_grid_meter_only ? 'grid' : 'acload'
+  return isFullDevice(config) ? 'acload' : 'grid'
 }
 
 // For a single-phase acload, the physical phase it's wired to is configurable (acload_phasesetting)
@@ -30,17 +35,17 @@ function resolvePhase (config, i) {
 }
 
 function initialize (config, ifaceDesc, iface, node) {
-  const gridMeterOnly = !!config.acload_grid_meter_only
+  const isFull = isFullDevice(config)
 
   initializeMinimalMeter(config, ifaceDesc, iface, {
     nrOfPhases: config.acload_nrofphases,
-    includePosition: !gridMeterOnly,
+    includePosition: isFull,
     position: config.acload_position,
     phaseSetting: config.acload_phasesetting
   })
 
-  if (gridMeterOnly) {
-    return `Virtual ${iface.NrOfPhases}-phase AC load (grid meter mode)`
+  if (!isFull) {
+    return `Virtual ${iface.NrOfPhases}-phase AC load (generic energy meter)`
   }
 
   enableS2Support({
@@ -55,7 +60,7 @@ function initialize (config, ifaceDesc, iface, node) {
 }
 
 function onPropertiesChanged ({ changes, instance, config }) {
-  if (!config.acload_auto_energy || config.acload_grid_meter_only) return changes
+  if (!config.acload_auto_energy) return changes
 
   const now = Date.now()
   const nrOfPhases = Number(config.acload_nrofphases ?? 1)

--- a/src/nodes/victron-virtual/device-type/energymeter.js
+++ b/src/nodes/victron-virtual/device-type/energymeter.js
@@ -41,7 +41,10 @@ function buildProperties (config) {
   debug('Building properties for energy meter with config: %o', config)
 
   // make copy of sharedProperties to avoid modifying the original object
-  const properties = { ...sharedProperties }
+  const properties = {
+    ...sharedProperties,
+    IsGenericEnergyMeter: { ...sharedProperties.IsGenericEnergyMeter, value: config.energymeter_role === 'gridmeter' ? 1 : 0 }
+  }
 
   switch (config.energymeter_role) {
     case 'gridmeter':
@@ -95,6 +98,7 @@ function initialize (config, ifaceDesc, iface, node) {
     iface['Ac/Power'] = 0
     iface['Ac/Energy/Forward'] = 0
     iface['Ac/Energy/Reverse'] = 0
+    iface['Ac/PowerFactor'] = 0
   }
   return `Virtual ${iface.NrOfPhases}-phase energy meter`
 }

--- a/src/nodes/victron-virtual/device-type/evcs.js
+++ b/src/nodes/victron-virtual/device-type/evcs.js
@@ -1,0 +1,24 @@
+const { buildMinimalMeterProperties, initializeMinimalMeter } = require('./shared/minimal-meter')
+
+// Measurement-only, not a full EVSE simulator - always the minimal meter shape.
+const properties = buildMinimalMeterProperties({ includePosition: false })
+
+function initialize (config, ifaceDesc, iface, node) {
+  initializeMinimalMeter(config, ifaceDesc, iface, {
+    nrOfPhases: config.evcs_nrofphases,
+    includePosition: false
+  })
+
+  return `Virtual ${iface.NrOfPhases}-phase EV charger`
+}
+
+// Registers as com.victronenergy.evcharger on D-Bus - see minimal-meter.js.
+function getServiceType () {
+  return 'evcharger'
+}
+
+function productType () {
+  return 'grid'
+}
+
+module.exports = { properties, initialize, getServiceType, productType, label: 'EV charger' }

--- a/src/nodes/victron-virtual/device-type/generator.js
+++ b/src/nodes/victron-virtual/device-type/generator.js
@@ -1,3 +1,5 @@
+const { buildMinimalMeterProperties, initializeMinimalMeter } = require('./shared/minimal-meter')
+
 const ENERGY_PERSIST_SECONDS = 60
 
 const commonGeneratorProperties = {
@@ -50,14 +52,17 @@ const commonGeneratorProperties = {
   Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1, immediate: true }
 }
 
+const gensetProperties = {
+  ...commonGeneratorProperties,
+  'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(1) + 'Hz' : '' },
+  NrOfPhases: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
+}
+
 const properties = {
-  genset: {
-    ...commonGeneratorProperties,
-    'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
-    'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
-    'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(1) + 'Hz' : '' },
-    NrOfPhases: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
-  },
+  // "Use as grid meter only" switches to the minimal meter shape - see minimal-meter.js.
+  genset: (config) => config.generator_grid_meter_only ? buildMinimalMeterProperties({ includePosition: false }) : gensetProperties,
   dcgenset: {
     ...commonGeneratorProperties,
     'Dc/0/Current': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'A' : '' },
@@ -75,6 +80,19 @@ const properties = {
   }
 }
 
+// Mirrors the genset/dcgenset ternary in index.js's getActualDeviceType(). D-Bus service stays
+// genset/dcgenset even in "Use as grid meter only" mode - see productType below.
+function getServiceType (config) {
+  return config.generator_type === 'dc' ? 'dcgenset' : 'genset'
+}
+
+// "Use as grid meter only" (AC only) keeps the D-Bus service as com.victronenergy.genset (see
+// getServiceType), but the reported ProductId should still reflect a grid meter when used as one.
+function productType (config) {
+  if (config.generator_type !== 'dc' && config.generator_grid_meter_only) return 'grid'
+  return config.generator_type === 'dc' ? 'dcgenset' : 'genset'
+}
+
 const acPhaseProperties = [
   { name: 'Current', unit: 'A' },
   { name: 'Power', unit: 'W' },
@@ -83,6 +101,15 @@ const acPhaseProperties = [
 
 function initialize (config, ifaceDesc, iface, node) {
   const generatorType = config.generator_type === 'dc' ? 'dcgenset' : 'genset'
+
+  if (generatorType === 'genset' && config.generator_grid_meter_only) {
+    initializeMinimalMeter(config, ifaceDesc, iface, {
+      nrOfPhases: config.generator_nrofphases,
+      includePosition: false
+    })
+    return `Virtual ${iface.NrOfPhases}-phase AC generator (grid meter mode)`
+  }
+
   const nrOfPhases = Number(config.generator_nrofphases ?? 1)
 
   if (generatorType === 'genset') {
@@ -147,4 +174,4 @@ function initialize (config, ifaceDesc, iface, node) {
   return `Virtual ${generatorType === 'dcgenset' ? 'DC' : `${nrOfPhases}-phase AC`} generator`
 }
 
-module.exports = { properties, initialize, label: 'Generator' }
+module.exports = { properties, getServiceType, productType, initialize, label: 'Generator' }

--- a/src/nodes/victron-virtual/device-type/generator.js
+++ b/src/nodes/victron-virtual/device-type/generator.js
@@ -49,7 +49,8 @@ const commonGeneratorProperties = {
   StarterVoltage: { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'V' : '', persist: true, immediate: true },
   FirmwareVersion: { type: 's', format: (v) => v != null ? v : '', persist: true },
   Model: { type: 's', format: (v) => v != null ? v : '', persist: true },
-  Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1, immediate: true }
+  Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1, immediate: true },
+  IsGenericEnergyMeter: { type: 'i', format: (v) => v != null ? v : '', value: 0 }
 }
 
 const gensetProperties = {

--- a/src/nodes/victron-virtual/device-type/heatpump.js
+++ b/src/nodes/victron-virtual/device-type/heatpump.js
@@ -2,13 +2,18 @@ const { accumulateDelta } = require('../energy-utils')
 const { enableS2Support } = require('../s2-support')
 const { buildMinimalMeterProperties, initializeMinimalMeter } = require('./shared/minimal-meter')
 
-// "Use as grid meter only" reports a minimal measurement set (see minimal-meter.js) for use as
-// the system's grid meter, but - unlike acload/generator/evcs - stays registered as
-// com.victronenergy.heatpump on D-Bus rather than switching to com.victronenergy.grid.
+// Presents as a plain generic energy meter by default (see minimal-meter.js). Enabling S2
+// support is the only thing that adds extra paths (Position/PhaseSetting plus the S2 paths
+// themselves), promoting it to its own full heat pump device.
+function isFullDevice (config) {
+  return !!config.enable_s2support
+}
+
 function properties (config) {
+  const isFull = isFullDevice(config)
   return buildMinimalMeterProperties({
-    includePosition: !config.heatpump_grid_meter_only,
-    isGenericEnergyMeter: !!config.heatpump_grid_meter_only
+    includePosition: isFull,
+    isGenericEnergyMeter: !isFull
   })
 }
 
@@ -18,9 +23,9 @@ function getServiceType () {
 
 // The D-Bus service stays com.victronenergy.heatpump (see getServiceType above), but the
 // ProductId/ProductName dbus-victron-virtual reports on it should still reflect a grid meter
-// when used as one.
+// when presenting as a plain generic energy meter.
 function productType (config) {
-  return config.heatpump_grid_meter_only ? 'grid' : 'heatpump'
+  return isFullDevice(config) ? 'heatpump' : 'grid'
 }
 
 // For a single-phase heat pump, the physical phase it's wired to is configurable
@@ -30,17 +35,17 @@ function resolvePhase (config, i) {
 }
 
 function initialize (config, ifaceDesc, iface, node) {
-  const gridMeterOnly = !!config.heatpump_grid_meter_only
+  const isFull = isFullDevice(config)
 
   initializeMinimalMeter(config, ifaceDesc, iface, {
     nrOfPhases: config.heatpump_nrofphases,
-    includePosition: !gridMeterOnly,
+    includePosition: isFull,
     position: config.heatpump_position,
     phaseSetting: config.heatpump_phasesetting
   })
 
-  if (gridMeterOnly) {
-    return `Virtual ${iface.NrOfPhases}-phase heat pump (grid meter mode)`
+  if (!isFull) {
+    return `Virtual ${iface.NrOfPhases}-phase heat pump (generic energy meter)`
   }
 
   enableS2Support({
@@ -55,7 +60,7 @@ function initialize (config, ifaceDesc, iface, node) {
 }
 
 function onPropertiesChanged ({ changes, instance, config }) {
-  if (!config.heatpump_auto_energy || config.heatpump_grid_meter_only) return changes
+  if (!config.heatpump_auto_energy) return changes
 
   const now = Date.now()
   const nrOfPhases = Number(config.heatpump_nrofphases ?? 1)

--- a/src/nodes/victron-virtual/device-type/heatpump.js
+++ b/src/nodes/victron-virtual/device-type/heatpump.js
@@ -3,44 +3,44 @@ const { enableS2Support } = require('../s2-support')
 const { buildMinimalMeterProperties, initializeMinimalMeter } = require('./shared/minimal-meter')
 
 // "Use as grid meter only" reports a minimal measurement set (see minimal-meter.js) for use as
-// the system's grid meter, but stays registered as com.victronenergy.acload on D-Bus rather than
-// switching to com.victronenergy.grid.
+// the system's grid meter, but - unlike acload/generator/evcs - stays registered as
+// com.victronenergy.heatpump on D-Bus rather than switching to com.victronenergy.grid.
 function properties (config) {
   return buildMinimalMeterProperties({
-    includePosition: !config.acload_grid_meter_only,
-    isGenericEnergyMeter: !!config.acload_grid_meter_only
+    includePosition: !config.heatpump_grid_meter_only,
+    isGenericEnergyMeter: !!config.heatpump_grid_meter_only
   })
 }
 
 function getServiceType () {
-  return 'acload'
+  return 'heatpump'
 }
 
-// The D-Bus service stays com.victronenergy.acload (see getServiceType above), but the
+// The D-Bus service stays com.victronenergy.heatpump (see getServiceType above), but the
 // ProductId/ProductName dbus-victron-virtual reports on it should still reflect a grid meter
 // when used as one.
 function productType (config) {
-  return config.acload_grid_meter_only ? 'grid' : 'acload'
+  return config.heatpump_grid_meter_only ? 'grid' : 'heatpump'
 }
 
-// For a single-phase acload, the physical phase it's wired to is configurable (acload_phasesetting)
-// instead of always being L1. Multi-phase configs always start at L1.
+// For a single-phase heat pump, the physical phase it's wired to is configurable
+// (heatpump_phasesetting) instead of always being L1. Multi-phase configs always start at L1.
 function resolvePhase (config, i) {
-  return Number(config.acload_nrofphases ?? 1) === 1 ? Number(config.acload_phasesetting ?? 1) : i
+  return Number(config.heatpump_nrofphases ?? 1) === 1 ? Number(config.heatpump_phasesetting ?? 1) : i
 }
 
 function initialize (config, ifaceDesc, iface, node) {
-  const gridMeterOnly = !!config.acload_grid_meter_only
+  const gridMeterOnly = !!config.heatpump_grid_meter_only
 
   initializeMinimalMeter(config, ifaceDesc, iface, {
-    nrOfPhases: config.acload_nrofphases,
+    nrOfPhases: config.heatpump_nrofphases,
     includePosition: !gridMeterOnly,
-    position: config.acload_position,
-    phaseSetting: config.acload_phasesetting
+    position: config.heatpump_position,
+    phaseSetting: config.heatpump_phasesetting
   })
 
   if (gridMeterOnly) {
-    return `Virtual ${iface.NrOfPhases}-phase AC load (grid meter mode)`
+    return `Virtual ${iface.NrOfPhases}-phase heat pump (grid meter mode)`
   }
 
   enableS2Support({
@@ -48,17 +48,17 @@ function initialize (config, ifaceDesc, iface, node) {
     ifaceDesc,
     iface,
     node,
-    deviceLabel: 'acload'
+    deviceLabel: 'heatpump'
   })
 
-  return `Virtual ${iface.NrOfPhases}-phase AC load`
+  return `Virtual ${iface.NrOfPhases}-phase heat pump`
 }
 
 function onPropertiesChanged ({ changes, instance, config }) {
-  if (!config.acload_auto_energy || config.acload_grid_meter_only) return changes
+  if (!config.heatpump_auto_energy || config.heatpump_grid_meter_only) return changes
 
   const now = Date.now()
-  const nrOfPhases = Number(config.acload_nrofphases ?? 1)
+  const nrOfPhases = Number(config.heatpump_nrofphases ?? 1)
   let anyPhaseUpdated = false
   let phaseTotal = 0
 
@@ -90,4 +90,4 @@ function onPropertiesChanged ({ changes, instance, config }) {
   return changes
 }
 
-module.exports = { properties, getServiceType, productType, initialize, onPropertiesChanged, label: 'AC Load', supportsS2: true }
+module.exports = { properties, getServiceType, productType, initialize, onPropertiesChanged, label: 'Heat pump', supportsS2: true }

--- a/src/nodes/victron-virtual/device-type/shared/minimal-meter.js
+++ b/src/nodes/victron-virtual/device-type/shared/minimal-meter.js
@@ -1,0 +1,83 @@
+const ENERGY_PERSIST_SECONDS = 60
+
+// Generic "minimal meter" D-Bus shape (see
+// https://github.com/victronenergy/venus/wiki/dbus#grid-and-genset-and-acload-and-heatpump-meter -
+// Ac/Frequency is missing there, a gap in that page). Position/PhaseSetting are valid for
+// acload and heatpump only - callers opt in via `includePosition`.
+const sharedProperties = {
+  'Ac/Energy/Forward': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Energy/Reverse': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'kWh' : '', persist: ENERGY_PERSIST_SECONDS },
+  'Ac/Frequency': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'Hz' : '' },
+  'Ac/Power': { type: 'd', format: (v) => v != null ? v.toFixed(2) + 'W' : '' },
+  'Ac/PowerFactor': { type: 'd', format: (v) => v != null ? v.toFixed(2) : '' },
+  Connected: { type: 'i', format: (v) => v != null ? v : '', value: 1 },
+  DeviceType: { type: 'i', format: (v) => v != null ? v : '', value: 0 },
+  ErrorCode: { type: 'i', format: (v) => v != null ? v : '', value: 0 },
+  IsGenericEnergyMeter: { type: 'i', format: (v) => v != null ? v : '', value: 1 },
+  NrOfPhases: { type: 'i', format: (v) => v != null ? v : '', value: 1 }
+}
+
+const phaseProperties = [
+  { name: 'Current', unit: 'A' },
+  { name: 'Energy/Forward', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
+  { name: 'Energy/Reverse', unit: 'kWh', persist: ENERGY_PERSIST_SECONDS },
+  { name: 'Power', unit: 'W' },
+  { name: 'PowerFactor', unit: '' },
+  { name: 'Voltage', unit: 'V' }
+]
+
+function buildMinimalMeterProperties ({ includePosition, isGenericEnergyMeter = true }) {
+  const properties = {
+    ...sharedProperties,
+    IsGenericEnergyMeter: { ...sharedProperties.IsGenericEnergyMeter, value: isGenericEnergyMeter ? 1 : 0 }
+  }
+  if (includePosition) {
+    properties.Position = {
+      type: 'i',
+      format: (v) => ({
+        0: 'AC output',
+        1: 'AC input'
+      }[v] || 'unknown')
+    }
+  }
+  return properties
+}
+
+function initializeMinimalMeter (config, ifaceDesc, iface, { nrOfPhases, includePosition, position, phaseSetting }) {
+  if (includePosition) {
+    iface.Position = Number(position ?? 0)
+  }
+  iface.NrOfPhases = Number(nrOfPhases ?? 1)
+
+  const isSinglePhase = iface.NrOfPhases === 1
+  let singlePhaseNumber = 1
+  if (isSinglePhase && includePosition) {
+    singlePhaseNumber = Number(phaseSetting ?? 1)
+    iface.PhaseSetting = singlePhaseNumber
+    ifaceDesc.properties.PhaseSetting = { type: 'i', format: (v) => v != null ? 'L' + v : '' }
+  }
+
+  for (let i = 1; i <= iface.NrOfPhases; i++) {
+    const phase = `L${isSinglePhase ? singlePhaseNumber : i}`
+    phaseProperties.forEach(({ name, unit, persist }) => {
+      const key = `Ac/${phase}/${name}`
+      const propDef = {
+        type: 'd',
+        format: (v) => v != null ? v.toFixed(2) + unit : '',
+        ...(persist && { persist })
+      }
+      ifaceDesc.properties[key] = propDef
+      iface[key] = 0
+    })
+  }
+
+  if (config.default_values) {
+    iface['Ac/Power'] = 0
+    iface['Ac/Energy/Forward'] = 0
+    iface['Ac/Energy/Reverse'] = 0
+    iface['Ac/Frequency'] = 50
+    iface['Ac/PowerFactor'] = 0
+  }
+}
+
+module.exports = { buildMinimalMeterProperties, initializeMinimalMeter }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -79,7 +79,10 @@ const DEVICE_TYPES = [
   { value: 'temperature', label: 'Temperature sensor' }
 ]
 
-// Kept working for already-deployed nodes, but no longer offered for new ones.
+// Kept working for already-deployed nodes, but not offered for new ones. Still included in
+// DEVICE_TYPES (flagged legacyOnly) rather than omitted entirely, so the editor can still
+// resolve/display the correct option for an existing node using one of these - see the
+// legacyOnly filtering in victron-virtual.html's oneditprepare.
 const LEGACY_ONLY_DEVICE_TYPES = new Set(['energymeter'])
 
 const registeredModules = new Set(Object.keys(deviceModules))
@@ -93,13 +96,12 @@ try {
         const mod = require(path.join(__dirname, 'device-type', name))
         deviceModules[name] = mod
         properties[name] = mod.properties
-        if (LEGACY_ONLY_DEVICE_TYPES.has(name)) {
-          debug(`Loaded legacy-only virtual device type: ${name} (not advertised)`)
-          return
-        }
+        const legacyOnly = LEGACY_ONLY_DEVICE_TYPES.has(name)
         const label = mod.label || (name.charAt(0).toUpperCase() + name.slice(1))
-        DEVICE_TYPES.push({ value: name, label })
-        debug(`Loaded virtual device type: ${name} (${label})`)
+        DEVICE_TYPES.push({ value: name, label, legacyOnly })
+        debug(legacyOnly
+          ? `Loaded legacy-only virtual device type: ${name} (not advertised for new nodes)`
+          : `Loaded virtual device type: ${name} (${label})`)
       } catch (err) {
         console.error(`Failed to load virtual device type "${name}":`, err)
       }

--- a/src/nodes/victron-virtual/index.js
+++ b/src/nodes/victron-virtual/index.js
@@ -79,6 +79,9 @@ const DEVICE_TYPES = [
   { value: 'temperature', label: 'Temperature sensor' }
 ]
 
+// Kept working for already-deployed nodes, but no longer offered for new ones.
+const LEGACY_ONLY_DEVICE_TYPES = new Set(['energymeter'])
+
 const registeredModules = new Set(Object.keys(deviceModules))
 try {
   fs.readdirSync(path.join(__dirname, 'device-type'))
@@ -90,6 +93,10 @@ try {
         const mod = require(path.join(__dirname, 'device-type', name))
         deviceModules[name] = mod
         properties[name] = mod.properties
+        if (LEGACY_ONLY_DEVICE_TYPES.has(name)) {
+          debug(`Loaded legacy-only virtual device type: ${name} (not advertised)`)
+          return
+        }
         const label = mod.label || (name.charAt(0).toUpperCase() + name.slice(1))
         DEVICE_TYPES.push({ value: name, label })
         debug(`Loaded virtual device type: ${name} (${label})`)
@@ -100,6 +107,8 @@ try {
 } catch (err) {
   console.error('Failed to load virtual device types:', err)
 }
+
+DEVICE_TYPES.sort((a, b) => a.label.localeCompare(b.label))
 
 // Annotates DEVICE_TYPES with capability flags declared by each module (e.g. supportsS2), so the
 // editor can generalize S2-support UI/output wiring without hardcoding device names.
@@ -529,7 +538,7 @@ module.exports = function (RED) {
 
         const moduleProductType = deviceModules[config.device]?.productType
         if (moduleProductType) {
-          ifaceDesc.productType = moduleProductType
+          ifaceDesc.productType = typeof moduleProductType === 'function' ? moduleProductType(config) : moduleProductType
         }
 
         // Then we need to create the interface implementation (with actual functions)
@@ -916,3 +925,5 @@ module.exports = function (RED) {
 
 // Exported for direct unit testing without needing a full RED/D-Bus mock.
 module.exports.annotateDeviceTypesWithCapabilities = annotateDeviceTypesWithCapabilities
+module.exports.DEVICE_TYPES = DEVICE_TYPES
+module.exports.deviceModules = deviceModules

--- a/src/nodes/victron-virtual/s2-support.js
+++ b/src/nodes/victron-virtual/s2-support.js
@@ -66,7 +66,9 @@ function enableS2Support ({ config, ifaceDesc, iface, node, deviceLabel, resourc
     Connect: function (cemId, timeout) {
       node._s2PowerMeasurementActive = false
       node._s2PowerMeasurementCemId = null
-      node.setValuesLocally({ 'S2/0/Active': 1, 'S2/0/Rm': 'CEM: ' + cemId })
+      // Per spec, Active reflects a selected control type other than NO_CONTROL, not mere
+      // transport connection - the flow sets it once it activates one.
+      node.setValuesLocally({ 'S2/0/Rm': 'CEM: ' + cemId })
       console.log('Connect received for CEM ID:', cemId, 'timeout', timeout)
       node.send([
         null,

--- a/test/victron-virtual-acload-productid.test.js
+++ b/test/victron-virtual-acload-productid.test.js
@@ -1,0 +1,38 @@
+// test/victron-virtual-acload-productid.test.js
+/* eslint-env jest */
+const { addVictronInterfaces } = require('dbus-victron-virtual')
+const acload = require('../src/nodes/victron-virtual/device-type/acload')
+
+function makeBus () {
+  return { exportInterface: jest.fn() }
+}
+
+function makeIfaceDesc (name, productType) {
+  const desc = {
+    name,
+    methods: {},
+    properties: { Connected: { type: 'i' } },
+    signals: {}
+  }
+  if (productType !== undefined) {
+    desc.productType = productType
+  }
+  return desc
+}
+
+// The AC load's D-Bus service always stays com.victronenergy.acload (see acload.js
+// getServiceType) even in "Use as grid meter only" mode, so the productType override is what
+// makes the reported ProductId reflect a grid meter instead of an AC load.
+describe('virtual acload ProductId', () => {
+  test('normal mode: acload productType gives AC load ProductId', () => {
+    const iface = { emit: jest.fn(), Connected: 1 }
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.acload.virtual_test', acload.productType({})), iface, true, null)
+    expect(iface.ProductId).toBe(0xc06a)
+  })
+
+  test('grid meter only mode: grid productType gives grid meter ProductId', () => {
+    const iface = { emit: jest.fn(), Connected: 1 }
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.acload.virtual_test', acload.productType({ acload_grid_meter_only: true })), iface, true, null)
+    expect(iface.ProductId).toBe(0xc062)
+  })
+})

--- a/test/victron-virtual-acload-productid.test.js
+++ b/test/victron-virtual-acload-productid.test.js
@@ -21,18 +21,18 @@ function makeIfaceDesc (name, productType) {
 }
 
 // The AC load's D-Bus service always stays com.victronenergy.acload (see acload.js
-// getServiceType) even in "Use as grid meter only" mode, so the productType override is what
+// getServiceType) even as a plain generic energy meter, so the productType override is what
 // makes the reported ProductId reflect a grid meter instead of an AC load.
 describe('virtual acload ProductId', () => {
-  test('normal mode: acload productType gives AC load ProductId', () => {
+  test('full device (S2 enabled): acload productType gives AC load ProductId', () => {
     const iface = { emit: jest.fn(), Connected: 1 }
-    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.acload.virtual_test', acload.productType({})), iface, true, null)
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.acload.virtual_test', acload.productType({ enable_s2support: true })), iface, true, null)
     expect(iface.ProductId).toBe(0xc06a)
   })
 
-  test('grid meter only mode: grid productType gives grid meter ProductId', () => {
+  test('generic energy meter mode: grid productType gives grid meter ProductId', () => {
     const iface = { emit: jest.fn(), Connected: 1 }
-    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.acload.virtual_test', acload.productType({ acload_grid_meter_only: true })), iface, true, null)
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.acload.virtual_test', acload.productType({})), iface, true, null)
     expect(iface.ProductId).toBe(0xc062)
   })
 })

--- a/test/victron-virtual-acload.test.js
+++ b/test/victron-virtual-acload.test.js
@@ -4,7 +4,9 @@ const acload = require('../src/nodes/victron-virtual/device-type/acload')
 
 describe('acload device module', () => {
   test('exports required contract', () => {
-    expect(typeof acload.properties).toBe('object')
+    expect(typeof acload.properties).toBe('function')
+    expect(typeof acload.getServiceType).toBe('function')
+    expect(typeof acload.productType).toBe('function')
     expect(typeof acload.initialize).toBe('function')
     expect(typeof acload.onPropertiesChanged).toBe('function')
   })
@@ -243,6 +245,70 @@ describe('acload device module', () => {
         config: { acload_auto_energy: true, acload_nrofphases: 1 }
       })
       expect(result['Ac/Energy/Forward'] ?? 0).toBeCloseTo(0, 3)
+    })
+  })
+
+  describe('grid meter only mode', () => {
+    test('getServiceType always returns acload', () => {
+      expect(acload.getServiceType({ acload_grid_meter_only: true })).toBe('acload')
+      expect(acload.getServiceType({ acload_grid_meter_only: false })).toBe('acload')
+      expect(acload.getServiceType({})).toBe('acload')
+    })
+
+    test('productType returns grid when enabled, acload otherwise', () => {
+      expect(acload.productType({ acload_grid_meter_only: true })).toBe('grid')
+      expect(acload.productType({ acload_grid_meter_only: false })).toBe('acload')
+      expect(acload.productType({})).toBe('acload')
+    })
+
+    test('properties omit Position when enabled, include it otherwise', () => {
+      expect(acload.properties({ acload_grid_meter_only: true }).Position).toBeUndefined()
+      expect(acload.properties({ acload_grid_meter_only: false }).Position).toBeDefined()
+      expect(acload.properties({}).Position).toBeDefined()
+    })
+
+    test('properties declare IsGenericEnergyMeter as 1 when enabled, 0 otherwise', () => {
+      expect(acload.properties({ acload_grid_meter_only: true }).IsGenericEnergyMeter.value).toBe(1)
+      expect(acload.properties({ acload_grid_meter_only: false }).IsGenericEnergyMeter.value).toBe(0)
+      expect(acload.properties({}).IsGenericEnergyMeter.value).toBe(0)
+    })
+
+    test('properties do not expose S2/0/RmSettings/* in either mode', () => {
+      const gridMeter = acload.properties({ acload_grid_meter_only: true })
+      const normal = acload.properties({ acload_grid_meter_only: false })
+      expect(Object.keys(gridMeter).some(k => k.startsWith('S2/0/RmSettings/'))).toBe(false)
+      expect(Object.keys(normal).some(k => k.startsWith('S2/0/RmSettings/'))).toBe(false)
+    })
+
+    test('initialize does not add Position/PhaseSetting when enabled', () => {
+      const ifaceDesc = { properties: {} }
+      const iface = {}
+      const node = { error: jest.fn() }
+      acload.initialize({ acload_nrofphases: 1, acload_grid_meter_only: true }, ifaceDesc, iface, node)
+      expect(iface.Position).toBeUndefined()
+      expect(iface.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.properties.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/L1/Power']).toBeDefined()
+    })
+
+    test('initialize does not enable S2 support even when enable_s2support is set', () => {
+      const ifaceDesc = { properties: {} }
+      const iface = {}
+      const node = { error: jest.fn() }
+      acload.initialize({ acload_nrofphases: 1, acload_grid_meter_only: true, enable_s2support: true }, ifaceDesc, iface, node)
+      expect(ifaceDesc.__enableS2).toBeUndefined()
+    })
+
+    test('onPropertiesChanged is a no-op even when acload_auto_energy is true', () => {
+      const instance = { 'Ac/L1/Power': 500 }
+      const changes = { 'Ac/L1/Power': 600 }
+      const result = acload.onPropertiesChanged({
+        changes,
+        instance,
+        config: { acload_auto_energy: true, acload_grid_meter_only: true, acload_nrofphases: 1 }
+      })
+      expect(result).toBe(changes)
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
     })
   })
 })

--- a/test/victron-virtual-acload.test.js
+++ b/test/victron-virtual-acload.test.js
@@ -248,67 +248,66 @@ describe('acload device module', () => {
     })
   })
 
-  describe('grid meter only mode', () => {
+  describe('generic energy meter vs full device (S2 support)', () => {
     test('getServiceType always returns acload', () => {
-      expect(acload.getServiceType({ acload_grid_meter_only: true })).toBe('acload')
-      expect(acload.getServiceType({ acload_grid_meter_only: false })).toBe('acload')
+      expect(acload.getServiceType({ enable_s2support: true })).toBe('acload')
+      expect(acload.getServiceType({ enable_s2support: false })).toBe('acload')
       expect(acload.getServiceType({})).toBe('acload')
     })
 
-    test('productType returns grid when enabled, acload otherwise', () => {
-      expect(acload.productType({ acload_grid_meter_only: true })).toBe('grid')
-      expect(acload.productType({ acload_grid_meter_only: false })).toBe('acload')
-      expect(acload.productType({})).toBe('acload')
+    test('productType returns acload when S2 enabled, grid otherwise', () => {
+      expect(acload.productType({ enable_s2support: true })).toBe('acload')
+      expect(acload.productType({ enable_s2support: false })).toBe('grid')
+      expect(acload.productType({})).toBe('grid')
     })
 
-    test('properties omit Position when enabled, include it otherwise', () => {
-      expect(acload.properties({ acload_grid_meter_only: true }).Position).toBeUndefined()
-      expect(acload.properties({ acload_grid_meter_only: false }).Position).toBeDefined()
-      expect(acload.properties({}).Position).toBeDefined()
+    test('properties include Position when S2 enabled, omit it otherwise', () => {
+      expect(acload.properties({ enable_s2support: true }).Position).toBeDefined()
+      expect(acload.properties({ enable_s2support: false }).Position).toBeUndefined()
+      expect(acload.properties({}).Position).toBeUndefined()
     })
 
-    test('properties declare IsGenericEnergyMeter as 1 when enabled, 0 otherwise', () => {
-      expect(acload.properties({ acload_grid_meter_only: true }).IsGenericEnergyMeter.value).toBe(1)
-      expect(acload.properties({ acload_grid_meter_only: false }).IsGenericEnergyMeter.value).toBe(0)
-      expect(acload.properties({}).IsGenericEnergyMeter.value).toBe(0)
+    test('properties declare IsGenericEnergyMeter as 0 when S2 enabled, 1 otherwise', () => {
+      expect(acload.properties({ enable_s2support: true }).IsGenericEnergyMeter.value).toBe(0)
+      expect(acload.properties({ enable_s2support: false }).IsGenericEnergyMeter.value).toBe(1)
+      expect(acload.properties({}).IsGenericEnergyMeter.value).toBe(1)
     })
 
     test('properties do not expose S2/0/RmSettings/* in either mode', () => {
-      const gridMeter = acload.properties({ acload_grid_meter_only: true })
-      const normal = acload.properties({ acload_grid_meter_only: false })
-      expect(Object.keys(gridMeter).some(k => k.startsWith('S2/0/RmSettings/'))).toBe(false)
-      expect(Object.keys(normal).some(k => k.startsWith('S2/0/RmSettings/'))).toBe(false)
+      const generic = acload.properties({ enable_s2support: false })
+      const full = acload.properties({ enable_s2support: true })
+      expect(Object.keys(generic).some(k => k.startsWith('S2/0/RmSettings/'))).toBe(false)
+      expect(Object.keys(full).some(k => k.startsWith('S2/0/RmSettings/'))).toBe(false)
     })
 
-    test('initialize does not add Position/PhaseSetting when enabled', () => {
+    test('initialize does not add Position/PhaseSetting when S2 is disabled', () => {
       const ifaceDesc = { properties: {} }
       const iface = {}
       const node = { error: jest.fn() }
-      acload.initialize({ acload_nrofphases: 1, acload_grid_meter_only: true }, ifaceDesc, iface, node)
+      acload.initialize({ acload_nrofphases: 1 }, ifaceDesc, iface, node)
       expect(iface.Position).toBeUndefined()
       expect(iface.PhaseSetting).toBeUndefined()
       expect(ifaceDesc.properties.PhaseSetting).toBeUndefined()
       expect(ifaceDesc.properties['Ac/L1/Power']).toBeDefined()
     })
 
-    test('initialize does not enable S2 support even when enable_s2support is set', () => {
+    test('initialize returns the generic energy meter label when S2 is disabled', () => {
       const ifaceDesc = { properties: {} }
       const iface = {}
       const node = { error: jest.fn() }
-      acload.initialize({ acload_nrofphases: 1, acload_grid_meter_only: true, enable_s2support: true }, ifaceDesc, iface, node)
-      expect(ifaceDesc.__enableS2).toBeUndefined()
+      const result = acload.initialize({ acload_nrofphases: 1 }, ifaceDesc, iface, node)
+      expect(result).toBe('Virtual 1-phase AC load (generic energy meter)')
     })
 
-    test('onPropertiesChanged is a no-op even when acload_auto_energy is true', () => {
+    test('onPropertiesChanged still accumulates energy in generic energy meter mode', () => {
       const instance = { 'Ac/L1/Power': 500 }
       const changes = { 'Ac/L1/Power': 600 }
       const result = acload.onPropertiesChanged({
         changes,
         instance,
-        config: { acload_auto_energy: true, acload_grid_meter_only: true, acload_nrofphases: 1 }
+        config: { acload_auto_energy: true, acload_nrofphases: 1 }
       })
-      expect(result).toBe(changes)
-      expect(result['Ac/Energy/Forward']).toBeUndefined()
+      expect(result['Ac/Energy/Forward']).toBeDefined()
     })
   })
 })

--- a/test/victron-virtual-device-picker.test.js
+++ b/test/victron-virtual-device-picker.test.js
@@ -1,0 +1,33 @@
+// test/victron-virtual-device-picker.test.js
+/* eslint-env jest */
+const { DEVICE_TYPES, deviceModules } = require('../src/nodes/victron-virtual/index.js')
+
+describe('virtual device picker', () => {
+  test('DEVICE_TYPES includes the new heatpump and evcs types', () => {
+    const values = DEVICE_TYPES.map(dt => dt.value)
+    expect(values).toContain('heatpump')
+    expect(values).toContain('evcs')
+  })
+
+  test('DEVICE_TYPES no longer offers energymeter', () => {
+    const values = DEVICE_TYPES.map(dt => dt.value)
+    expect(values).not.toContain('energymeter')
+  })
+
+  test('deviceModules still resolves energymeter for already-deployed nodes', () => {
+    expect(deviceModules.energymeter).toBeDefined()
+    expect(typeof deviceModules.energymeter.initialize).toBe('function')
+  })
+
+  test('dynamically-discovered types are interleaved alphabetically, not appended at the end', () => {
+    const labels = DEVICE_TYPES.map(dt => dt.label)
+    const indexOf = label => labels.indexOf(label)
+
+    // These are auto-discovered (not in the hardcoded DEVICE_TYPES array), so without sorting
+    // they'd land after every hardcoded entry regardless of where they alphabetize.
+    expect(indexOf('EV charger')).toBeLessThan(indexOf('Generator'))
+    expect(indexOf('Heat pump')).toBeLessThan(indexOf('Meteo'))
+    expect(indexOf('Pulse meter')).toBeLessThan(indexOf('PV inverter'))
+    expect(indexOf('Pulse meter')).toBeGreaterThan(indexOf('Meteo'))
+  })
+})

--- a/test/victron-virtual-device-picker.test.js
+++ b/test/victron-virtual-device-picker.test.js
@@ -9,9 +9,15 @@ describe('virtual device picker', () => {
     expect(values).toContain('evcs')
   })
 
-  test('DEVICE_TYPES no longer offers energymeter', () => {
-    const values = DEVICE_TYPES.map(dt => dt.value)
-    expect(values).not.toContain('energymeter')
+  test('DEVICE_TYPES includes energymeter flagged legacyOnly, not offered for new nodes', () => {
+    const energymeter = DEVICE_TYPES.find(dt => dt.value === 'energymeter')
+    expect(energymeter).toBeDefined()
+    expect(energymeter.legacyOnly).toBe(true)
+  })
+
+  test('DEVICE_TYPES does not flag current device types as legacyOnly', () => {
+    const nonLegacy = DEVICE_TYPES.filter(dt => dt.value !== 'energymeter')
+    expect(nonLegacy.every(dt => !dt.legacyOnly)).toBe(true)
   })
 
   test('deviceModules still resolves energymeter for already-deployed nodes', () => {

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -33,7 +33,7 @@ describe('acload', () => {
   describe('initialize', () => {
     test('adds L1 phase properties for 1-phase', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      const result = acload.initialize({ acload_nrofphases: 1 }, ifaceDesc, iface, node)
+      const result = acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
       expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
       expect(ifaceDesc.properties['Ac/L2/Current']).toBeUndefined()
       expect(result).toBe('Virtual 1-phase AC load')
@@ -49,7 +49,7 @@ describe('acload', () => {
 
     test('labels single-phase properties with the configured PhaseSetting', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      acload.initialize({ acload_nrofphases: 1, acload_phasesetting: 3 }, ifaceDesc, iface, node)
+      acload.initialize({ acload_nrofphases: 1, acload_phasesetting: 3, enable_s2support: true }, ifaceDesc, iface, node)
       expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
       expect(iface['Ac/L3/Current']).toBe(0)
       expect(iface.PhaseSetting).toBe(3)
@@ -57,14 +57,14 @@ describe('acload', () => {
 
     test('defaults PhaseSetting to 1 (L1) when not set', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      acload.initialize({ acload_nrofphases: 1 }, ifaceDesc, iface, node)
+      acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
       expect(iface.PhaseSetting).toBe(1)
       expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
     })
 
     test('does not add PhaseSetting for multi-phase configs, and phases are labeled L1-L3 in order', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      acload.initialize({ acload_nrofphases: 3, acload_phasesetting: 2 }, ifaceDesc, iface, node)
+      acload.initialize({ acload_nrofphases: 3, acload_phasesetting: 2, enable_s2support: true }, ifaceDesc, iface, node)
       expect(iface.PhaseSetting).toBeUndefined()
       expect(ifaceDesc.properties.PhaseSetting).toBeUndefined()
       expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
@@ -72,23 +72,23 @@ describe('acload', () => {
       expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
     })
 
-    test('static properties declare IsGenericEnergyMeter as 0 in normal mode', () => {
-      expect(acload.properties({}).IsGenericEnergyMeter.value).toBe(0)
+    test('static properties declare IsGenericEnergyMeter as 1 by default (generic energy meter)', () => {
+      expect(acload.properties({}).IsGenericEnergyMeter.value).toBe(1)
     })
 
-    test('static properties declare IsGenericEnergyMeter as 1 in grid meter only mode', () => {
-      expect(acload.properties({ acload_grid_meter_only: true }).IsGenericEnergyMeter.value).toBe(1)
+    test('static properties declare IsGenericEnergyMeter as 0 when S2 support is enabled', () => {
+      expect(acload.properties({ enable_s2support: true }).IsGenericEnergyMeter.value).toBe(0)
     })
 
     test('sets Position from config', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      acload.initialize({ acload_nrofphases: 1, acload_position: 1 }, ifaceDesc, iface, node)
+      acload.initialize({ acload_nrofphases: 1, acload_position: 1, enable_s2support: true }, ifaceDesc, iface, node)
       expect(iface.Position).toBe(1)
     })
 
     test('defaults Position to 0 when not set', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      acload.initialize({ acload_nrofphases: 1 }, ifaceDesc, iface, node)
+      acload.initialize({ acload_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
       expect(iface.Position).toBe(0)
     })
 
@@ -216,7 +216,7 @@ describe('acload', () => {
       [1, 'AC input'],
       [99, 'unknown']
     ])('Position %i -> %s', (v, expected) => {
-      expect(acload.properties({}).Position.format(v)).toBe(expected)
+      expect(acload.properties({ enable_s2support: true }).Position.format(v)).toBe(expected)
     })
   })
 })

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -177,7 +177,7 @@ describe('acload', () => {
       expect(ifaceDesc.__s2Handlers).toBeUndefined()
     })
 
-    test('Connect handler resets power measurement state, updates S2 active/rm, and sends command on port 2', () => {
+    test('Connect handler resets power measurement state, updates S2 rm, and sends command on port 2', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       node.send = jest.fn()
       node.setValuesLocally = jest.fn()
@@ -187,7 +187,7 @@ describe('acload', () => {
       ifaceDesc.__s2Handlers.Connect('cem-1', 30)
       expect(node._s2PowerMeasurementActive).toBe(false)
       expect(node._s2PowerMeasurementCemId).toBeNull()
-      expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Active': 1, 'S2/0/Rm': 'CEM: cem-1' })
+      expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Rm': 'CEM: cem-1' })
       expect(node.send).toHaveBeenCalledWith([null, {
         payload: { command: 'Connect', cemId: 'cem-1', keepAliveInterval: 30 }
       }])

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -630,6 +630,12 @@ describe('generator', () => {
       expect(props['Ac/Power']).toBeDefined()
     })
 
+    test('IsGenericEnergyMeter is 1 for genset grid meter only, 0 for full genset/dcgenset', () => {
+      expect(generator.properties.genset({ generator_grid_meter_only: true }).IsGenericEnergyMeter.value).toBe(1)
+      expect(generator.properties.genset({ generator_grid_meter_only: false }).IsGenericEnergyMeter.value).toBe(0)
+      expect(generator.properties.dcgenset.IsGenericEnergyMeter.value).toBe(0)
+    })
+
     test('initialize returns grid meter mode label and skips engine/alarm setup', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       const result = generator.initialize({ generator_type: 'ac', generator_nrofphases: 3, generator_grid_meter_only: true }, ifaceDesc, iface, node)

--- a/test/victron-virtual-device-type-init.test.js
+++ b/test/victron-virtual-device-type-init.test.js
@@ -62,18 +62,6 @@ describe('acload', () => {
       expect(ifaceDesc.properties['Ac/L1/Current']).toBeDefined()
     })
 
-    test('removes the stale static L1 property set when relabeled to a different phase', () => {
-      const { iface, node } = makeFixtures()
-      const ifaceDesc = { properties: { 'Ac/L1/Current': { type: 'd' }, 'Ac/L1/Power': { type: 'd' } } }
-      iface['Ac/L1/Current'] = 0
-
-      acload.initialize({ acload_nrofphases: 1, acload_phasesetting: 2 }, ifaceDesc, iface, node)
-
-      expect(ifaceDesc.properties['Ac/L1/Current']).toBeUndefined()
-      expect(iface['Ac/L1/Current']).toBeUndefined()
-      expect(ifaceDesc.properties['Ac/L2/Current']).toBeDefined()
-    })
-
     test('does not add PhaseSetting for multi-phase configs, and phases are labeled L1-L3 in order', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
       acload.initialize({ acload_nrofphases: 3, acload_phasesetting: 2 }, ifaceDesc, iface, node)
@@ -84,8 +72,12 @@ describe('acload', () => {
       expect(ifaceDesc.properties['Ac/L3/Current']).toBeDefined()
     })
 
-    test('static properties declare IsGenericEnergyMeter as 1', () => {
-      expect(acload.properties.IsGenericEnergyMeter.value).toBe(1)
+    test('static properties declare IsGenericEnergyMeter as 0 in normal mode', () => {
+      expect(acload.properties({}).IsGenericEnergyMeter.value).toBe(0)
+    })
+
+    test('static properties declare IsGenericEnergyMeter as 1 in grid meter only mode', () => {
+      expect(acload.properties({ acload_grid_meter_only: true }).IsGenericEnergyMeter.value).toBe(1)
     })
 
     test('sets Position from config', () => {
@@ -106,6 +98,7 @@ describe('acload', () => {
       expect(iface['Ac/Power']).toBe(0)
       expect(iface['Ac/Energy/Forward']).toBe(0)
       expect(iface['Ac/Energy/Reverse']).toBe(0)
+      expect(iface['Ac/PowerFactor']).toBe(0)
     })
 
     test('does not set default values when disabled', () => {
@@ -115,8 +108,8 @@ describe('acload', () => {
     })
 
     test('energy properties in static properties have persist set', () => {
-      expect(acload.properties['Ac/Energy/Forward'].persist).toBeDefined()
-      expect(acload.properties['Ac/Energy/Reverse'].persist).toBeDefined()
+      expect(acload.properties({})['Ac/Energy/Forward'].persist).toBeDefined()
+      expect(acload.properties({})['Ac/Energy/Reverse'].persist).toBeDefined()
     })
 
     test('phase energy properties added by initialize have persist set', () => {
@@ -223,7 +216,7 @@ describe('acload', () => {
       [1, 'AC input'],
       [99, 'unknown']
     ])('Position %i -> %s', (v, expected) => {
-      expect(acload.properties.Position.format(v)).toBe(expected)
+      expect(acload.properties({}).Position.format(v)).toBe(expected)
     })
   })
 })
@@ -487,8 +480,17 @@ describe('ev', () => {
 
 describe('generator', () => {
   describe('productType', () => {
-    it('does not export productType so the library resolves it from the service name', () => {
-      expect(generator.productType).toBeUndefined()
+    it('returns genset/dcgenset outside grid meter only mode', () => {
+      expect(generator.productType({ generator_type: 'ac' })).toBe('genset')
+      expect(generator.productType({ generator_type: 'dc' })).toBe('dcgenset')
+    })
+
+    it('returns grid for AC in grid meter only mode', () => {
+      expect(generator.productType({ generator_type: 'ac', generator_grid_meter_only: true })).toBe('grid')
+    })
+
+    it('ignores generator_grid_meter_only for DC', () => {
+      expect(generator.productType({ generator_type: 'dc', generator_grid_meter_only: true })).toBe('dcgenset')
     })
   })
 
@@ -580,7 +582,7 @@ describe('generator', () => {
     })
 
     test('genset Ac/Energy/Forward has persist set', () => {
-      expect(generator.properties.genset['Ac/Energy/Forward'].persist).toBeDefined()
+      expect(generator.properties.genset({})['Ac/Energy/Forward'].persist).toBeDefined()
     })
 
     test('dcgenset History/EnergyOut has persist set', () => {
@@ -589,7 +591,7 @@ describe('generator', () => {
   })
 
   describe('format', () => {
-    const fmt = generator.properties.genset.StatusCode.format
+    const fmt = generator.properties.genset({}).StatusCode.format
     test.each([
       [0, 'Standby'],
       [8, 'Running'],
@@ -605,6 +607,35 @@ describe('generator', () => {
       expect(stateFmt(0)).toBe('Stopped')
       expect(stateFmt(1)).toBe('Running')
       expect(stateFmt(99)).toBe('unknown')
+    })
+  })
+
+  describe('grid meter only mode (AC only)', () => {
+    test('getServiceType still returns genset for AC when enabled', () => {
+      expect(generator.getServiceType({ generator_type: 'ac', generator_grid_meter_only: true })).toBe('genset')
+    })
+
+    test('getServiceType returns genset for AC when disabled', () => {
+      expect(generator.getServiceType({ generator_type: 'ac', generator_grid_meter_only: false })).toBe('genset')
+    })
+
+    test('getServiceType ignores generator_grid_meter_only for DC', () => {
+      expect(generator.getServiceType({ generator_type: 'dc', generator_grid_meter_only: true })).toBe('dcgenset')
+    })
+
+    test('genset properties omit Position and engine/alarm data when enabled', () => {
+      const props = generator.properties.genset({ generator_grid_meter_only: true })
+      expect(props.Position).toBeUndefined()
+      expect(props['Engine/OperatingHours']).toBeUndefined()
+      expect(props['Ac/Power']).toBeDefined()
+    })
+
+    test('initialize returns grid meter mode label and skips engine/alarm setup', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      const result = generator.initialize({ generator_type: 'ac', generator_nrofphases: 3, generator_grid_meter_only: true }, ifaceDesc, iface, node)
+      expect(result).toBe('Virtual 3-phase AC generator (grid meter mode)')
+      expect(ifaceDesc.properties['Engine/OperatingHours']).toBeUndefined()
+      expect(ifaceDesc.properties['Ac/L1/Power']).toBeDefined()
     })
   })
 })
@@ -1104,6 +1135,14 @@ describe('energymeter', () => {
       expect(energymeter.properties({}).Position.format(0)).toBe('output')
       expect(energymeter.properties({}).Position.format(1)).toBe('input')
     })
+
+    it.each(['acload', 'heatpump', 'evcharger', 'inverter', 'generator'])('declares IsGenericEnergyMeter as 0 for role "%s"', (role) => {
+      expect(energymeter.properties({ energymeter_role: role }).IsGenericEnergyMeter.value).toBe(0)
+    })
+
+    it('declares IsGenericEnergyMeter as 1 for role "gridmeter"', () => {
+      expect(energymeter.properties({ energymeter_role: 'gridmeter' }).IsGenericEnergyMeter.value).toBe(1)
+    })
   })
 
   describe('getServiceType', () => {
@@ -1178,6 +1217,7 @@ describe('energymeter', () => {
       expect(iface['Ac/Power']).toBe(0)
       expect(iface['Ac/Energy/Forward']).toBe(0)
       expect(iface['Ac/Energy/Reverse']).toBe(0)
+      expect(iface['Ac/PowerFactor']).toBe(0)
     })
 
     it('shared energy properties have persist set', () => {

--- a/test/victron-virtual-evcs-productid.test.js
+++ b/test/victron-virtual-evcs-productid.test.js
@@ -1,0 +1,35 @@
+// test/victron-virtual-evcs-productid.test.js
+/* eslint-env jest */
+const { addVictronInterfaces } = require('dbus-victron-virtual')
+const evcs = require('../src/nodes/victron-virtual/device-type/evcs')
+
+function makeBus () {
+  return { exportInterface: jest.fn() }
+}
+
+function makeIfaceDesc (name, productType) {
+  const desc = {
+    name,
+    methods: {},
+    properties: { Connected: { type: 'i' } },
+    signals: {}
+  }
+  if (productType !== undefined) {
+    desc.productType = productType
+  }
+  return desc
+}
+
+describe('virtual evcs ProductId', () => {
+  test('evcharger service without productType override gets no ProductId', () => {
+    const iface = { emit: jest.fn(), Connected: 1 }
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.evcharger.virtual_test'), iface, true, null)
+    expect(iface.ProductId).toBeUndefined()
+  })
+
+  test('grid productType override gives grid meter ProductId', () => {
+    const iface = { emit: jest.fn(), Connected: 1 }
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.evcharger.virtual_test', evcs.productType()), iface, true, null)
+    expect(iface.ProductId).toBe(0xc062)
+  })
+})

--- a/test/victron-virtual-evcs.test.js
+++ b/test/victron-virtual-evcs.test.js
@@ -1,0 +1,58 @@
+// test/victron-virtual-evcs.test.js
+/* eslint-env jest */
+const evcs = require('../src/nodes/victron-virtual/device-type/evcs')
+
+function makeFixtures () {
+  return {
+    ifaceDesc: { properties: {} },
+    iface: {},
+    node: { error: jest.fn() }
+  }
+}
+
+describe('evcs (EV charger) device module', () => {
+  test('exports required contract', () => {
+    expect(typeof evcs.properties).toBe('object')
+    expect(typeof evcs.initialize).toBe('function')
+    expect(typeof evcs.getServiceType).toBe('function')
+    expect(typeof evcs.productType).toBe('function')
+    expect(evcs.supportsS2).not.toBe(true)
+  })
+
+  test('getServiceType always returns evcharger', () => {
+    expect(evcs.getServiceType()).toBe('evcharger')
+    expect(evcs.getServiceType({})).toBe('evcharger')
+  })
+
+  test('productType always returns grid', () => {
+    expect(evcs.productType()).toBe('grid')
+    expect(evcs.productType({})).toBe('grid')
+  })
+
+  test('properties omit Position/PhaseSetting', () => {
+    expect(evcs.properties.Position).toBeUndefined()
+  })
+
+  test('properties include the minimal generic meter fields', () => {
+    expect(evcs.properties['Ac/Power']).toBeDefined()
+    expect(evcs.properties.IsGenericEnergyMeter.value).toBe(1)
+  })
+
+  test('initialize adds phase properties and returns a label', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    const result = evcs.initialize({ evcs_nrofphases: 3 }, ifaceDesc, iface, node)
+    expect(ifaceDesc.properties['Ac/L1/Power']).toBeDefined()
+    expect(ifaceDesc.properties['Ac/L2/Power']).toBeDefined()
+    expect(ifaceDesc.properties['Ac/L3/Power']).toBeDefined()
+    expect(iface.Position).toBeUndefined()
+    expect(result).toBe('Virtual 3-phase EV charger')
+  })
+
+  test('initialize defaults to 1 phase', () => {
+    const { ifaceDesc, iface, node } = makeFixtures()
+    evcs.initialize({}, ifaceDesc, iface, node)
+    expect(iface.NrOfPhases).toBe(1)
+    expect(ifaceDesc.properties['Ac/L1/Power']).toBeDefined()
+    expect(ifaceDesc.properties['Ac/L2/Power']).toBeUndefined()
+  })
+})

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -303,8 +303,8 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
 
       checkSelectedVirtualDevice()
 
-      expect(mockNrOfPhasesSelect.off).toHaveBeenCalledWith('change.acload-phasesetting')
-      expect(mockNrOfPhasesSelect.on).toHaveBeenCalledWith('change.acload-phasesetting', expect.any(Function))
+      expect(mockNrOfPhasesSelect.off).toHaveBeenCalledWith('change.phasesetting')
+      expect(mockNrOfPhasesSelect.on).toHaveBeenCalledWith('change.phasesetting', expect.any(Function))
       expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
     })
 
@@ -441,145 +441,6 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
           return mockNrOfPhasesSelect
         }
         if (selector === '#acload-phasesetting-row') {
-          return mockPhaseSettingRow
-        }
-        if (selector.startsWith('.input-')) {
-          return createMockElement()
-        }
-        return createMockElement()
-      })
-
-      checkSelectedVirtualDevice()
-
-      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
-    })
-
-    test('shows energymeter Position row for a role where it is configurable', () => {
-      const mockRoleSelect = createMockElement({ val: 'acload' })
-      const mockPositionRow = createMockElement()
-
-      global.$.mockImplementation((selector) => {
-        if (selector === 'select#node-input-device') {
-          return createMockElement({ val: 'energymeter' })
-        }
-        if (selector === '#node-input-energymeter_role') {
-          return mockRoleSelect
-        }
-        if (selector === '#energymeter-position-row') {
-          return mockPositionRow
-        }
-        if (selector.startsWith('.input-')) {
-          return createMockElement()
-        }
-        return createMockElement()
-      })
-
-      checkSelectedVirtualDevice()
-
-      expect(mockRoleSelect.off).toHaveBeenCalledWith('change.energymeter-position')
-      expect(mockRoleSelect.on).toHaveBeenCalledWith('change.energymeter-position', expect.any(Function))
-      expect(mockPositionRow.toggle).toHaveBeenCalledWith(true)
-    })
-
-    test('hides energymeter Position row for a role where it is fixed', () => {
-      const mockRoleSelect = createMockElement({ val: 'gridmeter' })
-      const mockPositionRow = createMockElement()
-
-      global.$.mockImplementation((selector) => {
-        if (selector === 'select#node-input-device') {
-          return createMockElement({ val: 'energymeter' })
-        }
-        if (selector === '#node-input-energymeter_role') {
-          return mockRoleSelect
-        }
-        if (selector === '#energymeter-position-row') {
-          return mockPositionRow
-        }
-        if (selector.startsWith('.input-')) {
-          return createMockElement()
-        }
-        return createMockElement()
-      })
-
-      checkSelectedVirtualDevice()
-
-      expect(mockPositionRow.toggle).toHaveBeenCalledWith(false)
-    })
-
-    test('shows energymeter PhaseSetting row for a configurable role with 1 phase', () => {
-      const mockRoleSelect = createMockElement({ val: 'acload' })
-      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
-      const mockPhaseSettingRow = createMockElement()
-
-      global.$.mockImplementation((selector) => {
-        if (selector === 'select#node-input-device') {
-          return createMockElement({ val: 'energymeter' })
-        }
-        if (selector === '#node-input-energymeter_role') {
-          return mockRoleSelect
-        }
-        if (selector === '#node-input-energymeter_nrofphases') {
-          return mockNrOfPhasesSelect
-        }
-        if (selector === '#energymeter-phasesetting-row') {
-          return mockPhaseSettingRow
-        }
-        if (selector.startsWith('.input-')) {
-          return createMockElement()
-        }
-        return createMockElement()
-      })
-
-      checkSelectedVirtualDevice()
-
-      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
-    })
-
-    test('hides energymeter PhaseSetting row for a configurable role with 3 phases', () => {
-      const mockRoleSelect = createMockElement({ val: 'acload' })
-      const mockNrOfPhasesSelect = createMockElement({ val: '3' })
-      const mockPhaseSettingRow = createMockElement()
-
-      global.$.mockImplementation((selector) => {
-        if (selector === 'select#node-input-device') {
-          return createMockElement({ val: 'energymeter' })
-        }
-        if (selector === '#node-input-energymeter_role') {
-          return mockRoleSelect
-        }
-        if (selector === '#node-input-energymeter_nrofphases') {
-          return mockNrOfPhasesSelect
-        }
-        if (selector === '#energymeter-phasesetting-row') {
-          return mockPhaseSettingRow
-        }
-        if (selector.startsWith('.input-')) {
-          return createMockElement()
-        }
-        return createMockElement()
-      })
-
-      checkSelectedVirtualDevice()
-
-      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
-    })
-
-    test('hides energymeter PhaseSetting row for a role where Position is not configurable', () => {
-      const mockRoleSelect = createMockElement({ val: 'gridmeter' })
-      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
-      const mockPhaseSettingRow = createMockElement()
-
-      global.$.mockImplementation((selector) => {
-        if (selector === 'select#node-input-device') {
-          return createMockElement({ val: 'energymeter' })
-        }
-        if (selector === '#node-input-energymeter_role') {
-          return mockRoleSelect
-        }
-        if (selector === '#node-input-energymeter_nrofphases') {
-          return mockNrOfPhasesSelect
-        }
-        if (selector === '#energymeter-phasesetting-row') {
           return mockPhaseSettingRow
         }
         if (selector.startsWith('.input-')) {

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -309,51 +309,7 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
     })
 
-    test('filters S2 Measurement to 3-phase-symmetric and the matching single phase, auto-syncing an out-of-date single-phase selection', () => {
-      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
-      const mockPhaseSettingSelect = createMockElement({ val: '2' })
-      const mockPhaseSettingRow = createMockElement()
-      const { mockS2Select, toggleCallsByValue } = createMockS2MeasurementSelect('L1')
-
-      global.$.mockImplementation((selector) => {
-        if (selector === 'select#node-input-device') {
-          return createMockElement({ val: 'acload' })
-        }
-        if (selector === '#node-input-acload_nrofphases') {
-          return mockNrOfPhasesSelect
-        }
-        if (selector === '#node-input-acload_phasesetting') {
-          return mockPhaseSettingSelect
-        }
-        if (selector === '#acload-phasesetting-row') {
-          return mockPhaseSettingRow
-        }
-        if (selector === '#node-input-s2_measurement_type') {
-          return mockS2Select
-        }
-        if (typeof selector === 'object') {
-          return wrapMockS2Option(selector, toggleCallsByValue)
-        }
-        if (selector.startsWith('.input-')) {
-          return createMockElement()
-        }
-        return createMockElement()
-      })
-
-      checkSelectedVirtualDevice()
-
-      // Per-phase reporting and the two non-matching single-phase options are hidden; the total
-      // (3-phase symmetric) and the phase actually wired (L2) stay visible.
-      expect(toggleCallsByValue['3_PHASE_SYMMETRIC']).toEqual([true])
-      expect(toggleCallsByValue.L1_L2_L3).toEqual([false])
-      expect(toggleCallsByValue.L1).toEqual([false])
-      expect(toggleCallsByValue.L2).toEqual([true])
-      expect(toggleCallsByValue.L3).toEqual([false])
-      // The previously-selected "Single phase L1" no longer matches Phase=L2, so it's auto-synced.
-      expect(mockS2Select.val()).toBe('L2')
-    })
-
-    test('leaves 3-phase-symmetric S2 Measurement selection untouched for a single-phase config', () => {
+    test('locks S2 Measurement to the matching single phase for a 1-phase config, overriding any prior selection', () => {
       const mockNrOfPhasesSelect = createMockElement({ val: '1' })
       const mockPhaseSettingSelect = createMockElement({ val: '2' })
       const mockPhaseSettingRow = createMockElement()
@@ -386,11 +342,60 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
 
       checkSelectedVirtualDevice()
 
+      // Only the phase actually wired (L2) stays visible - re-picking phase type in S2
+      // Measurement would just duplicate what Number of phases/Phase already say.
+      expect(toggleCallsByValue['3_PHASE_SYMMETRIC']).toEqual([false])
+      expect(toggleCallsByValue.L1_L2_L3).toEqual([false])
+      expect(toggleCallsByValue.L1).toEqual([false])
+      expect(toggleCallsByValue.L2).toEqual([true])
+      expect(toggleCallsByValue.L3).toEqual([false])
+      expect(mockS2Select.val()).toBe('L2')
+    })
+
+    test('offers only 3-phase-symmetric/per-phase for a 3-phase config, resetting an invalid single-phase selection', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '3' })
+      const mockPhaseSettingSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingRow = createMockElement()
+      const { mockS2Select, toggleCallsByValue } = createMockS2MeasurementSelect('L1')
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '#node-input-acload_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#node-input-acload_phasesetting') {
+          return mockPhaseSettingSelect
+        }
+        if (selector === '#acload-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector === '#node-input-s2_measurement_type') {
+          return mockS2Select
+        }
+        if (typeof selector === 'object') {
+          return wrapMockS2Option(selector, toggleCallsByValue)
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(toggleCallsByValue['3_PHASE_SYMMETRIC']).toEqual([true])
+      expect(toggleCallsByValue.L1_L2_L3).toEqual([true])
+      expect(toggleCallsByValue.L1).toEqual([false])
+      expect(toggleCallsByValue.L2).toEqual([false])
+      expect(toggleCallsByValue.L3).toEqual([false])
+      // "Single phase L1" no longer applies to a 3-phase config, so it's reset.
       expect(mockS2Select.val()).toBe('3_PHASE_SYMMETRIC')
     })
 
-    test('does not filter S2 Measurement options for a multi-phase config', () => {
-      const mockNrOfPhasesSelect = createMockElement({ val: '3' })
+    test('does not filter S2 Measurement options for a split-phase config', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '2' })
       const mockPhaseSettingSelect = createMockElement({ val: '1' })
       const mockPhaseSettingRow = createMockElement()
       const { mockS2Select, toggleCallsByValue } = createMockS2MeasurementSelect('L1')

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -282,9 +282,10 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockBatteryRow.toggle).toHaveBeenCalledWith(true)
     })
 
-    test('shows acload PhaseSetting row for a 1-phase config', () => {
+    test('shows acload PhaseSetting row for a 1-phase config with S2 support enabled', () => {
       const mockNrOfPhasesSelect = createMockElement({ val: '1' })
       const mockPhaseSettingRow = createMockElement()
+      const mockS2Checkbox = createMockElement({ is: true })
 
       global.$.mockImplementation((selector) => {
         if (selector === 'select#node-input-device') {
@@ -295,6 +296,9 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
         }
         if (selector === '#acload-phasesetting-row') {
           return mockPhaseSettingRow
+        }
+        if (selector === '#node-input-enable_s2support') {
+          return mockS2Checkbox
         }
         if (selector.startsWith('.input-')) {
           return createMockElement()
@@ -307,6 +311,36 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockNrOfPhasesSelect.off).toHaveBeenCalledWith('change.phasesetting')
       expect(mockNrOfPhasesSelect.on).toHaveBeenCalledWith('change.phasesetting', expect.any(Function))
       expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
+    })
+
+    test('hides acload Position/PhaseSetting row for a 1-phase config when S2 support is disabled', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingRow = createMockElement()
+      const mockPositionRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '#node-input-acload_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#acload-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector === '#node-input-acload_position') {
+          return mockPositionRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
+      expect(mockPositionRow.toggle).toHaveBeenCalledWith(false)
     })
 
     test('locks S2 Measurement to the matching single phase for a 1-phase config, overriding any prior selection', () => {

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -27,6 +27,7 @@ function createMockElement (customValues = {}) {
     is: jest.fn().mockReturnValue(customValues.is || false),
     off: jest.fn().mockReturnThis(),
     on: jest.fn().mockReturnThis(),
+    trigger: jest.fn().mockReturnThis(),
     append: jest.fn().mockReturnThis(),
     empty: jest.fn().mockReturnThis(),
     remove: jest.fn().mockReturnThis(),
@@ -452,6 +453,40 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       checkSelectedVirtualDevice()
 
       expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
+    })
+
+    test('hides Position and PhaseSetting row for acload grid meter only, even for a 1-phase config', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingRow = createMockElement()
+      const mockPositionRow = createMockElement()
+      const mockGridMeterOnlyCheckbox = createMockElement({ is: true })
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'acload' })
+        }
+        if (selector === '#node-input-acload_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#acload-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector === '#node-input-acload_grid_meter_only') {
+          return mockGridMeterOnlyCheckbox
+        }
+        if (selector === '#node-input-acload_position') {
+          return mockPositionRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
+      expect(mockPositionRow.toggle).toHaveBeenCalledWith(false)
     })
 
     test('handles generator device selection', () => {

--- a/test/victron-virtual-generator-productid.test.js
+++ b/test/victron-virtual-generator-productid.test.js
@@ -1,6 +1,7 @@
 // test/victron-virtual-generator-productid.test.js
 /* eslint-env jest */
 const { addVictronInterfaces } = require('dbus-victron-virtual')
+const generator = require('../src/nodes/victron-virtual/device-type/generator')
 
 function makeBus () {
   return { exportInterface: jest.fn() }
@@ -82,5 +83,22 @@ describe('virtual energy meter ProductId (970cf0c0 regression)', () => {
     const iface = { emit: jest.fn(), Connected: 1 }
     addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.grid.virtual_test', 'energymeter'), iface, true, null)
     expect(iface.ProductId).toBe(0xc06f)
+  })
+})
+
+// The genset's D-Bus service stays com.victronenergy.genset even in "Use as grid meter only"
+// mode (see generator.js getServiceType), so the productType override is what makes the
+// reported ProductId reflect a grid meter instead of a genset.
+describe('virtual generator (genset) ProductId in grid meter only mode', () => {
+  test('normal mode: genset productType gives genset ProductId', () => {
+    const iface = { emit: jest.fn(), Connected: 1 }
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.genset.virtual_test', generator.productType({ generator_type: 'ac' })), iface, true, null)
+    expect(iface.ProductId).toBe(0xc06b)
+  })
+
+  test('grid meter only mode: grid productType gives grid meter ProductId', () => {
+    const iface = { emit: jest.fn(), Connected: 1 }
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.genset.virtual_test', generator.productType({ generator_type: 'ac', generator_grid_meter_only: true })), iface, true, null)
+    expect(iface.ProductId).toBe(0xc062)
   })
 })

--- a/test/victron-virtual-heatpump-productid.test.js
+++ b/test/victron-virtual-heatpump-productid.test.js
@@ -21,18 +21,18 @@ function makeIfaceDesc (name, productType) {
 }
 
 // The heatpump's D-Bus service always stays com.victronenergy.heatpump (see heatpump.js
-// getServiceType) even in "Use as grid meter only" mode, so the productType override is what
+// getServiceType) even as a plain generic energy meter, so the productType override is what
 // makes the reported ProductId reflect a grid meter instead of a heat pump.
 describe('virtual heatpump ProductId', () => {
-  test('normal mode: heatpump productType gives heatpump ProductId', () => {
+  test('full device (S2 enabled): heatpump productType gives heatpump ProductId', () => {
     const iface = { emit: jest.fn(), Connected: 1 }
-    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.heatpump.virtual_test', heatpump.productType({})), iface, true, null)
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.heatpump.virtual_test', heatpump.productType({ enable_s2support: true })), iface, true, null)
     expect(iface.ProductId).toBe(0xc064)
   })
 
-  test('grid meter only mode: grid productType gives grid meter ProductId', () => {
+  test('generic energy meter mode: grid productType gives grid meter ProductId', () => {
     const iface = { emit: jest.fn(), Connected: 1 }
-    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.heatpump.virtual_test', heatpump.productType({ heatpump_grid_meter_only: true })), iface, true, null)
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.heatpump.virtual_test', heatpump.productType({})), iface, true, null)
     expect(iface.ProductId).toBe(0xc062)
   })
 })

--- a/test/victron-virtual-heatpump-productid.test.js
+++ b/test/victron-virtual-heatpump-productid.test.js
@@ -1,0 +1,38 @@
+// test/victron-virtual-heatpump-productid.test.js
+/* eslint-env jest */
+const { addVictronInterfaces } = require('dbus-victron-virtual')
+const heatpump = require('../src/nodes/victron-virtual/device-type/heatpump')
+
+function makeBus () {
+  return { exportInterface: jest.fn() }
+}
+
+function makeIfaceDesc (name, productType) {
+  const desc = {
+    name,
+    methods: {},
+    properties: { Connected: { type: 'i' } },
+    signals: {}
+  }
+  if (productType !== undefined) {
+    desc.productType = productType
+  }
+  return desc
+}
+
+// The heatpump's D-Bus service always stays com.victronenergy.heatpump (see heatpump.js
+// getServiceType) even in "Use as grid meter only" mode, so the productType override is what
+// makes the reported ProductId reflect a grid meter instead of a heat pump.
+describe('virtual heatpump ProductId', () => {
+  test('normal mode: heatpump productType gives heatpump ProductId', () => {
+    const iface = { emit: jest.fn(), Connected: 1 }
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.heatpump.virtual_test', heatpump.productType({})), iface, true, null)
+    expect(iface.ProductId).toBe(0xc064)
+  })
+
+  test('grid meter only mode: grid productType gives grid meter ProductId', () => {
+    const iface = { emit: jest.fn(), Connected: 1 }
+    addVictronInterfaces(makeBus(), makeIfaceDesc('com.victronenergy.heatpump.virtual_test', heatpump.productType({ heatpump_grid_meter_only: true })), iface, true, null)
+    expect(iface.ProductId).toBe(0xc062)
+  })
+})

--- a/test/victron-virtual-heatpump.test.js
+++ b/test/victron-virtual-heatpump.test.js
@@ -1,0 +1,127 @@
+// test/victron-virtual-heatpump.test.js
+/* eslint-env jest */
+const heatpump = require('../src/nodes/victron-virtual/device-type/heatpump')
+
+function makeFixtures () {
+  return {
+    ifaceDesc: { properties: {} },
+    iface: {},
+    node: { error: jest.fn() }
+  }
+}
+
+describe('heatpump device module', () => {
+  test('exports required contract', () => {
+    expect(typeof heatpump.properties).toBe('function')
+    expect(typeof heatpump.getServiceType).toBe('function')
+    expect(typeof heatpump.productType).toBe('function')
+    expect(typeof heatpump.initialize).toBe('function')
+    expect(typeof heatpump.onPropertiesChanged).toBe('function')
+    expect(heatpump.supportsS2).toBe(true)
+  })
+
+  describe('normal mode', () => {
+    test('getServiceType returns heatpump', () => {
+      expect(heatpump.getServiceType({})).toBe('heatpump')
+      expect(heatpump.getServiceType({ heatpump_grid_meter_only: false })).toBe('heatpump')
+    })
+
+    test('productType returns heatpump', () => {
+      expect(heatpump.productType({})).toBe('heatpump')
+      expect(heatpump.productType({ heatpump_grid_meter_only: false })).toBe('heatpump')
+    })
+
+    test('properties include Position', () => {
+      expect(heatpump.properties({}).Position).toBeDefined()
+    })
+
+    test('properties declare IsGenericEnergyMeter as 0', () => {
+      expect(heatpump.properties({}).IsGenericEnergyMeter.value).toBe(0)
+    })
+
+    test('initialize sets Position/PhaseSetting for single phase', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      const result = heatpump.initialize({ heatpump_nrofphases: 1, heatpump_phasesetting: 2 }, ifaceDesc, iface, node)
+      expect(iface.Position).toBe(0)
+      expect(iface.PhaseSetting).toBe(2)
+      expect(ifaceDesc.properties['Ac/L2/Power']).toBeDefined()
+      expect(result).toBe('Virtual 1-phase heat pump')
+    })
+
+    test('initialize adds L1-L3 for 3-phase', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      heatpump.initialize({ heatpump_nrofphases: 3 }, ifaceDesc, iface, node)
+      expect(ifaceDesc.properties['Ac/L1/Power']).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Power']).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L3/Power']).toBeDefined()
+    })
+
+    test('S2 support enabled exposes transport properties only, no RmSettings', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      heatpump.initialize({ heatpump_nrofphases: 1, enable_s2support: true }, ifaceDesc, iface, node)
+      expect(ifaceDesc.__enableS2).toBe(true)
+      expect(ifaceDesc.properties['S2/0/Active']).toBeDefined()
+      expect(Object.keys(ifaceDesc.properties).some(k => k.startsWith('S2/0/RmSettings/'))).toBe(false)
+    })
+
+    test('onPropertiesChanged accumulates energy when heatpump_auto_energy is true', () => {
+      const instance = { 'Ac/L1/Power': 500 }
+      const changes = { 'Ac/L1/Power': 600 }
+      const result = heatpump.onPropertiesChanged({
+        changes,
+        instance,
+        config: { heatpump_auto_energy: true, heatpump_nrofphases: 1 }
+      })
+      expect(result).toBe(changes)
+    })
+
+    test('onPropertiesChanged is a no-op when heatpump_auto_energy is false', () => {
+      const instance = { 'Ac/L1/Power': 500 }
+      const changes = { 'Ac/L1/Power': 600 }
+      const result = heatpump.onPropertiesChanged({
+        changes,
+        instance,
+        config: { heatpump_auto_energy: false, heatpump_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+  })
+
+  describe('grid meter only mode', () => {
+    test('getServiceType still returns heatpump', () => {
+      expect(heatpump.getServiceType({ heatpump_grid_meter_only: true })).toBe('heatpump')
+    })
+
+    test('productType returns grid', () => {
+      expect(heatpump.productType({ heatpump_grid_meter_only: true })).toBe('grid')
+    })
+
+    test('properties omit Position', () => {
+      expect(heatpump.properties({ heatpump_grid_meter_only: true }).Position).toBeUndefined()
+    })
+
+    test('properties declare IsGenericEnergyMeter as 1', () => {
+      expect(heatpump.properties({ heatpump_grid_meter_only: true }).IsGenericEnergyMeter.value).toBe(1)
+    })
+
+    test('initialize does not add Position/PhaseSetting or S2 support', () => {
+      const { ifaceDesc, iface, node } = makeFixtures()
+      const result = heatpump.initialize({ heatpump_nrofphases: 1, heatpump_grid_meter_only: true, enable_s2support: true }, ifaceDesc, iface, node)
+      expect(iface.Position).toBeUndefined()
+      expect(iface.PhaseSetting).toBeUndefined()
+      expect(ifaceDesc.__enableS2).toBeUndefined()
+      expect(result).toBe('Virtual 1-phase heat pump (grid meter mode)')
+    })
+
+    test('onPropertiesChanged is a no-op even when heatpump_auto_energy is true', () => {
+      const instance = { 'Ac/L1/Power': 500 }
+      const changes = { 'Ac/L1/Power': 600 }
+      const result = heatpump.onPropertiesChanged({
+        changes,
+        instance,
+        config: { heatpump_auto_energy: true, heatpump_grid_meter_only: true, heatpump_nrofphases: 1 }
+      })
+      expect(result['Ac/Energy/Forward']).toBeUndefined()
+    })
+  })
+})

--- a/test/victron-virtual-heatpump.test.js
+++ b/test/victron-virtual-heatpump.test.js
@@ -20,28 +20,26 @@ describe('heatpump device module', () => {
     expect(heatpump.supportsS2).toBe(true)
   })
 
-  describe('normal mode', () => {
+  describe('full device (S2 support enabled)', () => {
     test('getServiceType returns heatpump', () => {
-      expect(heatpump.getServiceType({})).toBe('heatpump')
-      expect(heatpump.getServiceType({ heatpump_grid_meter_only: false })).toBe('heatpump')
+      expect(heatpump.getServiceType({ enable_s2support: true })).toBe('heatpump')
     })
 
     test('productType returns heatpump', () => {
-      expect(heatpump.productType({})).toBe('heatpump')
-      expect(heatpump.productType({ heatpump_grid_meter_only: false })).toBe('heatpump')
+      expect(heatpump.productType({ enable_s2support: true })).toBe('heatpump')
     })
 
     test('properties include Position', () => {
-      expect(heatpump.properties({}).Position).toBeDefined()
+      expect(heatpump.properties({ enable_s2support: true }).Position).toBeDefined()
     })
 
     test('properties declare IsGenericEnergyMeter as 0', () => {
-      expect(heatpump.properties({}).IsGenericEnergyMeter.value).toBe(0)
+      expect(heatpump.properties({ enable_s2support: true }).IsGenericEnergyMeter.value).toBe(0)
     })
 
     test('initialize sets Position/PhaseSetting for single phase', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      const result = heatpump.initialize({ heatpump_nrofphases: 1, heatpump_phasesetting: 2 }, ifaceDesc, iface, node)
+      const result = heatpump.initialize({ heatpump_nrofphases: 1, heatpump_phasesetting: 2, enable_s2support: true }, ifaceDesc, iface, node)
       expect(iface.Position).toBe(0)
       expect(iface.PhaseSetting).toBe(2)
       expect(ifaceDesc.properties['Ac/L2/Power']).toBeDefined()
@@ -50,7 +48,7 @@ describe('heatpump device module', () => {
 
     test('initialize adds L1-L3 for 3-phase', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      heatpump.initialize({ heatpump_nrofphases: 3 }, ifaceDesc, iface, node)
+      heatpump.initialize({ heatpump_nrofphases: 3, enable_s2support: true }, ifaceDesc, iface, node)
       expect(ifaceDesc.properties['Ac/L1/Power']).toBeDefined()
       expect(ifaceDesc.properties['Ac/L2/Power']).toBeDefined()
       expect(ifaceDesc.properties['Ac/L3/Power']).toBeDefined()
@@ -70,7 +68,7 @@ describe('heatpump device module', () => {
       const result = heatpump.onPropertiesChanged({
         changes,
         instance,
-        config: { heatpump_auto_energy: true, heatpump_nrofphases: 1 }
+        config: { heatpump_auto_energy: true, heatpump_nrofphases: 1, enable_s2support: true }
       })
       expect(result).toBe(changes)
     })
@@ -81,47 +79,47 @@ describe('heatpump device module', () => {
       const result = heatpump.onPropertiesChanged({
         changes,
         instance,
-        config: { heatpump_auto_energy: false, heatpump_nrofphases: 1 }
+        config: { heatpump_auto_energy: false, heatpump_nrofphases: 1, enable_s2support: true }
       })
       expect(result['Ac/Energy/Forward']).toBeUndefined()
     })
   })
 
-  describe('grid meter only mode', () => {
+  describe('generic energy meter mode (S2 support disabled)', () => {
     test('getServiceType still returns heatpump', () => {
-      expect(heatpump.getServiceType({ heatpump_grid_meter_only: true })).toBe('heatpump')
+      expect(heatpump.getServiceType({})).toBe('heatpump')
     })
 
     test('productType returns grid', () => {
-      expect(heatpump.productType({ heatpump_grid_meter_only: true })).toBe('grid')
+      expect(heatpump.productType({})).toBe('grid')
     })
 
     test('properties omit Position', () => {
-      expect(heatpump.properties({ heatpump_grid_meter_only: true }).Position).toBeUndefined()
+      expect(heatpump.properties({}).Position).toBeUndefined()
     })
 
     test('properties declare IsGenericEnergyMeter as 1', () => {
-      expect(heatpump.properties({ heatpump_grid_meter_only: true }).IsGenericEnergyMeter.value).toBe(1)
+      expect(heatpump.properties({}).IsGenericEnergyMeter.value).toBe(1)
     })
 
     test('initialize does not add Position/PhaseSetting or S2 support', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      const result = heatpump.initialize({ heatpump_nrofphases: 1, heatpump_grid_meter_only: true, enable_s2support: true }, ifaceDesc, iface, node)
+      const result = heatpump.initialize({ heatpump_nrofphases: 1 }, ifaceDesc, iface, node)
       expect(iface.Position).toBeUndefined()
       expect(iface.PhaseSetting).toBeUndefined()
       expect(ifaceDesc.__enableS2).toBeUndefined()
-      expect(result).toBe('Virtual 1-phase heat pump (grid meter mode)')
+      expect(result).toBe('Virtual 1-phase heat pump (generic energy meter)')
     })
 
-    test('onPropertiesChanged is a no-op even when heatpump_auto_energy is true', () => {
+    test('onPropertiesChanged still accumulates energy when heatpump_auto_energy is true', () => {
       const instance = { 'Ac/L1/Power': 500 }
       const changes = { 'Ac/L1/Power': 600 }
       const result = heatpump.onPropertiesChanged({
         changes,
         instance,
-        config: { heatpump_auto_energy: true, heatpump_grid_meter_only: true, heatpump_nrofphases: 1 }
+        config: { heatpump_auto_energy: true, heatpump_nrofphases: 1 }
       })
-      expect(result['Ac/Energy/Forward']).toBeUndefined()
+      expect(result['Ac/Energy/Forward']).toBeDefined()
     })
   })
 })

--- a/test/victron-virtual-s2-support.test.js
+++ b/test/victron-virtual-s2-support.test.js
@@ -80,7 +80,7 @@ describe('enableS2Support', () => {
     expect(typeof ifaceDesc.__s2Handlers.KeepAlive).toBe('function')
   })
 
-  test('Connect handler updates S2 active/rm and sends command on port 2', () => {
+  test('Connect handler updates S2 rm and sends command on port 2, leaves Active for the flow to set', () => {
     const { ifaceDesc, iface, node } = makeFixtures()
     enableS2Support({ config: { enable_s2support: true }, ifaceDesc, iface, node })
     node._s2PowerMeasurementActive = true
@@ -88,7 +88,7 @@ describe('enableS2Support', () => {
     ifaceDesc.__s2Handlers.Connect('cem-1', 30)
     expect(node._s2PowerMeasurementActive).toBe(false)
     expect(node._s2PowerMeasurementCemId).toBeNull()
-    expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Active': 1, 'S2/0/Rm': 'CEM: cem-1' })
+    expect(node.setValuesLocally).toHaveBeenCalledWith({ 'S2/0/Rm': 'CEM: cem-1' })
     expect(node.send).toHaveBeenCalledWith([null, {
       payload: { command: 'Connect', cemId: 'cem-1', keepAliveInterval: 30 }
     }])


### PR DESCRIPTION
Consolidates AC Load, Generator, Heat pump, and EV charger virtual devices onto a shared minimal-meter D-Bus shape, replacing the old "Energy meter" node's Role dropdown (kept registered internally so already-deployed flows keep working).

- Add standalone Heat pump and EV charger device types.
- AC Load, Generator (AC), and Heat pump gain a "use as grid meter only" checkbox for reduced/grid-meter-style reporting. All three (and EV charger) stay registered under their own D-Bus service name, with a productType override so the reported ProductId still reflects the grid meter when used as one.
- Remove AC Load's unused `S2/0/RmSettings/*` properties.
- Correct `IsGenericEnergyMeter` and `Ac/PowerFactor` defaults to match the device's actual role/mode (affects AC Load, Heat pump, and the legacy Energy meter node).
- Add "Usage" doc entries for Heat pump/EV charger; misc tooltip wording fixes.