### PR TITLE
fix(dbus): stop excluding com.victronenergy.shelly from service init

### DIFF
--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -87,7 +87,6 @@ const initServiceDenylist = [
   'com.victronenergy.fronius',
   'com.victronenergy.modbusclient.tcp',
   'com.victronenergy.modbustcp',
-  'com.victronenergy.shelly',
   'com.victronenergy.logger'
 ]
 
@@ -486,3 +485,4 @@ class VictronDbusListener {
 
 module.exports = VictronDbusListener
 module.exports.serviceNamesWithoutDeviceInstance = serviceNamesWithoutDeviceInstance
+module.exports.initServiceDenylist = initServiceDenylist

--- a/test/dbus-listener.test.js
+++ b/test/dbus-listener.test.js
@@ -11,6 +11,10 @@ describe('VictronDbusListener', () => {
     expect(listener.address).toBe('the-address')
   })
 
+  test('initServiceDenylist does not exclude com.victronenergy.shelly (regression)', () => {
+    expect(VictronDbusListener.initServiceDenylist).not.toContain('com.victronenergy.shelly')
+  })
+
   describe('_initService', () => {
     beforeEach(() => {
       listener.bus = {


### PR DESCRIPTION
The shelly daemon service exposes a valid `/DeviceInstance`, so it doesn't belong in `initServiceDenylist` alongside services that lack one. Being denylisted made it invisible to the D-Bus client cache entirely, regardless of path.