### PR TITLE
docs: fix contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This library is community-supported. For help:
 
 ## Contributing
 
-Contributions are welcome! See our [Contributing Guide](https://github.com/victronenergy/node-red-contrib-victron/blob/master/CONTRIBUTING.md) for details.
+Contributions are welcome! See our [Contributing Guide](docs/DEVELOPMENT.md#contributing-guidelines) for details.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- point the README's Contributing Guide link to the existing contribution instructions
- replace the broken root-level `CONTRIBUTING.md` URL with the relevant section in `docs/DEVELOPMENT.md`

## Validation

- confirmed the previous URL returns 404
- confirmed the replacement URL resolves successfully
- searched existing issues and pull requests for a duplicate fix