### PR TITLE
fix(nodes): persist conditional-mode output count across editor reload

### DIFF
--- a/src/nodes/victron-nodes.html
+++ b/src/nodes/victron-nodes.html
@@ -1207,6 +1207,7 @@
             category: 'Victron Energy',
             paletteLabel: nodePaletteLabel,
             defaults: {
+                outputs: { value: isOutputNode ? 0 : 1 }, // must be in defaults for Node-RED to persist it across reloads (#557)
                 service: { value: "", required: true },
                 path: { value: "", required: true },
                 serviceObj: { value: undefined },


### PR DESCRIPTION
Node-RED's editor only restores a node's saved output count from the flow JSON when 'outputs' is declared inside defaults. Input nodes only had it as a static top-level property, so on reload the editor always fell back to 1 output and silently dropped the wire on output 2 for nodes with conditional evaluation enabled.

Fixes #557