### PR TITLE
fix(services): fix unreachable service-removal branch in dbus-listener

### DIFF
--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -344,15 +344,15 @@ class VictronDbusListener {
           if (newOwner) {
             this._initService(newOwner, name)
             this.eventHandler('INITIALIZE', name)
-          }
-        } else {
-          const oldOwner = msg.body[1]
-          if (oldOwner && this.services[oldOwner]) {
-            const deviceInstanceSuffix = ('/' + (this.services[oldOwner].deviceInstance != null ? this.services[oldOwner].deviceInstance : '')).replace(/\.$/, '')
-            const svcName = this.services[oldOwner].name.split('.').splice(0, 3).join('.') + deviceInstanceSuffix
-            this.eventHandler('DELETE', this.services[oldOwner].name)
-            delete this.services[oldOwner]
-            this.eventHandler('DELETE', svcName)
+          } else {
+            const oldOwner = msg.body[1]
+            if (oldOwner && this.services[oldOwner]) {
+              const deviceInstanceSuffix = ('/' + (this.services[oldOwner].deviceInstance != null ? this.services[oldOwner].deviceInstance : '')).replace(/\.$/, '')
+              const svcName = this.services[oldOwner].name.split('.').splice(0, 3).join('.') + deviceInstanceSuffix
+              this.eventHandler('DELETE', this.services[oldOwner].name)
+              delete this.services[oldOwner]
+              this.eventHandler('DELETE', svcName)
+            }
           }
         }
       }

--- a/test/dbus-listener.test.js
+++ b/test/dbus-listener.test.js
@@ -122,4 +122,43 @@ describe('VictronDbusListener', () => {
       expect(service.deviceInstance).toBe(0)
     })
   })
+
+  describe('_signalRecieve NameOwnerChanged (service removal)', () => {
+    let eventHandler
+
+    beforeEach(() => {
+      eventHandler = jest.fn()
+      listener = new VictronDbusListener('the-address', { eventHandler })
+    })
+
+    test('a service losing its name owner fires a DELETE event and removes it from services', () => {
+      listener.services[':1.42'] = {
+        name: 'com.victronenergy.heatpump.shelly_D885AC1B38F4_0',
+        deviceInstance: 61
+      }
+
+      listener._signalRecieve({
+        interface: 'org.freedesktop.DBus',
+        member: 'NameOwnerChanged',
+        body: ['com.victronenergy.heatpump.shelly_D885AC1B38F4_0', ':1.42', '']
+      })
+
+      expect(eventHandler).toHaveBeenCalledWith('DELETE', 'com.victronenergy.heatpump.shelly_D885AC1B38F4_0')
+      expect(eventHandler).toHaveBeenCalledWith('DELETE', 'com.victronenergy.heatpump/61')
+      expect(listener.services[':1.42']).toBeUndefined()
+    })
+
+    test('a service gaining a name owner fires an INITIALIZE event', () => {
+      listener._initService = jest.fn()
+
+      listener._signalRecieve({
+        interface: 'org.freedesktop.DBus',
+        member: 'NameOwnerChanged',
+        body: ['com.victronenergy.heatpump.shelly_D885AC1B38F4_0', '', ':1.42']
+      })
+
+      expect(listener._initService).toHaveBeenCalledWith(':1.42', 'com.victronenergy.heatpump.shelly_D885AC1B38F4_0')
+      expect(eventHandler).toHaveBeenCalledWith('INITIALIZE', 'com.victronenergy.heatpump.shelly_D885AC1B38F4_0')
+    })
+  })
 })


### PR DESCRIPTION
In _signalRecieve's NameOwnerChanged handling, the deletion branch was nested as the else of `if (name.startsWith('com.victronenergy'))` instead of the else of `if (newOwner)`. Since every tracked service name starts with 'com.victronenergy' (the entire allowlist), a service losing its D-Bus name owner always took the truthy branch, failed the `if (newOwner)` check (newOwner is '' on removal), and hit neither the INITIALIZE nor the DELETE logic - the deletion branch was dead code for every real service.

This meant SERVICE_REMOVE never fired: stale entries stayed in the system cache indefinitely after a device's D-Bus service actually disappeared (e.g. a Shelly relay dropping off Wi-Fi), even though the D-Bus daemon correctly broadcast the NameOwnerChanged signal.

Verified against a real Shelly-backed heatpump service on Venus OS: before the fix, zero SERVICE_REMOVE events fired for any service across repeated disconnect cycles; after the fix, the removal is correctly detected and the stale cache entry is cleared.