### PR TITLE
fix(nodes): stop removeStatusListener from wiping other nodes' status

### DIFF
--- a/src/nodes/config-client.js
+++ b/src/nodes/config-client.js
@@ -138,7 +138,7 @@ module.exports = function (RED) {
       return id
     }
 
-    this.removeStatusListener = id => { statusListeners = statusListeners.filter(o => o.id === id) }
+    this.removeStatusListener = id => { statusListeners = statusListeners.filter(o => o.id !== id) }
   }
 
   RED.nodes.registerType('victron-client', ConfigVictronClient)

--- a/test/config-client.test.js
+++ b/test/config-client.test.js
@@ -1,0 +1,47 @@
+jest.mock('../src/services/victron-client.js', () => {
+  return jest.fn().mockImplementation(() => ({
+    connect: jest.fn(),
+    onStatusUpdate: () => {},
+    system: { cache: {} }
+  }))
+})
+
+const configClientInitFunction = require('../src/nodes/config-client')
+const utils = require('../src/services/utils.js')
+
+function buildMockRED () {
+  const registeredTypes = {}
+  const mockRED = {
+    httpNode: { get: jest.fn() },
+    auth: { needsPermission: jest.fn() },
+    nodes: {
+      registerType: (type, fn) => { registeredTypes[type] = fn },
+      createNode: (self, config) => { Object.assign(self, config) }
+    }
+  }
+  configClientInitFunction(mockRED)
+  return registeredTypes['victron-client']
+}
+
+describe('config-client status listeners', () => {
+  it('removeStatusListener only removes the specified listener, leaving other nodes able to receive status updates', () => {
+    const ConfigVictronClient = buildMockRED()
+    const configNode = new ConfigVictronClient({})
+
+    const nodeA = { status: jest.fn() }
+    const nodeB = { status: jest.fn() }
+
+    const idA = configNode.addStatusListener(nodeA, 'com.victronenergy.heatpump/40', '/State')
+    configNode.addStatusListener(nodeB, 'com.victronenergy.switch/41', '/State')
+
+    // clear the initial status() call every addStatusListener performs on registration
+    nodeA.status.mockClear()
+    nodeB.status.mockClear()
+
+    configNode.removeStatusListener(idA)
+
+    configNode.client.onStatusUpdate({ service: 'com.victronenergy.switch/41' }, utils.STATUS.SERVICE_REMOVE)
+
+    expect(nodeB.status).toHaveBeenCalledWith(utils.DISCONNECTED)
+  })
+})


### PR DESCRIPTION
statusListeners.filter(o => o.id === id) kept only the listener being removed and discarded every other node's entry. Since removeStatusListener runs on every input node's close event (fired for touched nodes on any deploy, not just full deploys), other Custom Input nodes silently lost their status tracking and their editor status froze at whatever it last was - typically the green "Connected" dot, even after the underlying D-Bus service (e.g. a Shelly switch/relay) had disappeared.

Confirmed against a real Shelly heatpump device: unplugging it fully removes its D-Bus service (NameOwnerChanged), so the SERVICE_REMOVE event was already being emitted correctly - it just never reached other nodes.