### PR TITLE
fix(services):  fill dbus path gaps (and repair check-services-json.js)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "prerelease": "npm run verify",
     "release": "git tag -d v$npm_package_version; git tag v$npm_package_version && git push --tags && git push && npm run create-release",
     "documentation": "bash -c '( sed \"/^<!--/q\" src/nodes/config-client.html && node scripts/service2doc.js -s src/services/services.json -r src/nodes/victron-nodes.html -o nodered ) | sponge src/nodes/config-client.html'",
+    "check-services": "node scripts/check-services-json.js",
     "wiki": "bash -c 'S=\"src/services/services.json\" R=\"src/nodes/victron-nodes.html\"; node scripts/service2doc.js -s $S -r $R -o md --page index   | sponge ../node-red-contrib-victron.wiki/Available-nodes.md && node scripts/service2doc.js -s $S -r $R -o md --page input   | sponge ../node-red-contrib-victron.wiki/Input-nodes.md && node scripts/service2doc.js -s $S -r $R -o md --page output  | sponge ../node-red-contrib-victron.wiki/Output-nodes.md && node scripts/service2doc.js -s $S -r $R -o md --page virtual | sponge ../node-red-contrib-victron.wiki/Virtual-devices.md && node scripts/service2doc.js -s $S -r $R -o md --page sidebar | sponge ../node-red-contrib-victron.wiki/_Sidebar.md'",
     "prepare": "husky || echo \"WARNING: husky not available, proceeding\""
   },

--- a/scripts/check-services-json.js
+++ b/scripts/check-services-json.js
@@ -1,197 +1,140 @@
 // Also see https://github.com/victronenergy/node-red-contrib-victron/issues/115
+//
+// Compares services.json against the dbus_modbustcp attributes.csv (see
+// https://github.com/victronenergy/dbus_modbustcp/blob/master/attributes.csv),
+// which lists every dbus path that project knows about together with its
+// type/enum/unit info. That csv is the most complete public reference we
+// have for dbus paths, even though not every dbus path ends up exposed over
+// Modbus TCP (see scripts/exclude.txt for known, intentional gaps).
 
 const fs = require('fs')
-const Excel = require('exceljs')
 
 const argv = require('yargs/yargs')(process.argv.slice(2))
-  .usage('Usage: $0 -s services.json -x modbus_tcp.xlsx')
+  .usage('Usage: $0 -s services.json -c attributes.csv')
   .option('services', {
     alias: 's',
-    describe: 'Services file'
+    describe: 'Services file',
+    default: 'src/services/services.json'
   })
-  .option('excel', {
-    alias: 'x',
-    describe: 'Excel file, containing the modbus_tcp information'
+  .option('csv', {
+    alias: 'c',
+    describe: 'attributes.csv file from the dbus_modbustcp repository',
+    default: '../dbus_modbustcp/attributes.csv'
   })
-  .demandOption(['s', 'x'])
   .help('h')
   .version(false)
   .argv
 
 const servicesJSON = argv.services
-const xlsFile = argv.excel
+const csvFile = argv.csv
 
-// Read the services.json file
+// Maps a dbus interface name (e.g. "charger") to the top-level node name
+// used in services.json (e.g. "accharger"). Interfaces not listed here use
+// their own name as the node name.
+const IFACE_TO_NODE = {
+  grid: 'gridmeter',
+  charger: 'accharger',
+  genset: 'generator',
+  dcgenset: 'generator'
+}
+
+// Interfaces that are intentionally not modelled in services.json.
+const SKIP_IFACES = new Set([
+  'hub4', // writing here interferes with systemcalc
+  'platform' // internal, not a device type
+])
+
 const services = JSON.parse(fs.readFileSync(servicesJSON))
 
-const workbook = new Excel.Workbook()
-workbook.xlsx.readFile(xlsFile)
-  .then(function () {
-    const worksheet = workbook.getWorksheet('Field list')
-    worksheet.eachRow({ includeEmpty: true }, function (row, rowNumber) {
-      // We can ignore the first two rows
-      if (rowNumber <= 2) { return }
-      // Nothing to do when there are no more entries
-      if (typeof row.values[1] === 'undefined') { return }
-      // Determine the node name. If it is writeable: output else input
-      let node
-      if (row.values[8] && row.values[8] === 'yes') { node = 'output-' } else { node = 'input-' };
-      node = node + row.values[1].split('.')[2]
-      if (node === 'input-grid') { node = 'input-gridmeter' }
-      if (node === 'input-charger') { node = 'input-accharger' }
-      if (node === 'input-genset') { node = 'input-generator' }
-      if (node === 'input-dcgenset') { node = 'input-generator' }
-      if (typeof row.values[7] === 'undefined') { return }
-      const path = row.values[7].replace('Cgwacs', 'CGwacs')
-      // console.log("Check for node " + node + ", path: " + path);
+const rows = fs.readFileSync(csvFile, 'utf8')
+  .split('\n')
+  .map(line => line.trim())
+  .filter(line => line.length > 0)
+  .map(line => {
+    const [service, path, type, unitOrEnum, register, datatype, scale, access] = line.split(',')
+    return { service, path, type, unitOrEnum, register, datatype, scale, access }
+  })
 
-      // Relays are to be found under relay node, so modify the node name.
-      if (path.match(/\/Relay\/\d+\/State/) && node !== 'relay') {
-        // We need to make sure that the in-/output-relay has this sub service
-        if (node.match(/^input-*/) && services['input-relay'][node.replace('input-', '')]) {
-          return
-        }
-        if (node.match(/^output-*/) && services['output-relay'][node.replace('output-', '')]) {
-          return
-        }
-        console.log('// Missing relay service for ' + node + ' ' + path)
-        return
-      }
+function guessType (row) {
+  if (row.unitOrEnum && row.unitOrEnum.includes(';')) return 'enum'
+  if (row.datatype && row.datatype.match(/string/)) return 'string'
+  return 'float'
+}
 
-      // Leave out hub4, writing stuff here will interfere with systemcalc
-      if (node === 'input-hub4') { return }
+function guessEnum (row) {
+  const enumValues = {}
+  row.unitOrEnum.split(';').forEach(entry => {
+    const [key, value] = entry.split('=')
+    enumValues[key.trim()] = value.trim()
+  })
+  return enumValues
+}
 
-      if (!services[node]) {
-        console.log('// Missing node in services.json: ' + node)
-        // process.exit(1);
-      } else {
-        // The node exists, check for the path within the node
-        // We make an array of all of the paths for this node
-        const paths = []
-        for (const [, value] of Object.entries(services[node])) {
-          if (Object.prototype.toString.call(value) === '[object Array]') {
-            value.forEach(item => {
-              paths.push(item.path)
-            })
-          }
-        }
+// services.json paths can contain wildcard segments like "L{index}" or
+// "{phase}" that expand against live dbus data at runtime. Build a regex out
+// of a template path so it also matches the concrete paths reported in the
+// csv (e.g. "/Ac/Out/{phase}/V" should match "/Ac/Out/L1/V").
+function templateToRegex (templatePath) {
+  const escaped = templatePath.replace(/[.*+?^$()|[\]\\]/g, '\\$&')
+  const pattern = escaped.replace(/\{[^}]+\}/g, '[^/]+')
+  return new RegExp('^' + pattern + '$')
+}
 
-        // And check if the path we expect is included in the array of paths
-        if (!paths.includes(path)) {
-          // Print some info on the missing entry
-          let name = row.values[2]
-          if (row.values[9] && typeof row.values[9] === 'string' && !row.values[9].match(/;/)) {
-            name = name + ' (' + row.values[9] + ')'
-          }
-          // check the type; if row 9 contains a semicolon, it is enum. Else it is a bit of
-          // a guess, but we default it to float if we are not sure
-          let type
-          if (row.values[9] && typeof row.values[9] === 'string' && row.values[9].match(/;/)) {
-            type = 'enum'
-          } else {
-            if (row.values[4].match(/string/)) {
-              type = 'string'
-            } else {
-              type = 'float'
-            }
-          }
-          console.log('// Missing path in services.json node: ' + node + ', path: ' + path)
-          const missing = {
-            path,
-            type,
-            name
-          }
+console.log('// Checking for paths present in attributes.csv but missing from services.json')
+rows.forEach(row => {
+  if (row.path === 'RESERVED') return
 
-          if (type === 'enum') {
-            missing.enum = {}
-            row.values[9].split(';').forEach(en => {
-              const x = en.split('=')
-              missing.enum[x[0].trim()] = x[1].trim()
-            })
-          }
-          console.log(JSON.stringify(missing, null, 4))
-        }
+  const iface = row.service.replace('com.victronenergy.', '')
+  if (SKIP_IFACES.has(iface)) return
+
+  const node = IFACE_TO_NODE[iface] || iface
+
+  if (row.path.match(/\/Relay\/\d+\/State/)) {
+    if (!services.relay || !services.relay[node]) {
+      console.log(`// Missing relay service for ${node}, path: ${row.path}`)
+    }
+    return
+  }
+
+  if (!services[node]) {
+    console.log(`// Missing node in services.json: ${node} (from interface ${iface})`)
+    return
+  }
+
+  if (!services[node][iface]) {
+    console.log(`// Missing service in services.json node "${node}": ${iface}`)
+    return
+  }
+
+  const matches = services[node][iface].some(entry => templateToRegex(entry.path).test(row.path))
+  if (!matches) {
+    const type = guessType(row)
+    const missing = {
+      path: row.path,
+      type,
+      name: null // fill in a human-readable name before adding this entry
+    }
+    if (type === 'enum') missing.enum = guessEnum(row)
+
+    console.log(`// Missing path in services.json node "${node}", service "${iface}": ${row.path} (access: ${row.access}, register: ${row.register})`)
+    console.log(JSON.stringify(missing, null, 2))
+  }
+})
+
+console.log('// Checking services.json for entries not present in attributes.csv')
+for (const [node, nodeData] of Object.entries(services)) {
+  for (const [iface, entries] of Object.entries(nodeData)) {
+    if (iface === 'help' || iface === 'communityTag') continue
+
+    const dbusServiceName = 'com.victronenergy.' + iface
+    entries.forEach(entry => {
+      if (entry.path.match(/\/Relay\//)) return // relay coverage in the csv is spotty, skip
+
+      const regex = templateToRegex(entry.path)
+      const found = rows.some(row => row.service === dbusServiceName && regex.test(row.path))
+      if (!found) {
+        console.log(`${node}:${iface}:${entry.path}`)
       }
     })
-
-    // Now check the other way around: Do we have any obsolete entries in our services.json
-    // We check for each service.json entry to exist within the spreadsheet.
-    // We currently _only_ check the path and dbus-service-name combination
-    console.log('// Checking services.json for obsolete entries')
-    const maxrows = worksheet.actualRowCount
-    for (const [node] of Object.entries(services)) {
-      let dbusServiceName = 'com.victronenergy.' + node.split('-')[1]
-      if (dbusServiceName.match(/relay/)) { continue }
-      if (dbusServiceName.match(/gridmeter/)) { dbusServiceName = 'com.victronenergy.grid' }
-      if (dbusServiceName.match(/accharger/)) { dbusServiceName = 'com.victronenergy.charger' }
-      for (const [_x, nodedata] of Object.entries(services[node])) {
-        if (_x === 'help') { continue }
-        if (dbusServiceName.split('.')[2] !== _x) {
-          dbusServiceName = dbusServiceName.replace(dbusServiceName.split('.')[2], _x)
-        }
-        nodedata.forEach(service => {
-          let found = false
-          if (service.path.match(/\/Relay/)) { found = true }
-          for (let i = 2; i <= maxrows; i++) {
-            if (worksheet.getCell('G' + i).value === null) {
-              continue
-            }
-            if (worksheet.getCell('G' + i).value.replace('Cgwacs', 'CGwacs') === service.path) {
-              if (worksheet.getCell('A' + i).value === dbusServiceName) {
-                found = true
-                break
-              }
-            }
-          }
-          if (!found) {
-            console.log(node + ':' + service.path)
-          }
-          //
-        })
-      }
-    }
-
-    // Another check (coming from issue #182). We also want to make sure that all of the output
-    // paths are defined as an input path as well.
-    console.log('// Checking if all output paths are available as input too')
-    for (const [node] of Object.entries(services)) {
-      if (node.split('-')[0] === 'input') {
-        continue
-      }
-
-      for (const [_x, nodedata] of Object.entries(services[node])) {
-        if (_x === 'help') { continue }
-
-        nodedata.forEach(service => {
-          let found = false
-          let missing = null
-          for (const [searchnode] of Object.entries(services)) {
-            if (searchnode.split('-')[0] === 'output') {
-              continue
-            }
-            for (const [_y, searchnodedata] of Object.entries(services[searchnode])) {
-              missing = {
-                path: service.path,
-                type: service.type,
-                name: service.name
-              }
-              if (service.type === 'enum') {
-                missing.enum = service.enum
-              }
-              if (_y === 'help') { continue }
-              searchnodedata.forEach(searchservice => {
-                if (searchservice.path === service.path) {
-                  found = true
-                }
-              })
-            }
-          }
-
-          if (!found) {
-            console.log('// Missing input entry for ' + node + ':' + service.path)
-            console.log(JSON.stringify(missing, null, 4))
-          }
-        })
-      }
-    }
-  })
+  }
+}

--- a/scripts/check-services-json.js
+++ b/scripts/check-services-json.js
@@ -132,6 +132,21 @@ rows.forEach(row => {
   }
 })
 
+const excluded = fs.readFileSync('scripts/exclude.txt', 'utf8')
+  .split('\n')
+  .map(line => line.trim())
+  .filter(line => line.length > 0 && !line.startsWith('#') && line.includes(':'))
+  .map(line => {
+    const idx = line.indexOf(':')
+    const rawNode = line.slice(0, idx)
+    const path = line.slice(idx + 1)
+
+    const node = rawNode.replace(/^(input|output)-/, '')
+    const iface = Object.keys(IFACE_TO_NODE).find(key => IFACE_TO_NODE[key] === node) || node
+
+    return { iface, path }
+  })
+
 console.log('// Checking services.json for entries not present in attributes.csv')
 for (const [node, nodeData] of Object.entries(services)) {
   for (const [iface, entries] of Object.entries(nodeData)) {
@@ -142,6 +157,8 @@ for (const [node, nodeData] of Object.entries(services)) {
       if (entry.path.match(/\/Relay\//)) return // relay coverage in the csv is spotty, skip
 
       const regex = templateToRegex(entry.path)
+      if (excluded.some(ex => ex.iface === iface && regex.test(ex.path))) return
+
       const found = rows.some(row => row.service === dbusServiceName && regex.test(row.path))
       if (!found) {
         console.log(`${node}:${iface}:${entry.path}`)

--- a/scripts/check-services-json.js
+++ b/scripts/check-services-json.js
@@ -46,14 +46,25 @@ const SKIP_IFACES = new Set([
 
 const services = JSON.parse(fs.readFileSync(servicesJSON))
 
-const rows = fs.readFileSync(csvFile, 'utf8')
-  .split('\n')
-  .map(line => line.trim())
-  .filter(line => line.length > 0)
-  .map(line => {
-    const [service, path, type, unitOrEnum, register, datatype, scale, access] = line.split(',')
-    return { service, path, type, unitOrEnum, register, datatype, scale, access }
-  })
+const parse = require('csv-parse/lib/sync')
+
+const rows = parse(fs.readFileSync(csvFile, 'utf8'), {
+  relax_column_count: true,
+  skip_empty_lines: true,
+  trim: true,
+  comment: '#'
+})
+  .map(([service, path, type, unitOrEnum, register, datatype, scale, access]) => ({
+    service,
+    path,
+    type,
+    unitOrEnum,
+    register,
+    datatype,
+    scale,
+    access
+  }))
+  .filter(row => row.service && row.service.startsWith('com.victronenergy.'))
 
 function guessType (row) {
   if (row.unitOrEnum && row.unitOrEnum.includes(';')) return 'enum'

--- a/scripts/check-services-json.js
+++ b/scripts/check-services-json.js
@@ -46,7 +46,7 @@ const SKIP_IFACES = new Set([
 
 const services = JSON.parse(fs.readFileSync(servicesJSON))
 
-const parse = require('csv-parse/lib/sync')
+const { parse } = require('csv-parse/sync')
 
 const rows = parse(fs.readFileSync(csvFile, 'utf8'), {
   relax_column_count: true,

--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -489,7 +489,7 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dd>Dbus path: <b>/Ac/In/1/L1/F</b><span class="property-mode"></span>
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Output voltage <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (V AC)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/Out/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>}/V</b><span class="property-mode"></span>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/Out/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/V</b><span class="property-mode"></span>
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Output current <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (A AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/Out/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/I</b><span class="property-mode"></span>
@@ -526,6 +526,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">ESS Active SOC Limit (%)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Ess/ActiveSocLimit</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">PV enabled<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Pv/Disable</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - PV enabled</li>
+  <li>1 - PV Disabled</li>
+</ul></dd>
   <dt class="optional">Ac current limit at grid meter (A)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Settings/Ac/In/CurrentLimitEnergyMeter</b><span class="property-mode"> (Mode: both)</span>
 </dd>
@@ -599,7 +605,7 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dd>Dbus path: <b>/Ac/In/1/L1/F</b><span class="property-mode"></span>
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Output voltage <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (V AC)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/Out/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>}/V</b><span class="property-mode"></span>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/Out/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/V</b><span class="property-mode"></span>
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Output current <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (A AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/Out/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/I</b><span class="property-mode"></span>
@@ -636,6 +642,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">ESS Active SOC Limit (%)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Ess/ActiveSocLimit</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">PV enabled<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Pv/Disable</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - PV enabled</li>
+  <li>1 - PV Disabled</li>
+</ul></dd>
   <dt class="optional">Ac current limit at grid meter (A)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Settings/Ac/In/CurrentLimitEnergyMeter</b><span class="property-mode"> (Mode: both)</span>
 </dd>
@@ -972,8 +984,22 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>1 - Alarm active</li>
   <li>2 - Alarm</li>
 </ul></dd>
+  <dt class="optional">BMS cable alarm<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Alarms/BmsCable</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul></dd>
   <dt class="optional">Cell Imbalance alarm<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Alarms/CellImbalance</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul></dd>
+  <dt class="optional">Contactor alarm<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Alarms/Contactor</b><span class="property-mode"></span>
 <ul>
   <li>0 - No alarm</li>
   <li>1 - Warning</li>
@@ -994,6 +1020,13 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </ul></dd>
   <dt class="optional">High charge temperature alarm<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Alarms/HighChargeTemperature</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul></dd>
+  <dt class="optional">High current alarm<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Alarms/HighCurrent</b><span class="property-mode"></span>
 <ul>
   <li>0 - No alarm</li>
   <li>1 - Warning</li>
@@ -1464,8 +1497,22 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>1 - Alarm active</li>
   <li>2 - Alarm</li>
 </ul></dd>
+  <dt class="optional">BMS cable alarm<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Alarms/BmsCable</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul></dd>
   <dt class="optional">Cell Imbalance alarm<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Alarms/CellImbalance</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul></dd>
+  <dt class="optional">Contactor alarm<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Alarms/Contactor</b><span class="property-mode"></span>
 <ul>
   <li>0 - No alarm</li>
   <li>1 - Warning</li>
@@ -1486,6 +1533,13 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </ul></dd>
   <dt class="optional">High charge temperature alarm<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Alarms/HighChargeTemperature</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No alarm</li>
+  <li>1 - Warning</li>
+  <li>2 - Alarm</li>
+</ul></dd>
+  <dt class="optional">High current alarm<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Alarms/HighCurrent</b><span class="property-mode"></span>
 <ul>
   <li>0 - No alarm</li>
   <li>1 - Warning</li>
@@ -2278,12 +2332,27 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 <p>Dynamic ESS input node.</p>
 <h3>Dess</h3>
 <dl class="message-properties">
+  <dt class="optional">Dynamic ESS active<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Active</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Active</li>
+</ul></dd>
+  <dt class="optional">Grid feed-in allowed<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/AllowGridFeedIn</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Not allowed</li>
+  <li>1 - Allowed</li>
+</ul></dd>
   <dt class="optional">Is Dynamic ESS available<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/DynamicEss/Available</b><span class="property-mode"></span>
 <ul>
   <li>0 - System is not capable of doing DynamicEss</li>
   <li>1 - System is capable of doing DynamicEss</li>
 </ul></dd>
+  <dt class="optional">Battery charge rate (kW)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/ChargeRate</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Error<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/DynamicEss/ErrorCode</b><span class="property-mode"></span>
 <ul>
@@ -2322,12 +2391,27 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
  
 <h3>Dess</h3>
 <dl class="message-properties">
+  <dt class="optional">Dynamic ESS active<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Active</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Active</li>
+</ul></dd>
+  <dt class="optional">Grid feed-in allowed<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/AllowGridFeedIn</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Not allowed</li>
+  <li>1 - Allowed</li>
+</ul></dd>
   <dt class="optional">Is Dynamic ESS available<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/DynamicEss/Available</b><span class="property-mode"></span>
 <ul>
   <li>0 - System is not capable of doing DynamicEss</li>
   <li>1 - System is capable of doing DynamicEss</li>
 </ul></dd>
+  <dt class="optional">Battery charge rate (kW)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/ChargeRate</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Error<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/DynamicEss/ErrorCode</b><span class="property-mode"></span>
 <ul>
@@ -4056,6 +4140,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">DC current (DC A)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Current</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">DC voltage (DC V)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Engine coolant temperature (Degrees celsius)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Engine/CoolantTemperature</b><span class="property-mode"></span>
 </dd>
@@ -4086,6 +4173,15 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Heatsink temperature (Degrees celsius)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/HeatsinkTemperature</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Generator model<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/ProductId</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Remote start mode<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/RemoteStartModeEnabled</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Disabled</li>
+  <li>1 - Enabled</li>
+</ul></dd>
   <dt class="optional">Start generator<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Start</b><span class="property-mode"> (Mode: both)</span>
 <ul>
@@ -4095,6 +4191,122 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Starter battery voltage (DC V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/StarterVoltage</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Status<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/StatusCode</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Standby</li>
+  <li>1 - Startup 1</li>
+  <li>2 - Startup 2</li>
+  <li>3 - Startup 3</li>
+  <li>4 - Startup 4</li>
+  <li>5 - Startup 5</li>
+  <li>6 - Startup 6</li>
+  <li>7 - Startup 7</li>
+  <li>8 - Running</li>
+  <li>9 - Stopping</li>
+  <li>10 - Error</li>
+</ul></dd>
+  <dt class="optional">Error<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/ErrorCode</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - AC voltage L1 too low</li>
+  <li>2 - AC frequency L1 too low</li>
+  <li>3 - AC current too low</li>
+  <li>4 - AC power too low</li>
+  <li>5 - Emergency stop</li>
+  <li>6 - Servo current too low</li>
+  <li>7 - Oil pressure too low</li>
+  <li>8 - Engine temperature too low</li>
+  <li>9 - Winding temperature too low</li>
+  <li>10 - Exhaust temperature too low</li>
+  <li>13 - Starter current too low</li>
+  <li>14 - Glow current too low</li>
+  <li>15 - Glow current too low</li>
+  <li>16 - Fuel holding magnet current too low</li>
+  <li>17 - Stop solenoid hold coil current too low</li>
+  <li>18 - Stop solenoid pull coil current too low</li>
+  <li>19 - Optional DC out current too low</li>
+  <li>20 - 5V output voltage too low</li>
+  <li>21 - Boost output current too low</li>
+  <li>22 - Panel supply current too high</li>
+  <li>25 - Starter battery voltage too low</li>
+  <li>26 - Startup aborted (rotation too low)</li>
+  <li>28 - Rotation too low</li>
+  <li>29 - Power contactor current too low</li>
+  <li>30 - AC voltage L2 too low</li>
+  <li>31 - AC frequency L2 too low</li>
+  <li>32 - AC current L2 too low</li>
+  <li>33 - AC power L2 too low</li>
+  <li>34 - AC voltage L3 too low</li>
+  <li>35 - AC frequency L3 too low</li>
+  <li>36 - AC current L3 too low</li>
+  <li>37 - AC power L3 too low</li>
+  <li>62 - Fuel temperature too low</li>
+  <li>63 - Fuel level too low</li>
+  <li>65 - AC voltage L1 too high</li>
+  <li>66 - AC frequency too high</li>
+  <li>67 - AC current too high</li>
+  <li>68 - AC power too high</li>
+  <li>70 - Servo current too high</li>
+  <li>71 - Oil pressure too high</li>
+  <li>72 - Engine temperature too high</li>
+  <li>73 - Winding temperature too high</li>
+  <li>74 - Exhaust temperature too low</li>
+  <li>77 - Starter current too low</li>
+  <li>78 - Glow current too high</li>
+  <li>79 - Glow current too high</li>
+  <li>80 - Fuel holding magnet current too high</li>
+  <li>81 - Stop solenoid hold coil current too high</li>
+  <li>82 - Stop solenoid pull coil current too high</li>
+  <li>83 - Optional DC out current too high</li>
+  <li>84 - 5V output voltage too high</li>
+  <li>85 - Boost output current too high</li>
+  <li>89 - Starter battery voltage too high</li>
+  <li>90 - Startup aborted (rotation too high)</li>
+  <li>92 - Rotation too high</li>
+  <li>93 - Power contactor current too high</li>
+  <li>94 - AC voltage L2 too high</li>
+  <li>95 - AC frequency L2 too high</li>
+  <li>96 - AC current L2 too high</li>
+  <li>97 - AC power L2 too high</li>
+  <li>98 - AC voltage L3 too high</li>
+  <li>99 - AC frequency L3 too high</li>
+  <li>100 - AC current L3 too high</li>
+  <li>101 - AC power L3 too high</li>
+  <li>126 - Fuel temperature too high</li>
+  <li>127 - Fuel level too high</li>
+  <li>130 - Lost control unit</li>
+  <li>131 - Lost panel</li>
+  <li>132 - Service needed</li>
+  <li>133 - Lost 3-phase module</li>
+  <li>134 - Lost AGT module</li>
+  <li>135 - Synchronization failure</li>
+  <li>137 - Intake airfilter</li>
+  <li>139 - Lost sync. module</li>
+  <li>140 - Load-balance failed</li>
+  <li>141 - Sync-mode deactivated</li>
+  <li>142 - Engine controller</li>
+  <li>148 - Rotating field wrong</li>
+  <li>149 - Fuel level sensor lost</li>
+  <li>150 - Init failed</li>
+  <li>151 - Watchdog</li>
+  <li>152 - Out: winding</li>
+  <li>153 - Out: exhaust</li>
+  <li>154 - Out: Cyl. head</li>
+  <li>155 - Inverter over temperature</li>
+  <li>156 - Inverter overload</li>
+  <li>157 - Inverter communication lost</li>
+  <li>158 - Inverter sync failed</li>
+  <li>159 - CAN communication lost</li>
+  <li>160 - L1 overload</li>
+  <li>161 - L2 overload</li>
+  <li>162 - L3 overload</li>
+  <li>163 - DC overload</li>
+  <li>164 - DC overvoltage</li>
+  <li>165 - Emergency stop</li>
+  <li>166 - No connection</li>
+</ul></dd>
   <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
 </dd>
@@ -4124,6 +4336,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">DC current (DC A)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Current</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">DC voltage (DC V)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Engine coolant temperature (Degrees celsius)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Engine/CoolantTemperature</b><span class="property-mode"></span>
 </dd>
@@ -4154,6 +4369,15 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Heatsink temperature (Degrees celsius)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/HeatsinkTemperature</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Generator model<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/ProductId</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Remote start mode<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/RemoteStartModeEnabled</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Disabled</li>
+  <li>1 - Enabled</li>
+</ul></dd>
   <dt class="optional">Start generator<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Start</b><span class="property-mode"> (Mode: both)</span>
 <ul>
@@ -4163,6 +4387,122 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Starter battery voltage (DC V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/StarterVoltage</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Status<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/StatusCode</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Standby</li>
+  <li>1 - Startup 1</li>
+  <li>2 - Startup 2</li>
+  <li>3 - Startup 3</li>
+  <li>4 - Startup 4</li>
+  <li>5 - Startup 5</li>
+  <li>6 - Startup 6</li>
+  <li>7 - Startup 7</li>
+  <li>8 - Running</li>
+  <li>9 - Stopping</li>
+  <li>10 - Error</li>
+</ul></dd>
+  <dt class="optional">Error<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/ErrorCode</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - AC voltage L1 too low</li>
+  <li>2 - AC frequency L1 too low</li>
+  <li>3 - AC current too low</li>
+  <li>4 - AC power too low</li>
+  <li>5 - Emergency stop</li>
+  <li>6 - Servo current too low</li>
+  <li>7 - Oil pressure too low</li>
+  <li>8 - Engine temperature too low</li>
+  <li>9 - Winding temperature too low</li>
+  <li>10 - Exhaust temperature too low</li>
+  <li>13 - Starter current too low</li>
+  <li>14 - Glow current too low</li>
+  <li>15 - Glow current too low</li>
+  <li>16 - Fuel holding magnet current too low</li>
+  <li>17 - Stop solenoid hold coil current too low</li>
+  <li>18 - Stop solenoid pull coil current too low</li>
+  <li>19 - Optional DC out current too low</li>
+  <li>20 - 5V output voltage too low</li>
+  <li>21 - Boost output current too low</li>
+  <li>22 - Panel supply current too high</li>
+  <li>25 - Starter battery voltage too low</li>
+  <li>26 - Startup aborted (rotation too low)</li>
+  <li>28 - Rotation too low</li>
+  <li>29 - Power contactor current too low</li>
+  <li>30 - AC voltage L2 too low</li>
+  <li>31 - AC frequency L2 too low</li>
+  <li>32 - AC current L2 too low</li>
+  <li>33 - AC power L2 too low</li>
+  <li>34 - AC voltage L3 too low</li>
+  <li>35 - AC frequency L3 too low</li>
+  <li>36 - AC current L3 too low</li>
+  <li>37 - AC power L3 too low</li>
+  <li>62 - Fuel temperature too low</li>
+  <li>63 - Fuel level too low</li>
+  <li>65 - AC voltage L1 too high</li>
+  <li>66 - AC frequency too high</li>
+  <li>67 - AC current too high</li>
+  <li>68 - AC power too high</li>
+  <li>70 - Servo current too high</li>
+  <li>71 - Oil pressure too high</li>
+  <li>72 - Engine temperature too high</li>
+  <li>73 - Winding temperature too high</li>
+  <li>74 - Exhaust temperature too low</li>
+  <li>77 - Starter current too low</li>
+  <li>78 - Glow current too high</li>
+  <li>79 - Glow current too high</li>
+  <li>80 - Fuel holding magnet current too high</li>
+  <li>81 - Stop solenoid hold coil current too high</li>
+  <li>82 - Stop solenoid pull coil current too high</li>
+  <li>83 - Optional DC out current too high</li>
+  <li>84 - 5V output voltage too high</li>
+  <li>85 - Boost output current too high</li>
+  <li>89 - Starter battery voltage too high</li>
+  <li>90 - Startup aborted (rotation too high)</li>
+  <li>92 - Rotation too high</li>
+  <li>93 - Power contactor current too high</li>
+  <li>94 - AC voltage L2 too high</li>
+  <li>95 - AC frequency L2 too high</li>
+  <li>96 - AC current L2 too high</li>
+  <li>97 - AC power L2 too high</li>
+  <li>98 - AC voltage L3 too high</li>
+  <li>99 - AC frequency L3 too high</li>
+  <li>100 - AC current L3 too high</li>
+  <li>101 - AC power L3 too high</li>
+  <li>126 - Fuel temperature too high</li>
+  <li>127 - Fuel level too high</li>
+  <li>130 - Lost control unit</li>
+  <li>131 - Lost panel</li>
+  <li>132 - Service needed</li>
+  <li>133 - Lost 3-phase module</li>
+  <li>134 - Lost AGT module</li>
+  <li>135 - Synchronization failure</li>
+  <li>137 - Intake airfilter</li>
+  <li>139 - Lost sync. module</li>
+  <li>140 - Load-balance failed</li>
+  <li>141 - Sync-mode deactivated</li>
+  <li>142 - Engine controller</li>
+  <li>148 - Rotating field wrong</li>
+  <li>149 - Fuel level sensor lost</li>
+  <li>150 - Init failed</li>
+  <li>151 - Watchdog</li>
+  <li>152 - Out: winding</li>
+  <li>153 - Out: exhaust</li>
+  <li>154 - Out: Cyl. head</li>
+  <li>155 - Inverter over temperature</li>
+  <li>156 - Inverter overload</li>
+  <li>157 - Inverter communication lost</li>
+  <li>158 - Inverter sync failed</li>
+  <li>159 - CAN communication lost</li>
+  <li>160 - L1 overload</li>
+  <li>161 - L2 overload</li>
+  <li>162 - L3 overload</li>
+  <li>163 - DC overload</li>
+  <li>164 - DC overvoltage</li>
+  <li>165 - Emergency stop</li>
+  <li>166 - No connection</li>
+</ul></dd>
   <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
 </dd>
@@ -6036,8 +6376,8 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>2 - MPPT Tracker active</li>
   <li>255 - Not available</li>
 </ul></dd>
-  <dt class="optional">MPP operation mode tracker 1<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Pv/0/MppOperationMode</b><span class="property-mode"></span>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">MPP operation mode tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code><span class="property-type">enum</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/MppOperationMode</b><span class="property-mode"></span>
 <ul>
   <li>0 - Off</li>
   <li>1 - Voltage/current limited</li>
@@ -6055,6 +6395,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> voltage<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/V</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">PV current (A)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Pv/I</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">PV voltage<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Pv/V</b><span class="property-mode"></span>
@@ -6248,8 +6591,8 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>2 - MPPT Tracker active</li>
   <li>255 - Not available</li>
 </ul></dd>
-  <dt class="optional">MPP operation mode tracker 1<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Pv/0/MppOperationMode</b><span class="property-mode"></span>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">MPP operation mode tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code><span class="property-type">enum</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/MppOperationMode</b><span class="property-mode"></span>
 <ul>
   <li>0 - Off</li>
   <li>1 - Voltage/current limited</li>
@@ -6267,6 +6610,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> voltage<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/V</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">PV current (A)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Pv/I</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">PV voltage<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Pv/V</b><span class="property-mode"></span>
@@ -6737,6 +7083,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Humidity (%)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Humidity</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Indoor air quality score<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/IAQS</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Luminosity (lux)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Luminosity</b><span class="property-mode"></span>
 </dd>
@@ -6829,6 +7178,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>1 - AC Input 2</li>
   <li>240 - Disconnected</li>
 </ul></dd>
+  <dt class="optional">Active input current limit (A)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/CurrentLimit</b><span class="property-mode"> (Mode: both)</span>
+</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input frequency phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> (Hz)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/ActiveIn/L<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/F</b><span class="property-mode"></span>
 </dd>
@@ -7141,6 +7493,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>1 - AC Input 2</li>
   <li>240 - Disconnected</li>
 </ul></dd>
+  <dt class="optional">Active input current limit (A)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Ac/ActiveIn/CurrentLimit</b><span class="property-mode"> (Mode: both)</span>
+</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input frequency phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code> (Hz)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/ActiveIn/L<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/F</b><span class="property-mode"></span>
 </dd>

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -240,7 +240,7 @@
         "name": "Input frequency (Hz)"
       },
       {
-        "path": "/Ac/Out/{phase}}/V",
+        "path": "/Ac/Out/{phase}/V",
         "type": "float",
         "name": "Output voltage {phase} (V AC)"
       },
@@ -299,6 +299,16 @@
         "path": "/Ess/ActiveSocLimit",
         "type": "float",
         "name": "ESS Active SOC Limit (%)"
+      },
+      {
+        "path": "/Pv/Disable",
+        "type": "enum",
+        "name": "PV enabled",
+        "enum": {
+          "0": "PV enabled",
+          "1": "PV Disabled"
+        },
+        "mode": "both"
       },
       {
         "path": "/Settings/Ac/In/CurrentLimitEnergyMeter",
@@ -533,9 +543,29 @@
         }
       },
       {
+        "path": "/Alarms/BmsCable",
+        "type": "enum",
+        "name": "BMS cable alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
         "path": "/Alarms/CellImbalance",
         "type": "enum",
         "name": "Cell Imbalance alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/Contactor",
+        "type": "enum",
+        "name": "Contactor alarm",
         "enum": {
           "0": "No alarm",
           "1": "Warning",
@@ -565,6 +595,16 @@
         "path": "/Alarms/HighChargeTemperature",
         "type": "enum",
         "name": "High charge temperature alarm",
+        "enum": {
+          "0": "No alarm",
+          "1": "Warning",
+          "2": "Alarm"
+        }
+      },
+      {
+        "path": "/Alarms/HighCurrent",
+        "type": "enum",
+        "name": "High current alarm",
         "enum": {
           "0": "No alarm",
           "1": "Warning",
@@ -1617,6 +1657,24 @@
     },
     "system": [
       {
+        "path": "/DynamicEss/Active",
+        "type": "enum",
+        "name": "Dynamic ESS active",
+        "enum": {
+          "0": "Off",
+          "1": "Active"
+        }
+      },
+      {
+        "path": "/DynamicEss/AllowGridFeedIn",
+        "type": "enum",
+        "name": "Grid feed-in allowed",
+        "enum": {
+          "0": "Not allowed",
+          "1": "Allowed"
+        }
+      },
+      {
         "path": "/DynamicEss/Available",
         "type": "enum",
         "name": "Is Dynamic ESS available",
@@ -1624,6 +1682,11 @@
           "0": "System is not capable of doing DynamicEss",
           "1": "System is capable of doing DynamicEss"
         }
+      },
+      {
+        "path": "/DynamicEss/ChargeRate",
+        "type": "float",
+        "name": "Battery charge rate (kW)"
       },
       {
         "path": "/DynamicEss/ErrorCode",
@@ -2883,6 +2946,11 @@
         "name": "DC current (DC A)"
       },
       {
+        "path": "/Dc/0/Voltage",
+        "type": "float",
+        "name": "DC voltage (DC V)"
+      },
+      {
         "path": "/Engine/CoolantTemperature",
         "type": "float",
         "name": "Engine coolant temperature (Degrees celsius)"
@@ -2933,6 +3001,20 @@
         "name": "Heatsink temperature (Degrees celsius)"
       },
       {
+        "path": "/ProductId",
+        "type": "float",
+        "name": "Generator model"
+      },
+      {
+        "path": "/RemoteStartModeEnabled",
+        "type": "enum",
+        "name": "Remote start mode",
+        "enum": {
+          "0": "Disabled",
+          "1": "Enabled"
+        }
+      },
+      {
         "path": "/Start",
         "type": "enum",
         "name": "Start generator",
@@ -2946,6 +3028,128 @@
         "path": "/StarterVoltage",
         "type": "float",
         "name": "Starter battery voltage (DC V)"
+      },
+      {
+        "path": "/StatusCode",
+        "type": "enum",
+        "name": "Status",
+        "enum": {
+          "0": "Standby",
+          "1": "Startup 1",
+          "2": "Startup 2",
+          "3": "Startup 3",
+          "4": "Startup 4",
+          "5": "Startup 5",
+          "6": "Startup 6",
+          "7": "Startup 7",
+          "8": "Running",
+          "9": "Stopping",
+          "10": "Error"
+        }
+      },
+      {
+        "path": "/ErrorCode",
+        "type": "enum",
+        "name": "Error",
+        "enum": {
+          "0": "No error",
+          "1": "AC voltage L1 too low",
+          "2": "AC frequency L1 too low",
+          "3": "AC current too low",
+          "4": "AC power too low",
+          "5": "Emergency stop",
+          "6": "Servo current too low",
+          "7": "Oil pressure too low",
+          "8": "Engine temperature too low",
+          "9": "Winding temperature too low",
+          "10": "Exhaust temperature too low",
+          "13": "Starter current too low",
+          "14": "Glow current too low",
+          "15": "Glow current too low",
+          "16": "Fuel holding magnet current too low",
+          "17": "Stop solenoid hold coil current too low",
+          "18": "Stop solenoid pull coil current too low",
+          "19": "Optional DC out current too low",
+          "20": "5V output voltage too low",
+          "21": "Boost output current too low",
+          "22": "Panel supply current too high",
+          "25": "Starter battery voltage too low",
+          "26": "Startup aborted (rotation too low)",
+          "28": "Rotation too low",
+          "29": "Power contactor current too low",
+          "30": "AC voltage L2 too low",
+          "31": "AC frequency L2 too low",
+          "32": "AC current L2 too low",
+          "33": "AC power L2 too low",
+          "34": "AC voltage L3 too low",
+          "35": "AC frequency L3 too low",
+          "36": "AC current L3 too low",
+          "37": "AC power L3 too low",
+          "62": "Fuel temperature too low",
+          "63": "Fuel level too low",
+          "65": "AC voltage L1 too high",
+          "66": "AC frequency too high",
+          "67": "AC current too high",
+          "68": "AC power too high",
+          "70": "Servo current too high",
+          "71": "Oil pressure too high",
+          "72": "Engine temperature too high",
+          "73": "Winding temperature too high",
+          "74": "Exhaust temperature too low",
+          "77": "Starter current too low",
+          "78": "Glow current too high",
+          "79": "Glow current too high",
+          "80": "Fuel holding magnet current too high",
+          "81": "Stop solenoid hold coil current too high",
+          "82": "Stop solenoid pull coil current too high",
+          "83": "Optional DC out current too high",
+          "84": "5V output voltage too high",
+          "85": "Boost output current too high",
+          "89": "Starter battery voltage too high",
+          "90": "Startup aborted (rotation too high)",
+          "92": "Rotation too high",
+          "93": "Power contactor current too high",
+          "94": "AC voltage L2 too high",
+          "95": "AC frequency L2 too high",
+          "96": "AC current L2 too high",
+          "97": "AC power L2 too high",
+          "98": "AC voltage L3 too high",
+          "99": "AC frequency L3 too high",
+          "100": "AC current L3 too high",
+          "101": "AC power L3 too high",
+          "126": "Fuel temperature too high",
+          "127": "Fuel level too high",
+          "130": "Lost control unit",
+          "131": "Lost panel",
+          "132": "Service needed",
+          "133": "Lost 3-phase module",
+          "134": "Lost AGT module",
+          "135": "Synchronization failure",
+          "137": "Intake airfilter",
+          "139": "Lost sync. module",
+          "140": "Load-balance failed",
+          "141": "Sync-mode deactivated",
+          "142": "Engine controller",
+          "148": "Rotating field wrong",
+          "149": "Fuel level sensor lost",
+          "150": "Init failed",
+          "151": "Watchdog",
+          "152": "Out: winding",
+          "153": "Out: exhaust",
+          "154": "Out: Cyl. head",
+          "155": "Inverter over temperature",
+          "156": "Inverter overload",
+          "157": "Inverter communication lost",
+          "158": "Inverter sync failed",
+          "159": "CAN communication lost",
+          "160": "L1 overload",
+          "161": "L2 overload",
+          "162": "L3 overload",
+          "163": "DC overload",
+          "164": "DC overvoltage",
+          "165": "Emergency stop",
+          "166": "No connection"
+        }
       },
       {
         "path": "/History/EnergyOut",
@@ -4393,9 +4597,9 @@
         }
       },
       {
-        "path": "/Pv/0/MppOperationMode",
+        "path": "/Pv/{tracker}/MppOperationMode",
         "type": "enum",
-        "name": "MPP operation mode tracker 1",
+        "name": "MPP operation mode tracker {tracker}",
         "enum": {
           "0": "Off",
           "1": "Voltage/current limited",
@@ -4421,6 +4625,11 @@
         "path": "/Pv/{tracker}/V",
         "type": "float",
         "name": "Tracker {tracker} voltage"
+      },
+      {
+        "path": "/Pv/I",
+        "type": "float",
+        "name": "PV current (A)"
       },
       {
         "path": "/Pv/V",
@@ -4892,6 +5101,11 @@
         "name": "Humidity (%)"
       },
       {
+        "path": "/IAQS",
+        "type": "float",
+        "name": "Indoor air quality score"
+      },
+      {
         "path": "/Luminosity",
         "type": "float",
         "name": "Luminosity (lux)"
@@ -4994,6 +5208,12 @@
           "1": "AC Input 2",
           "240": "Disconnected"
         }
+      },
+      {
+        "path": "/Ac/ActiveIn/CurrentLimit",
+        "type": "float",
+        "name": "Active input current limit (A)",
+        "mode": "both"
       },
       {
         "path": "/Ac/ActiveIn/L{index}/F",


### PR DESCRIPTION
The audit script still assumed the retired input-X/output-X schema and crashed immediately against the current flat services.json. Rewrote it to compare against dbus_modbustcp's attributes.csv (no more unused exceljs dependency) and to expand wildcard path templates (e.g. /Ac/Out/{phase}/V) before diffing, fixing a large false-positive count. Wired it in as `npm run check-services`.

While auditing, found and fixed a stray `}` in acsystem's /Ac/Out/{phase}}/V that broke its wildcard expansion, and added several genuinely missing dbus paths surfaced by the fixed script: temperature /IAQS, battery alarm codes, DESS status fields, vebus active-input current limit, solarcharger PV current and per-tracker MPP mode, acsystem PV disable, and DC genset status/error/product fields to match their AC genset counterparts.

Regenerated src/nodes/config-client.html via `npm run documentation`.