### PR TITLE
feat(services): expose SwitchableOutput control on heatpump services

### DIFF
--- a/src/services/services.json
+++ b/src/services/services.json
@@ -3577,6 +3577,18 @@
         "mode": "both"
       }
     ],
+    "heatpump": [
+      {
+        "path": "/SwitchableOutput/{type}/State",
+        "type": "enum",
+        "enum": {
+          "0": "Off",
+          "1": "On"
+        },
+        "name": "{type} state",
+        "mode": "both"
+      }
+    ],
     "communityTag": "switch"
   },
   "meteo": {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -193,8 +193,8 @@ function expandWildcardPaths (pathObj, cachedPaths, serviceName) {
           }
         }
 
-        // For switches, try custom names (only for 'type' wildcard)
-        if (serviceName === 'switch' && wildcardName === 'type') {
+        // For switches (and switch-like SwitchableOutput services, e.g. heatpump), try custom names (only for 'type' wildcard)
+        if ((serviceName === 'switch' || serviceName === 'heatpump') && wildcardName === 'type') {
           const customNamePath = `/SwitchableOutput/${wildcardValue}/Settings/CustomName`
           const namePath = `/SwitchableOutput/${wildcardValue}/Name`
           const customName = cachedPaths[customNamePath] || cachedPaths[namePath]

--- a/test/victron-system.test.js
+++ b/test/victron-system.test.js
@@ -327,3 +327,40 @@ describe('ESS battery status reason codes (issue #342)', () => {
     }
   })
 })
+
+describe('heatpump SwitchableOutput support (Shelly relays used to control a heat pump)', () => {
+  let systemConfig
+
+  beforeEach(() => {
+    systemConfig = new SystemConfiguration()
+    systemConfig.cache = {
+      'com.victronenergy.heatpump.shelly_D885AC1B38F4_0': {
+        '/DeviceInstance': 40,
+        '/CustomName': 'Kelder - heating',
+        '/SwitchableOutput/0/State': 1,
+        '/SwitchableOutput/0/Status': 1,
+        '/SwitchableOutput/0/Settings/CustomName': 'Kelder - heating'
+      }
+    }
+  })
+
+  test('output-switch node whitelist includes a heatpump entry', () => {
+    expect(servicesJson.switch.heatpump).toBeDefined()
+    expect(servicesJson.switch.heatpump.find(p => p.path === '/SwitchableOutput/{type}/State')).toBeDefined()
+  })
+
+  test('output-switch node exposes the heatpump service SwitchableOutput/State path', () => {
+    const result = systemConfig.getNodeServices('output-switch')
+    const heatpumpService = result.services.find(s => s.service.startsWith('com.victronenergy.heatpump'))
+    expect(heatpumpService).toBeDefined()
+    const statePath = heatpumpService.paths.find(p => p.path === '/SwitchableOutput/0/State')
+    expect(statePath).toBeDefined()
+  })
+
+  test('SwitchableOutput display name uses the CustomName, matching switch behaviour', () => {
+    const result = systemConfig.getNodeServices('output-switch')
+    const heatpumpService = result.services.find(s => s.service.startsWith('com.victronenergy.heatpump'))
+    const statePath = heatpumpService.paths.find(p => p.path === '/SwitchableOutput/0/State')
+    expect(statePath.name).toBe('Kelder - heating state')
+  })
+})


### PR DESCRIPTION
Some heat pumps are controlled through a Shelly relay registered on D-Bus as `com.victronenergy.heatpump.*`, exposing the same `/SwitchableOutput/{type}/..` paths as `com.victronenergy.switch.*` and `com.victronenergy.acload.*` devices. The Switch (control) node's service whitelist only listed the switch and acload prefixes, so these heatpump services never appeared in its dropdown.

Adds a heatpump entry (State only - the only SwitchableOutput path confirmed present on a Shelly device in the heatpump role) to the switch node's whitelist in `esrvices.json`, and extends the `SwitchableOutput` custom-name lookup in `expandWildcardPaths` to also apply to heatpump services for display-name parity with switch.