### PR TITLE
fix(services): consolidate duplicate node-help blocks in generated docs

### DIFF
--- a/scripts/service2doc.js
+++ b/scripts/service2doc.js
@@ -152,84 +152,128 @@ function generatePathDoc (pathObj, format) {
 }
 
 /**
+ * Normalize a D-Bus path for duplicate detection: wildcard placeholders and
+ * concrete numeric path segments both collapse to the same token, so e.g.
+ * /Relay/{relay}/State and /Relay/0/State are recognised as the same shape.
+ */
+function normalizePathForDedup (dbusPath) {
+  return dbusPath
+    .replace(/\{[^}]+\}/g, '*')
+    .replace(/\/\d+(?=\/|$)/g, '/*')
+}
+
+/**
+ * Merge path definitions from multiple service sub-categories into a single
+ * list, one entry per distinct D-Bus property.
+ *
+ * Sub-categories often redeclare the same property - e.g. switch/acload both
+ * define /SwitchableOutput/{type}/State, or relay's per-device categories
+ * all define /Relay/0/State under a different name - so the first
+ * declaration encountered wins. When both a wildcard path and a concrete
+ * path normalize to the same shape (e.g. /Relay/{relay}/State vs
+ * /Relay/0/State), the wildcard version is kept since it documents the
+ * property generically instead of tying it to one device.
+ */
+function dedupePathDocs (pathObjs) {
+  const firstByExactPath = []
+  const seenExactPaths = new Set()
+  for (const pathObj of pathObjs) {
+    if (seenExactPaths.has(pathObj.path)) continue
+    seenExactPaths.add(pathObj.path)
+    firstByExactPath.push(pathObj)
+  }
+
+  const groupsByShape = new Map()
+  for (const pathObj of firstByExactPath) {
+    const shape = normalizePathForDedup(pathObj.path)
+    if (!groupsByShape.has(shape)) groupsByShape.set(shape, [])
+    groupsByShape.get(shape).push(pathObj)
+  }
+
+  return Array.from(groupsByShape.values()).map(group =>
+    group.find(pathObj => pathObj.path.includes('{')) || group[0]
+  )
+}
+
+/**
  * Generate documentation for a service
  */
 function generateServiceDoc (serviceName, serviceData, registeredNodes, format, nodeTypeFilter) {
   const nodeTypes = nodeTypeFilter ? [nodeTypeFilter] : ['input', 'output']
   let doc = ''
 
-  // Process each service type within the service
-  Object.entries(serviceData).forEach(([serviceType, serviceTypeData]) => {
-    if (serviceType === 'help' || serviceType === 'communityTag') return // Skip help section and communityTag
+  // Merge path definitions from every sub-category (e.g. switch/acload/
+  // heatpump, or relay's per-device categories) into one list per node
+  // type, so each node type gets a single documentation block instead of
+  // one per sub-category.
+  const allPathObjs = Object.entries(serviceData)
+    .filter(([serviceType]) => serviceType !== 'help' && serviceType !== 'communityTag')
+    .flatMap(([, serviceTypeData]) => Array.isArray(serviceTypeData) ? serviceTypeData : [])
 
-    const paths = serviceTypeData || []
-    if (!Array.isArray(paths) || paths.length === 0) return
+  for (const nodeType of nodeTypes) {
+    const relevantPaths = dedupePathDocs(
+      allPathObjs.filter(pathObj => !pathObj.mode || pathObj.mode === 'both' || pathObj.mode === nodeType)
+    )
 
-    for (const nodeType of nodeTypes) {
-      const relevantPaths = paths.filter(pathObj =>
-        !pathObj.mode || pathObj.mode === 'both' || pathObj.mode === nodeType
-      )
+    if (relevantPaths.length === 0) continue
 
-      if (relevantPaths.length === 0) continue
+    // Check if the node is actually registered
+    const nodeSet = nodeType === 'input' ? registeredNodes.inputNodes : registeredNodes.outputNodes
+    if (!nodeSet.has(serviceName)) continue
 
-      // Check if the node is actually registered
-      const nodeSet = nodeType === 'input' ? registeredNodes.inputNodes : registeredNodes.outputNodes
-      if (!nodeSet.has(serviceName)) continue
+    const nodeName = `victron-${nodeType}-${serviceName}`
+    const title = serviceName === 'motordrive' ? 'E-drive' : serviceName.charAt(0).toUpperCase() + serviceName.slice(1)
 
-      const nodeName = `victron-${nodeType}-${serviceName}`
-      const title = serviceName === 'motordrive' ? 'E-drive' : serviceName.charAt(0).toUpperCase() + serviceName.slice(1)
+    if (format === 'md') {
+      doc += `\n## ${title} (${nodeType})\n`
 
-      if (format === 'md') {
-        doc += `\n## ${title} (${nodeType})\n`
-
-        if (hasWildcards(relevantPaths)) {
-          doc += generateWildcardExplanation(format)
-        }
-
-        // Add help text if available
-        const helpText = serviceData.help?.[nodeType] || serviceData.help?.both
-        if (helpText) {
-          // Strip HTML tags for markdown and clean up
-          const cleanHelp = helpText.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim()
-          if (cleanHelp) {
-            doc += `\n${cleanHelp}\n`
-          }
-        }
-
-        relevantPaths.forEach(pathObj => {
-          doc += '\n' + generatePathDoc(pathObj, format) + '\n'
-        })
-      } else {
-        doc += `\n<script type="text/x-red" data-help-name="${nodeName}">\n`
-        doc += '<h3>Details</h3>\n'
-
-        // Add standard details text
-        const nodeTypeText = nodeType === 'input' ? 'input' : 'output'
-        doc += `<p>The <strong>${nodeTypeText} nodes</strong> have two selectable inputs: the devices select and measurement select. `
-        doc += 'The available options are dynamically updated based on the data that is actually available on the Venus device.</p>\n'
-
-        if (hasWildcards(relevantPaths)) {
-          doc += generateWildcardExplanation(format)
-        }
-
-        // Add help text if available
-        const helpText = serviceData.help?.[nodeType] || serviceData.help?.both
-        if (helpText) {
-          doc += helpText + '\n'
-        }
-
-        doc += `<h3>${title}</h3>\n`
-        doc += '<dl class="message-properties">\n'
-
-        relevantPaths.forEach(pathObj => {
-          doc += generatePathDoc(pathObj, format)
-        })
-
-        doc += '</dl>\n'
-        doc += '</script>\n'
+      if (hasWildcards(relevantPaths)) {
+        doc += generateWildcardExplanation(format)
       }
+
+      // Add help text if available
+      const helpText = serviceData.help?.[nodeType] || serviceData.help?.both
+      if (helpText) {
+        // Strip HTML tags for markdown and clean up
+        const cleanHelp = helpText.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim()
+        if (cleanHelp) {
+          doc += `\n${cleanHelp}\n`
+        }
+      }
+
+      relevantPaths.forEach(pathObj => {
+        doc += '\n' + generatePathDoc(pathObj, format) + '\n'
+      })
+    } else {
+      doc += `\n<script type="text/x-red" data-help-name="${nodeName}">\n`
+      doc += '<h3>Details</h3>\n'
+
+      // Add standard details text
+      const nodeTypeText = nodeType === 'input' ? 'input' : 'output'
+      doc += `<p>The <strong>${nodeTypeText} nodes</strong> have two selectable inputs: the devices select and measurement select. `
+      doc += 'The available options are dynamically updated based on the data that is actually available on the Venus device.</p>\n'
+
+      if (hasWildcards(relevantPaths)) {
+        doc += generateWildcardExplanation(format)
+      }
+
+      // Add help text if available
+      const helpText = serviceData.help?.[nodeType] || serviceData.help?.both
+      if (helpText) {
+        doc += helpText + '\n'
+      }
+
+      doc += `<h3>${title}</h3>\n`
+      doc += '<dl class="message-properties">\n'
+
+      relevantPaths.forEach(pathObj => {
+        doc += generatePathDoc(pathObj, format)
+      })
+
+      doc += '</dl>\n'
+      doc += '</script>\n'
     }
-  })
+  }
 
   return doc
 }
@@ -780,5 +824,6 @@ module.exports = {
   highlightWildcards,
   loadDeviceTypeModules,
   generateDeviceTypesTable,
-  generateSpecialNodesDoc
+  generateSpecialNodesDoc,
+  dedupePathDocs
 }

--- a/scripts/service2doc.js
+++ b/scripts/service2doc.js
@@ -219,7 +219,10 @@ function dedupePathDocs (pathObjs) {
 
     const coveringWildcard = Array.from(wildcardsByShape.values())
       .find(wildcardObj => wildcardCoversPath(wildcardObj.path, pathObj.path))
-    if (coveringWildcard) continue
+    if (coveringWildcard) {
+      console.warn(`service2doc: dropping "${pathObj.path}" (${pathObj.name}) from generated docs - covered by wildcard "${coveringWildcard.path}"`)
+      continue
+    }
 
     result.push(pathObj)
   }

--- a/scripts/service2doc.js
+++ b/scripts/service2doc.js
@@ -152,14 +152,28 @@ function generatePathDoc (pathObj, format) {
 }
 
 /**
- * Normalize a D-Bus path for duplicate detection: wildcard placeholders and
- * concrete numeric path segments both collapse to the same token, so e.g.
- * /Relay/{relay}/State and /Relay/0/State are recognised as the same shape.
+ * Normalize a D-Bus path's wildcard placeholders to a common token, e.g.
+ * /Relay/{relay}/State and /Relay/{output}/State both become /Relay/*\/State.
+ * Concrete numeric segments are left untouched: /Dc/0/Voltage and
+ * /Dc/1/Voltage are distinct properties, not the same shape.
  */
 function normalizePathForDedup (dbusPath) {
-  return dbusPath
-    .replace(/\{[^}]+\}/g, '*')
-    .replace(/\/\d+(?=\/|$)/g, '/*')
+  return dbusPath.replace(/\{[^}]+\}/g, '*')
+}
+
+/**
+ * A wildcard path "covers" a concrete path if replacing the wildcard's
+ * placeholders with the concrete path's corresponding segments reproduces
+ * it exactly, e.g. /Relay/{relay}/State covers /Relay/0/State (and any
+ * other /Relay/<anything>/State) but not /Dc/0/Voltage.
+ */
+function wildcardCoversPath (wildcardPath, concretePath) {
+  const wildcardSegments = wildcardPath.split('/')
+  const concreteSegments = concretePath.split('/')
+  if (wildcardSegments.length !== concreteSegments.length) return false
+  return wildcardSegments.every((segment, i) =>
+    segment.startsWith('{') || segment === concreteSegments[i]
+  )
 }
 
 /**
@@ -169,10 +183,12 @@ function normalizePathForDedup (dbusPath) {
  * Sub-categories often redeclare the same property - e.g. switch/acload both
  * define /SwitchableOutput/{type}/State, or relay's per-device categories
  * all define /Relay/0/State under a different name - so the first
- * declaration encountered wins. When both a wildcard path and a concrete
- * path normalize to the same shape (e.g. /Relay/{relay}/State vs
- * /Relay/0/State), the wildcard version is kept since it documents the
- * property generically instead of tying it to one device.
+ * declaration encountered wins. A concrete path already covered by a
+ * wildcard path (e.g. /Relay/0/State vs /Relay/{relay}/State) is dropped in
+ * favour of the wildcard, since it documents the property generically
+ * instead of tying it to one device. Concrete paths that only share a shape
+ * with each other (e.g. /Dc/0/Voltage vs /Dc/1/Voltage), with no wildcard
+ * declared for that shape, are distinct properties and both are kept.
  */
 function dedupePathDocs (pathObjs) {
   const firstByExactPath = []
@@ -183,16 +199,32 @@ function dedupePathDocs (pathObjs) {
     firstByExactPath.push(pathObj)
   }
 
-  const groupsByShape = new Map()
+  const wildcardsByShape = new Map()
   for (const pathObj of firstByExactPath) {
+    if (!pathObj.path.includes('{')) continue
     const shape = normalizePathForDedup(pathObj.path)
-    if (!groupsByShape.has(shape)) groupsByShape.set(shape, [])
-    groupsByShape.get(shape).push(pathObj)
+    if (!wildcardsByShape.has(shape)) wildcardsByShape.set(shape, pathObj)
   }
 
-  return Array.from(groupsByShape.values()).map(group =>
-    group.find(pathObj => pathObj.path.includes('{')) || group[0]
-  )
+  const result = []
+  const addedWildcardShapes = new Set()
+  for (const pathObj of firstByExactPath) {
+    if (pathObj.path.includes('{')) {
+      const shape = normalizePathForDedup(pathObj.path)
+      if (addedWildcardShapes.has(shape)) continue
+      addedWildcardShapes.add(shape)
+      result.push(pathObj)
+      continue
+    }
+
+    const coveringWildcard = Array.from(wildcardsByShape.values())
+      .find(wildcardObj => wildcardCoversPath(wildcardObj.path, pathObj.path))
+    if (coveringWildcard) continue
+
+    result.push(pathObj)
+  }
+
+  return result
 }
 
 /**

--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -473,9 +473,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input voltage <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (V AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/1/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/V</b><span class="property-mode"></span>
 </dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input voltage <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (V AC)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/1/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/V</b><span class="property-mode"></span>
-</dd>
   <dt class="optional">Input voltage phase 3 (V AC)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Ac/In/1/L3/V</b><span class="property-mode"></span>
 </dd>
@@ -585,9 +582,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 <dl class="message-properties">
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Ac input <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> current limit (A)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/CurrentLimit</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input voltage <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (V AC)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/1/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/V</b><span class="property-mode"></span>
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input voltage <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (V AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/1/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/V</b><span class="property-mode"></span>
@@ -1167,9 +1161,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
-  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
-</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Diagnostics; error <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code><span class="property-type">enum</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Diagnostics/LastErrors/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/Error</b><span class="property-mode"></span>
 <ul>
@@ -1680,9 +1671,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
-  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
-</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Diagnostics; error <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code><span class="property-type">enum</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Diagnostics/LastErrors/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/Error</b><span class="property-mode"></span>
 <ul>
@@ -2176,9 +2164,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
-  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
-</dd>
   <dt class="optional">Total energy consumed (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyIn</b><span class="property-mode"></span>
 </dd>
@@ -2241,9 +2226,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional">Battery voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Starter battery voltage (V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
@@ -2314,132 +2296,11 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V DC)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
-  <dt class="optional">Auxiliary voltage (V DC)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
-</dd>
   <dt class="optional">Total energy consumed (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyIn</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-dess">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>Dynamic ESS input node.</p>
-<h3>Dess</h3>
-<dl class="message-properties">
-  <dt class="optional">Dynamic ESS active<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/Active</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - Active</li>
-</ul></dd>
-  <dt class="optional">Grid feed-in allowed<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/AllowGridFeedIn</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Not allowed</li>
-  <li>1 - Allowed</li>
-</ul></dd>
-  <dt class="optional">Is Dynamic ESS available<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/Available</b><span class="property-mode"></span>
-<ul>
-  <li>0 - System is not capable of doing DynamicEss</li>
-  <li>1 - System is capable of doing DynamicEss</li>
-</ul></dd>
-  <dt class="optional">Battery charge rate (kW)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/ChargeRate</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Error<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/ErrorCode</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - No ESS</li>
-  <li>2 - ESS mode</li>
-  <li>3 - No matching schedule</li>
-  <li>4 - SOC low</li>
-  <li>5 - Battery capacity not configured</li>
-</ul></dd>
-  <dt class="optional">Active restrictions<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/Restrictions</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No restrictions between battery and the grid</li>
-  <li>1 - Battery to grid energy flow is restricted</li>
-  <li>2 - Grid to battery energy flow is restricted</li>
-  <li>3 - No energy flow between battery and grid</li>
-</ul></dd>
-  <dt class="optional">Used strategy for current time slot<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/Strategy</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Target SOC</li>
-  <li>1 - Self-consumption</li>
-  <li>2 - Pro battery</li>
-  <li>3 - Pro grid</li>
-</ul></dd>
-  <dt class="optional">The set target SOC for this time slot (%)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/TargetSoc</b><span class="property-mode"></span>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-dess">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Dess</h3>
-<dl class="message-properties">
-  <dt class="optional">Dynamic ESS active<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/Active</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - Active</li>
-</ul></dd>
-  <dt class="optional">Grid feed-in allowed<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/AllowGridFeedIn</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Not allowed</li>
-  <li>1 - Allowed</li>
-</ul></dd>
-  <dt class="optional">Is Dynamic ESS available<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/Available</b><span class="property-mode"></span>
-<ul>
-  <li>0 - System is not capable of doing DynamicEss</li>
-  <li>1 - System is capable of doing DynamicEss</li>
-</ul></dd>
-  <dt class="optional">Battery charge rate (kW)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/ChargeRate</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Error<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/ErrorCode</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - No ESS</li>
-  <li>2 - ESS mode</li>
-  <li>3 - No matching schedule</li>
-  <li>4 - SOC low</li>
-  <li>5 - Battery capacity not configured</li>
-</ul></dd>
-  <dt class="optional">Active restrictions<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/Restrictions</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No restrictions between battery and the grid</li>
-  <li>1 - Battery to grid energy flow is restricted</li>
-  <li>2 - Grid to battery energy flow is restricted</li>
-  <li>3 - No energy flow between battery and grid</li>
-</ul></dd>
-  <dt class="optional">Used strategy for current time slot<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/Strategy</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Target SOC</li>
-  <li>1 - Self-consumption</li>
-  <li>2 - Pro battery</li>
-  <li>3 - Pro grid</li>
-</ul></dd>
-  <dt class="optional">The set target SOC for this time slot (%)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/DynamicEss/TargetSoc</b><span class="property-mode"></span>
 </dd>
 </dl>
 </script>
@@ -2464,6 +2325,56 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </div><p>Dynamic ESS input node.</p>
 <h3>Dess</h3>
 <dl class="message-properties">
+  <dt class="optional">Dynamic ESS active<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Active</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Active</li>
+</ul></dd>
+  <dt class="optional">Grid feed-in allowed<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/AllowGridFeedIn</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Not allowed</li>
+  <li>1 - Allowed</li>
+</ul></dd>
+  <dt class="optional">Is Dynamic ESS available<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Available</b><span class="property-mode"></span>
+<ul>
+  <li>0 - System is not capable of doing DynamicEss</li>
+  <li>1 - System is capable of doing DynamicEss</li>
+</ul></dd>
+  <dt class="optional">Battery charge rate (kW)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/ChargeRate</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Error<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/ErrorCode</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - No ESS</li>
+  <li>2 - ESS mode</li>
+  <li>3 - No matching schedule</li>
+  <li>4 - SOC low</li>
+  <li>5 - Battery capacity not configured</li>
+</ul></dd>
+  <dt class="optional">Active restrictions<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Restrictions</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No restrictions between battery and the grid</li>
+  <li>1 - Battery to grid energy flow is restricted</li>
+  <li>2 - Grid to battery energy flow is restricted</li>
+  <li>3 - No energy flow between battery and grid</li>
+</ul></dd>
+  <dt class="optional">Used strategy for current time slot<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Strategy</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Target SOC</li>
+  <li>1 - Self-consumption</li>
+  <li>2 - Pro battery</li>
+  <li>3 - Pro grid</li>
+</ul></dd>
+  <dt class="optional">The set target SOC for this time slot (%)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/TargetSoc</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Battery capacity (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Settings/DynamicEss/BatteryCapacity</b><span class="property-mode"> (Mode: both)</span>
 </dd>
@@ -2550,6 +2461,56 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </div> 
 <h3>Dess</h3>
 <dl class="message-properties">
+  <dt class="optional">Dynamic ESS active<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Active</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Off</li>
+  <li>1 - Active</li>
+</ul></dd>
+  <dt class="optional">Grid feed-in allowed<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/AllowGridFeedIn</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Not allowed</li>
+  <li>1 - Allowed</li>
+</ul></dd>
+  <dt class="optional">Is Dynamic ESS available<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Available</b><span class="property-mode"></span>
+<ul>
+  <li>0 - System is not capable of doing DynamicEss</li>
+  <li>1 - System is capable of doing DynamicEss</li>
+</ul></dd>
+  <dt class="optional">Battery charge rate (kW)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/ChargeRate</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Error<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/ErrorCode</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - No ESS</li>
+  <li>2 - ESS mode</li>
+  <li>3 - No matching schedule</li>
+  <li>4 - SOC low</li>
+  <li>5 - Battery capacity not configured</li>
+</ul></dd>
+  <dt class="optional">Active restrictions<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Restrictions</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No restrictions between battery and the grid</li>
+  <li>1 - Battery to grid energy flow is restricted</li>
+  <li>2 - Grid to battery energy flow is restricted</li>
+  <li>3 - No energy flow between battery and grid</li>
+</ul></dd>
+  <dt class="optional">Used strategy for current time slot<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/Strategy</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Target SOC</li>
+  <li>1 - Self-consumption</li>
+  <li>2 - Pro battery</li>
+  <li>3 - Pro grid</li>
+</ul></dd>
+  <dt class="optional">The set target SOC for this time slot (%)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/DynamicEss/TargetSoc</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Battery capacity (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Settings/DynamicEss/BatteryCapacity</b><span class="property-mode"> (Mode: both)</span>
 </dd>
@@ -2628,15 +2589,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Pulse meter count<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Count</b><span class="property-mode"></span>
 </dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-digitalinput">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>With this node it is possible to read the digital inputs from the Venus device. The node only shows the enabled digital inputs, so first make sure to enable the input from the Venus OS GUI (<i>Settings -> I/O -> digital inputs</i>) for the desired readout.</p><p>Depending on the selected type of input, different measurements become available.</p><p>Also see the section on <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/digital-inputs.html">digital inputs</a> in the Cerbo GX manual.</p>
-<h3>Digitalinput</h3>
-<dl class="message-properties">
   <dt class="optional">Digital input alarm<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Alarm</b><span class="property-mode"></span>
 <ul>
@@ -2644,9 +2596,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>1 - Warning</li>
   <li>2 - Alarm</li>
 </ul></dd>
-  <dt class="optional">Digital input count<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Count</b><span class="property-mode"></span>
-</dd>
   <dt class="optional">Digital input state<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/State</b><span class="property-mode"></span>
 <ul>
@@ -2684,72 +2633,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 <script type="text/x-red" data-help-name="victron-input-ess">
 <h3>Details</h3>
 <p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>This node gives information on the energy storage system (ESS).</p>
-<h3>Ess</h3>
-<dl class="message-properties">
-  <dt class="optional">Maximum battery cell temperature<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/MaxCellTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Maximum battery cell voltage<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/MaxCellVoltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Minimum battery cell temperature<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/MinCellTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Minimum battery cell voltage<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/MinCellVoltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Number of modules blocking charge<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/NrOfModulesBlockingCharge</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Number of modules blocking discharge<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/NrOfModulesBlockingDischarge</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Number of offline modules<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/NrOfModulesOffline</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Number of online modules<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/NrOfModulesOnline</b><span class="property-mode"></span>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-ess">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Ess</h3>
-<dl class="message-properties">
-  <dt class="optional">Maximum battery cell temperature<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/MaxCellTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Maximum battery cell voltage<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/MaxCellVoltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Minimum battery cell temperature<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/MinCellTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Minimum battery cell voltage<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/MinCellVoltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Number of modules blocking charge<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/NrOfModulesBlockingCharge</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Number of modules blocking discharge<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/NrOfModulesBlockingDischarge</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Number of offline modules<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/NrOfModulesOffline</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Number of online modules<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/System/NrOfModulesOnline</b><span class="property-mode"></span>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-ess">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
 
 <div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
   <strong>📝 Wildcard Paths:</strong> 
@@ -2767,6 +2650,30 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </div><p>This node gives information on the energy storage system (ESS).</p>
 <h3>Ess</h3>
 <dl class="message-properties">
+  <dt class="optional">Maximum battery cell temperature<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/MaxCellTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Maximum battery cell voltage<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/MaxCellVoltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Minimum battery cell temperature<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/MinCellTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Minimum battery cell voltage<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/MinCellVoltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Number of modules blocking charge<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/NrOfModulesBlockingCharge</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Number of modules blocking discharge<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/NrOfModulesBlockingDischarge</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Number of offline modules<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/NrOfModulesOffline</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Number of online modules<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/NrOfModulesOnline</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Disable charge<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Hub4/DisableCharge</b><span class="property-mode"> (Mode: both)</span>
 <ul>
@@ -2803,88 +2710,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>0 - No</li>
   <li>1 - Yes</li>
 </ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-ess">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div> 
-<h3>Ess</h3>
-<dl class="message-properties">
-  <dt class="optional">Disable charge<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Hub4/DisableCharge</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul></dd>
-  <dt class="optional">Disable feed-in<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Hub4/DisableFeedIn</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul></dd>
-  <dt class="optional">Feed in overvoltage<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Hub4/DoNotFeedInOvervoltage</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Yes</li>
-  <li>1 - No</li>
-</ul></dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">AC Power <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code> setpoint (W)<span class="property-type">integer</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Hub4/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code>/AcPowerSetpoint</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Maximum overvoltage feed-in power <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code> (W)<span class="property-type">integer</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Hub4/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code>/MaxFeedInPower</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional">Disable PV inverter<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/PvInverter/Disable</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul></dd>
-  <dt class="optional">VE.Bus system restart<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/SystemReset</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No</li>
-  <li>1 - Yes</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-ess">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div><p>This node gives information on the energy storage system (ESS).</p>
-<h3>Ess</h3>
-<dl class="message-properties">
   <dt class="optional">Grid set-point (W)<span class="property-type">integer</span></dt>
   <dd>Dbus path: <b>/Settings/CGwacs/AcPowerSetPoint</b><span class="property-mode"> (Mode: both)</span>
 </dd>
@@ -2979,132 +2804,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">DVCC Maximum charge voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeVoltage</b><span class="property-mode"> (Mode: both)</span>
 </dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-ess">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div> 
-<h3>Ess</h3>
-<dl class="message-properties">
-  <dt class="optional">Grid set-point (W)<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/AcPowerSetPoint</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional">Minimum Discharge SOC (%)<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/MinimumSocLimit</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: Self-consumption above limit<span class="property-type">enum</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/AllowDischarge</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Yes</li>
-  <li>1 - No</li>
-</ul></dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: Day<span class="property-type">enum</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/Day</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Sunday</li>
-  <li>1 - Monday</li>
-  <li>2 - Tuesday</li>
-  <li>3 - Wednesday</li>
-  <li>4 - Thursday</li>
-  <li>5 - Friday</li>
-  <li>6 - Saturday</li>
-  <li>7 - Every day</li>
-  <li>8 - Weekdays</li>
-  <li>9 - Weekends</li>
-  <li>11 - Monthly</li>
-  <li>-1 - Disabled</li>
-</ul></dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: Duration (seconds)<span class="property-type">integer</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/Duration</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: State of charge (%)<span class="property-type">integer</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/Soc</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: Start (seconds after midnight)<span class="property-type">integer</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/Start</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional">ESS state<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - No longer used</li>
-  <li>1 - Optimized w/ BatteryLife: BatteryLife enabled (set by GUI)</li>
-  <li>2 - Optimized w/ BatteryLife: Self consumption</li>
-  <li>3 - Optimized w/ BatteryLife: Self consumption, SoC exceeds 85%</li>
-  <li>4 - Optimized w/ BatteryLife: Self consumption, SoC at 100%</li>
-  <li>5 - Optimized w/ BatteryLife: SoC below dynamic SoC limit</li>
-  <li>6 - Optimized w/ BatteryLife: SoC below limit >24h, charging at 5A</li>
-  <li>7 - Optimized w/ BatteryLife: Multi/Quattro in sustain</li>
-  <li>8 - Optimized w/ BatteryLife: Recharge, SoC dropped 5%+ below MinSoC</li>
-  <li>9 - Keep batteries charged</li>
-  <li>10 - Optimized w/o BatteryLife: Self consumption, SoC at or above minimum SoC</li>
-  <li>11 - Optimized w/o BatteryLife: Self consumption, SoC below minimum SoC</li>
-  <li>12 - Optimized w/o BatteryLife: Recharge, SoC dropped 5%+ below minimum SoC</li>
-</ul><p>Writable values: 1 (Optimized with BatteryLife), 9 (Keep batteries charged), 10 (Optimized without BatteryLife).</p></dd>
-  <dt class="optional">ESS mode<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/Hub4Mode</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>1 - Optimized mode or 'keep batteries charged' and phase compensation enabled</li>
-  <li>2 - Optimized mode or 'keep batteries charged' and phase compensation disabled</li>
-  <li>3 - External control</li>
-</ul></dd>
-  <dt class="optional">Max charge power (W)<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/MaxChargePower</b><span class="property-mode"> (Mode: both)</span>
-<p>Not used with DVCC.</p></dd>
-  <dt class="optional">Max inverter power (W)<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/MaxDischargePower</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional">Maximum System Grid Feed In (W)<span class="property-type">integer</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/MaxFeedInPower</b><span class="property-mode"> (Mode: both)</span>
-<ul><li>-1: No limit</li><li> &gt;=0: limited system feed-in</li></ul><p>Applies to DC-coupled and AC-coupled feed-in.</p></dd>
-  <dt class="optional">Feed excess DC-coupled PV into grid<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/OvervoltageFeedIn</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Don’t feed excess DC-tied PV into grid</li>
-  <li>1 - Feed excess DC-tied PV into the grid</li>
-</ul></dd>
-  <dt class="optional">Don’t feed excess AC-coupled PV into grid<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/PreventFeedback</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Feed excess AC-tied PV into grid</li>
-  <li>1 - Don’t feed excess AC-tied PV into the grid</li>
-</ul></dd>
-  <dt class="optional">Grid metering<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Settings/CGwacs/RunWithoutGridMeter</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - External meter</li>
-  <li>1 - Inverter/Charger</li>
-</ul></dd>
-  <dt class="optional">DVCC Charge current limit (A)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeCurrent</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-  <dt class="optional">DVCC Maximum charge voltage (V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeVoltage</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-ess">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>This node gives information on the energy storage system (ESS).</p>
-<h3>Ess</h3>
-<dl class="message-properties">
   <dt class="optional">Active SOC limit (%)<span class="property-type">integer</span></dt>
   <dd>Dbus path: <b>/Control/ActiveSocLimit</b><span class="property-mode"></span>
 </dd>
@@ -3114,9 +2813,177 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 <script type="text/x-red" data-help-name="victron-output-ess">
 <h3>Details</h3>
 <p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
+
+<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
+  <strong>📝 Wildcard Paths:</strong> 
+  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
+  will be automatically expanded to show available options based on your connected devices.
+  <ul style="margin: 5px 0;">
+    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
+    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
+    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
+    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
+    <li><code>{input}</code> - AC inputs (1, 2)</li>
+    <li><code>{channel}</code> - DC channels (0, 1)</li>
+    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
+  </ul>
+</div> 
 <h3>Ess</h3>
 <dl class="message-properties">
+  <dt class="optional">Maximum battery cell temperature<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/MaxCellTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Maximum battery cell voltage<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/MaxCellVoltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Minimum battery cell temperature<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/MinCellTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Minimum battery cell voltage<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/MinCellVoltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Number of modules blocking charge<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/NrOfModulesBlockingCharge</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Number of modules blocking discharge<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/NrOfModulesBlockingDischarge</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Number of offline modules<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/NrOfModulesOffline</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Number of online modules<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/System/NrOfModulesOnline</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Disable charge<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Hub4/DisableCharge</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">Disable feed-in<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Hub4/DisableFeedIn</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">Feed in overvoltage<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Hub4/DoNotFeedInOvervoltage</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - Yes</li>
+  <li>1 - No</li>
+</ul></dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">AC Power <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code> setpoint (W)<span class="property-type">integer</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Hub4/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code>/AcPowerSetpoint</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Maximum overvoltage feed-in power <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code> (W)<span class="property-type">integer</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Hub4/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{line}</code>/MaxFeedInPower</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional">Disable PV inverter<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/PvInverter/Disable</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">VE.Bus system restart<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/SystemReset</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No</li>
+  <li>1 - Yes</li>
+</ul></dd>
+  <dt class="optional">Grid set-point (W)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/AcPowerSetPoint</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional">Minimum Discharge SOC (%)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/MinimumSocLimit</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: Self-consumption above limit<span class="property-type">enum</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/AllowDischarge</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - Yes</li>
+  <li>1 - No</li>
+</ul></dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: Day<span class="property-type">enum</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/Day</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - Sunday</li>
+  <li>1 - Monday</li>
+  <li>2 - Tuesday</li>
+  <li>3 - Wednesday</li>
+  <li>4 - Thursday</li>
+  <li>5 - Friday</li>
+  <li>6 - Saturday</li>
+  <li>7 - Every day</li>
+  <li>8 - Weekdays</li>
+  <li>9 - Weekends</li>
+  <li>11 - Monthly</li>
+  <li>-1 - Disabled</li>
+</ul></dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: Duration (seconds)<span class="property-type">integer</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/Duration</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: State of charge (%)<span class="property-type">integer</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/Soc</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Schedule <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>: Start (seconds after midnight)<span class="property-type">integer</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Settings/CGwacs/BatteryLife/Schedule/Charge/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{schedule}</code>/Start</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional">ESS state<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/BatteryLife/State</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - No longer used</li>
+  <li>1 - Optimized w/ BatteryLife: BatteryLife enabled (set by GUI)</li>
+  <li>2 - Optimized w/ BatteryLife: Self consumption</li>
+  <li>3 - Optimized w/ BatteryLife: Self consumption, SoC exceeds 85%</li>
+  <li>4 - Optimized w/ BatteryLife: Self consumption, SoC at 100%</li>
+  <li>5 - Optimized w/ BatteryLife: SoC below dynamic SoC limit</li>
+  <li>6 - Optimized w/ BatteryLife: SoC below limit >24h, charging at 5A</li>
+  <li>7 - Optimized w/ BatteryLife: Multi/Quattro in sustain</li>
+  <li>8 - Optimized w/ BatteryLife: Recharge, SoC dropped 5%+ below MinSoC</li>
+  <li>9 - Keep batteries charged</li>
+  <li>10 - Optimized w/o BatteryLife: Self consumption, SoC at or above minimum SoC</li>
+  <li>11 - Optimized w/o BatteryLife: Self consumption, SoC below minimum SoC</li>
+  <li>12 - Optimized w/o BatteryLife: Recharge, SoC dropped 5%+ below minimum SoC</li>
+</ul><p>Writable values: 1 (Optimized with BatteryLife), 9 (Keep batteries charged), 10 (Optimized without BatteryLife).</p></dd>
+  <dt class="optional">ESS mode<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/Hub4Mode</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>1 - Optimized mode or 'keep batteries charged' and phase compensation enabled</li>
+  <li>2 - Optimized mode or 'keep batteries charged' and phase compensation disabled</li>
+  <li>3 - External control</li>
+</ul></dd>
+  <dt class="optional">Max charge power (W)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/MaxChargePower</b><span class="property-mode"> (Mode: both)</span>
+<p>Not used with DVCC.</p></dd>
+  <dt class="optional">Max inverter power (W)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/MaxDischargePower</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional">Maximum System Grid Feed In (W)<span class="property-type">integer</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/MaxFeedInPower</b><span class="property-mode"> (Mode: both)</span>
+<ul><li>-1: No limit</li><li> &gt;=0: limited system feed-in</li></ul><p>Applies to DC-coupled and AC-coupled feed-in.</p></dd>
+  <dt class="optional">Feed excess DC-coupled PV into grid<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/OvervoltageFeedIn</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - Don’t feed excess DC-tied PV into grid</li>
+  <li>1 - Feed excess DC-tied PV into the grid</li>
+</ul></dd>
+  <dt class="optional">Don’t feed excess AC-coupled PV into grid<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/PreventFeedback</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - Feed excess AC-tied PV into grid</li>
+  <li>1 - Don’t feed excess AC-tied PV into the grid</li>
+</ul></dd>
+  <dt class="optional">Grid metering<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Settings/CGwacs/RunWithoutGridMeter</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - External meter</li>
+  <li>1 - Inverter/Charger</li>
+</ul></dd>
+  <dt class="optional">DVCC Charge current limit (A)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeCurrent</b><span class="property-mode"> (Mode: both)</span>
+</dd>
+  <dt class="optional">DVCC Maximum charge voltage (V)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Settings/SystemSetup/MaxChargeVoltage</b><span class="property-mode"> (Mode: both)</span>
+</dd>
   <dt class="optional">Active SOC limit (%)<span class="property-type">integer</span></dt>
   <dd>Dbus path: <b>/Control/ActiveSocLimit</b><span class="property-mode"></span>
 </dd>
@@ -3499,9 +3366,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V DC)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
-  <dt class="optional">Auxiliary voltage (V DC)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
-</dd>
   <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
 </dd>
@@ -3511,7 +3375,21 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 <script type="text/x-red" data-help-name="victron-input-generator">
 <h3>Details</h3>
 <p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>Generator input node for relay controlled and Fischer Panda generators.<br />In order to use the relay for controlling a generator, make sure to set the relay to <i>Generator</i> via the (remote) console first.<br />The <strong>Generator start/stop<strong> dropdown is for the generic generator. It can activate a relay, but also, in case of Fischer panda, a generator directly via D-Bus.<br />The other option(s) are for generator data like voltages, RPM, oil pressure etcetera.<br />Also see <a href="https://github.com/victronenergy/venus/wiki/dbus#generator-data">here</a> for more information.</p>
+
+<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
+  <strong>📝 Wildcard Paths:</strong> 
+  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
+  will be automatically expanded to show available options based on your connected devices.
+  <ul style="margin: 5px 0;">
+    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
+    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
+    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
+    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
+    <li><code>{input}</code> - AC inputs (1, 2)</li>
+    <li><code>{channel}</code> - DC channels (0, 1)</li>
+    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
+  </ul>
+</div><p>Generator input node for relay controlled and Fischer Panda generators.<br />In order to use the relay for controlling a generator, make sure to set the relay to <i>Generator</i> via the (remote) console first.<br />The <strong>Generator start/stop<strong> dropdown is for the generic generator. It can activate a relay, but also, in case of Fischer panda, a generator directly via D-Bus.<br />The other option(s) are for generator data like voltages, RPM, oil pressure etcetera.<br />Also see <a href="https://github.com/victronenergy/venus/wiki/dbus#generator-data">here</a> for more information.</p>
 <h3>Generator</h3>
 <dl class="message-properties">
   <dt class="optional">Generator not detected at AC input alarm<span class="property-type">enum</span></dt>
@@ -3585,13 +3463,230 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Today's run time (seconds)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/TodayRunTime</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">AC Frequency (Hz)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Ac/Frequency</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Power Factor<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Ac/PowerFactor</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> current (A AC)<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/Current</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> frequency (Hz)<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/Frequency</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> power (W)<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/Power</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> Power Factor<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/PowerFactor</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> voltage (V AC)<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/Voltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">The number of phases (1, 2 or 3)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/NrOfPhases</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Remote start mode<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/RemoteStartModeEnabled</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Disabled</li>
+  <li>1 - Enabled</li>
+</ul></dd>
+  <dt class="optional">DC output 1 - Current (A)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/0/Current</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">DC output 1 - Power (W)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/0/Power</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">DC output 1 - Voltage (V)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Engine coolant temperature (°C)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/CoolantTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Engine exhaust temperature (°C)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/ExaustTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Oil temperature (°C)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/OilTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Engine load (%)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/Load</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Oil pressure (kPa)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/OilPressure</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Engine operating hours (s)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/OperatingHours</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Engine speed (RPM)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/Speed</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Nr of starts (absolute count)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/Starts</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Engine winding temperature (°C)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Engine/WindingTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Generator specific error code <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code><span class="property-type">string</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Error/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/Id</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Error<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/ErrorCode</b><span class="property-mode"></span>
+<ul>
+  <li>0 - No error</li>
+  <li>1 - AC voltage L1 too low</li>
+  <li>2 - AC frequency L1 too low</li>
+  <li>3 - AC current too low</li>
+  <li>4 - AC power too low</li>
+  <li>5 - Emergency stop</li>
+  <li>6 - Servo current too low</li>
+  <li>7 - Oil pressure too low</li>
+  <li>8 - Engine temperature too low</li>
+  <li>9 - Winding temperature too low</li>
+  <li>10 - Exhaust temperature too low</li>
+  <li>13 - Starter current too low</li>
+  <li>14 - Glow current too low</li>
+  <li>15 - Glow current too low</li>
+  <li>16 - Fuel holding magnet current too low</li>
+  <li>17 - Stop solenoid hold coil current too low</li>
+  <li>18 - Stop solenoid pull coil current too low</li>
+  <li>19 - Optional DC out current too low</li>
+  <li>20 - 5V output voltage too low</li>
+  <li>21 - Boost output current too low</li>
+  <li>22 - Panel supply current too high</li>
+  <li>25 - Starter battery voltage too low</li>
+  <li>26 - Startup aborted (rotation too low)</li>
+  <li>28 - Rotation too low</li>
+  <li>29 - Power contactor current too low</li>
+  <li>30 - AC voltage L2 too low</li>
+  <li>31 - AC frequency L2 too low</li>
+  <li>32 - AC current L2 too low</li>
+  <li>33 - AC power L2 too low</li>
+  <li>34 - AC voltage L3 too low</li>
+  <li>35 - AC frequency L3 too low</li>
+  <li>36 - AC current L3 too low</li>
+  <li>37 - AC power L3 too low</li>
+  <li>62 - Fuel temperature too low</li>
+  <li>63 - Fuel level too low</li>
+  <li>65 - AC voltage L1 too high</li>
+  <li>66 - AC frequency too high</li>
+  <li>67 - AC current too high</li>
+  <li>68 - AC power too high</li>
+  <li>70 - Servo current too high</li>
+  <li>71 - Oil pressure too high</li>
+  <li>72 - Engine temperature too high</li>
+  <li>73 - Winding temperature too high</li>
+  <li>74 - Exhaust temperature too low</li>
+  <li>77 - Starter current too low</li>
+  <li>78 - Glow current too high</li>
+  <li>79 - Glow current too high</li>
+  <li>80 - Fuel holding magnet current too high</li>
+  <li>81 - Stop solenoid hold coil current too high</li>
+  <li>82 - Stop solenoid pull coil current too high</li>
+  <li>83 - Optional DC out current too high</li>
+  <li>84 - 5V output voltage too high</li>
+  <li>85 - Boost output current too high</li>
+  <li>89 - Starter battery voltage too high</li>
+  <li>90 - Startup aborted (rotation too high)</li>
+  <li>92 - Rotation too high</li>
+  <li>93 - Power contactor current too high</li>
+  <li>94 - AC voltage L2 too high</li>
+  <li>95 - AC frequency L2 too high</li>
+  <li>96 - AC current L2 too high</li>
+  <li>97 - AC power L2 too high</li>
+  <li>98 - AC voltage L3 too high</li>
+  <li>99 - AC frequency L3 too high</li>
+  <li>100 - AC current L3 too high</li>
+  <li>101 - AC power L3 too high</li>
+  <li>126 - Fuel temperature too high</li>
+  <li>127 - Fuel level too high</li>
+  <li>130 - Lost control unit</li>
+  <li>131 - Lost panel</li>
+  <li>132 - Service needed</li>
+  <li>133 - Lost 3-phase module</li>
+  <li>134 - Lost AGT module</li>
+  <li>135 - Synchronization failure</li>
+  <li>137 - Intake airfilter</li>
+  <li>139 - Lost sync. module</li>
+  <li>140 - Load-balance failed</li>
+  <li>141 - Sync-mode deactivated</li>
+  <li>142 - Engine controller</li>
+  <li>148 - Rotating field wrong</li>
+  <li>149 - Fuel level sensor lost</li>
+  <li>150 - Init failed</li>
+  <li>151 - Watchdog</li>
+  <li>152 - Out: winding</li>
+  <li>153 - Out: exhaust</li>
+  <li>154 - Out: Cyl. head</li>
+  <li>155 - Inverter over temperature</li>
+  <li>156 - Inverter overload</li>
+  <li>157 - Inverter communication lost</li>
+  <li>158 - Inverter sync failed</li>
+  <li>159 - CAN communication lost</li>
+  <li>160 - L1 overload</li>
+  <li>161 - L2 overload</li>
+  <li>162 - L3 overload</li>
+  <li>163 - DC overload</li>
+  <li>164 - DC overvoltage</li>
+  <li>165 - Emergency stop</li>
+  <li>166 - No connection</li>
+</ul></dd>
+  <dt class="optional">Heatsink temperature (°C)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/HeatsinkTemperature</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Generator model<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/ProductId</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Start generator<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/Start</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - Stop</li>
+  <li>1 - Start</li>
+</ul></dd>
+  <dt class="optional">Starter voltage (V DC)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/StarterVoltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Status<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/StatusCode</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Standby</li>
+  <li>1 - Startup 1</li>
+  <li>2 - Startup 2</li>
+  <li>3 - Startup 3</li>
+  <li>4 - Startup 4</li>
+  <li>5 - Startup 5</li>
+  <li>6 - Startup 6</li>
+  <li>7 - Startup 7</li>
+  <li>8 - Running</li>
+  <li>9 - Stopping</li>
+  <li>10 - Error</li>
+</ul></dd>
+  <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
+</dd>
 </dl>
 </script>
 
 <script type="text/x-red" data-help-name="victron-output-generator">
 <h3>Details</h3>
 <p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
+
+<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
+  <strong>📝 Wildcard Paths:</strong> 
+  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
+  will be automatically expanded to show available options based on your connected devices.
+  <ul style="margin: 5px 0;">
+    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
+    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
+    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
+    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
+    <li><code>{input}</code> - AC inputs (1, 2)</li>
+    <li><code>{channel}</code> - DC channels (0, 1)</li>
+    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
+  </ul>
+</div> 
 <h3>Generator</h3>
 <dl class="message-properties">
   <dt class="optional">Generator not detected at AC input alarm<span class="property-type">enum</span></dt>
@@ -3668,29 +3763,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Today's run time (seconds)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/TodayRunTime</b><span class="property-mode"></span>
 </dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-generator">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div><p>Generator input node for relay controlled and Fischer Panda generators.<br />In order to use the relay for controlling a generator, make sure to set the relay to <i>Generator</i> via the (remote) console first.<br />The <strong>Generator start/stop<strong> dropdown is for the generic generator. It can activate a relay, but also, in case of Fischer panda, a generator directly via D-Bus.<br />The other option(s) are for generator data like voltages, RPM, oil pressure etcetera.<br />Also see <a href="https://github.com/victronenergy/venus/wiki/dbus#generator-data">here</a> for more information.</p>
-<h3>Generator</h3>
-<dl class="message-properties">
   <dt class="optional">AC Frequency (Hz)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Ac/Frequency</b><span class="property-mode"></span>
 </dd>
@@ -3890,618 +3962,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>8 - Running</li>
   <li>9 - Stopping</li>
   <li>10 - Error</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-generator">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div> 
-<h3>Generator</h3>
-<dl class="message-properties">
-  <dt class="optional">AC Frequency (Hz)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Ac/Frequency</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Power Factor<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Ac/PowerFactor</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> current (A AC)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/Current</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> frequency (Hz)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/Frequency</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> power (W)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/Power</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> Power Factor<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/PowerFactor</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Phase <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> voltage (V AC)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/Voltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">The number of phases (1, 2 or 3)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/NrOfPhases</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Remote start mode<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/RemoteStartModeEnabled</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Disabled</li>
-  <li>1 - Enabled</li>
-</ul></dd>
-  <dt class="optional">DC output 1 - Current (A)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">DC output 1 - Power (W)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/0/Power</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">DC output 1 - Voltage (V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine coolant temperature (°C)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/CoolantTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine exhaust temperature (°C)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/ExaustTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Oil temperature (°C)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OilTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine load (%)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/Load</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Oil pressure (kPa)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OilPressure</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine operating hours (s)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OperatingHours</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine speed (RPM)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/Speed</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Nr of starts (absolute count)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/Starts</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine winding temperature (°C)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/WindingTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Generator specific error code <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code><span class="property-type">string</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Error/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/Id</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Error<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/ErrorCode</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - AC voltage L1 too low</li>
-  <li>2 - AC frequency L1 too low</li>
-  <li>3 - AC current too low</li>
-  <li>4 - AC power too low</li>
-  <li>5 - Emergency stop</li>
-  <li>6 - Servo current too low</li>
-  <li>7 - Oil pressure too low</li>
-  <li>8 - Engine temperature too low</li>
-  <li>9 - Winding temperature too low</li>
-  <li>10 - Exhaust temperature too low</li>
-  <li>13 - Starter current too low</li>
-  <li>14 - Glow current too low</li>
-  <li>15 - Glow current too low</li>
-  <li>16 - Fuel holding magnet current too low</li>
-  <li>17 - Stop solenoid hold coil current too low</li>
-  <li>18 - Stop solenoid pull coil current too low</li>
-  <li>19 - Optional DC out current too low</li>
-  <li>20 - 5V output voltage too low</li>
-  <li>21 - Boost output current too low</li>
-  <li>22 - Panel supply current too high</li>
-  <li>25 - Starter battery voltage too low</li>
-  <li>26 - Startup aborted (rotation too low)</li>
-  <li>28 - Rotation too low</li>
-  <li>29 - Power contactor current too low</li>
-  <li>30 - AC voltage L2 too low</li>
-  <li>31 - AC frequency L2 too low</li>
-  <li>32 - AC current L2 too low</li>
-  <li>33 - AC power L2 too low</li>
-  <li>34 - AC voltage L3 too low</li>
-  <li>35 - AC frequency L3 too low</li>
-  <li>36 - AC current L3 too low</li>
-  <li>37 - AC power L3 too low</li>
-  <li>62 - Fuel temperature too low</li>
-  <li>63 - Fuel level too low</li>
-  <li>65 - AC voltage L1 too high</li>
-  <li>66 - AC frequency too high</li>
-  <li>67 - AC current too high</li>
-  <li>68 - AC power too high</li>
-  <li>70 - Servo current too high</li>
-  <li>71 - Oil pressure too high</li>
-  <li>72 - Engine temperature too high</li>
-  <li>73 - Winding temperature too high</li>
-  <li>74 - Exhaust temperature too low</li>
-  <li>77 - Starter current too low</li>
-  <li>78 - Glow current too high</li>
-  <li>79 - Glow current too high</li>
-  <li>80 - Fuel holding magnet current too high</li>
-  <li>81 - Stop solenoid hold coil current too high</li>
-  <li>82 - Stop solenoid pull coil current too high</li>
-  <li>83 - Optional DC out current too high</li>
-  <li>84 - 5V output voltage too high</li>
-  <li>85 - Boost output current too high</li>
-  <li>89 - Starter battery voltage too high</li>
-  <li>90 - Startup aborted (rotation too high)</li>
-  <li>92 - Rotation too high</li>
-  <li>93 - Power contactor current too high</li>
-  <li>94 - AC voltage L2 too high</li>
-  <li>95 - AC frequency L2 too high</li>
-  <li>96 - AC current L2 too high</li>
-  <li>97 - AC power L2 too high</li>
-  <li>98 - AC voltage L3 too high</li>
-  <li>99 - AC frequency L3 too high</li>
-  <li>100 - AC current L3 too high</li>
-  <li>101 - AC power L3 too high</li>
-  <li>126 - Fuel temperature too high</li>
-  <li>127 - Fuel level too high</li>
-  <li>130 - Lost control unit</li>
-  <li>131 - Lost panel</li>
-  <li>132 - Service needed</li>
-  <li>133 - Lost 3-phase module</li>
-  <li>134 - Lost AGT module</li>
-  <li>135 - Synchronization failure</li>
-  <li>137 - Intake airfilter</li>
-  <li>139 - Lost sync. module</li>
-  <li>140 - Load-balance failed</li>
-  <li>141 - Sync-mode deactivated</li>
-  <li>142 - Engine controller</li>
-  <li>148 - Rotating field wrong</li>
-  <li>149 - Fuel level sensor lost</li>
-  <li>150 - Init failed</li>
-  <li>151 - Watchdog</li>
-  <li>152 - Out: winding</li>
-  <li>153 - Out: exhaust</li>
-  <li>154 - Out: Cyl. head</li>
-  <li>155 - Inverter over temperature</li>
-  <li>156 - Inverter overload</li>
-  <li>157 - Inverter communication lost</li>
-  <li>158 - Inverter sync failed</li>
-  <li>159 - CAN communication lost</li>
-  <li>160 - L1 overload</li>
-  <li>161 - L2 overload</li>
-  <li>162 - L3 overload</li>
-  <li>163 - DC overload</li>
-  <li>164 - DC overvoltage</li>
-  <li>165 - Emergency stop</li>
-  <li>166 - No connection</li>
-</ul></dd>
-  <dt class="optional">Heatsink temperature (°C)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/HeatsinkTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Generator model<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/ProductId</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Start generator<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Start</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Stop</li>
-  <li>1 - Start</li>
-</ul></dd>
-  <dt class="optional">Starter voltage (V DC)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/StarterVoltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Status<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/StatusCode</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Standby</li>
-  <li>1 - Startup 1</li>
-  <li>2 - Startup 2</li>
-  <li>3 - Startup 3</li>
-  <li>4 - Startup 4</li>
-  <li>5 - Startup 5</li>
-  <li>6 - Startup 6</li>
-  <li>7 - Startup 7</li>
-  <li>8 - Running</li>
-  <li>9 - Stopping</li>
-  <li>10 - Error</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-generator">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div><p>Generator input node for relay controlled and Fischer Panda generators.<br />In order to use the relay for controlling a generator, make sure to set the relay to <i>Generator</i> via the (remote) console first.<br />The <strong>Generator start/stop<strong> dropdown is for the generic generator. It can activate a relay, but also, in case of Fischer panda, a generator directly via D-Bus.<br />The other option(s) are for generator data like voltages, RPM, oil pressure etcetera.<br />Also see <a href="https://github.com/victronenergy/venus/wiki/dbus#generator-data">here</a> for more information.</p>
-<h3>Generator</h3>
-<dl class="message-properties">
-  <dt class="optional">DC current (DC A)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">DC voltage (DC V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine coolant temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/CoolantTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine exhaust temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/ExaustTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine load (%)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/Load</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Oil pressure (kPa)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OilPressure</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine oil temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OilTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine oil temperature (Seconds)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OperatingHours</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Heatsink temperature (RPM)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/Speed</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Internal winding temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/WindingTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Generator specific error code <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code><span class="property-type">string</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Error/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/Id</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Heatsink temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/HeatsinkTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Generator model<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/ProductId</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Remote start mode<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/RemoteStartModeEnabled</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Disabled</li>
-  <li>1 - Enabled</li>
-</ul></dd>
-  <dt class="optional">Start generator<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Start</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Stop generator</li>
-  <li>1 - Start generator</li>
-</ul></dd>
-  <dt class="optional">Starter battery voltage (DC V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/StarterVoltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Status<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/StatusCode</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Standby</li>
-  <li>1 - Startup 1</li>
-  <li>2 - Startup 2</li>
-  <li>3 - Startup 3</li>
-  <li>4 - Startup 4</li>
-  <li>5 - Startup 5</li>
-  <li>6 - Startup 6</li>
-  <li>7 - Startup 7</li>
-  <li>8 - Running</li>
-  <li>9 - Stopping</li>
-  <li>10 - Error</li>
-</ul></dd>
-  <dt class="optional">Error<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/ErrorCode</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - AC voltage L1 too low</li>
-  <li>2 - AC frequency L1 too low</li>
-  <li>3 - AC current too low</li>
-  <li>4 - AC power too low</li>
-  <li>5 - Emergency stop</li>
-  <li>6 - Servo current too low</li>
-  <li>7 - Oil pressure too low</li>
-  <li>8 - Engine temperature too low</li>
-  <li>9 - Winding temperature too low</li>
-  <li>10 - Exhaust temperature too low</li>
-  <li>13 - Starter current too low</li>
-  <li>14 - Glow current too low</li>
-  <li>15 - Glow current too low</li>
-  <li>16 - Fuel holding magnet current too low</li>
-  <li>17 - Stop solenoid hold coil current too low</li>
-  <li>18 - Stop solenoid pull coil current too low</li>
-  <li>19 - Optional DC out current too low</li>
-  <li>20 - 5V output voltage too low</li>
-  <li>21 - Boost output current too low</li>
-  <li>22 - Panel supply current too high</li>
-  <li>25 - Starter battery voltage too low</li>
-  <li>26 - Startup aborted (rotation too low)</li>
-  <li>28 - Rotation too low</li>
-  <li>29 - Power contactor current too low</li>
-  <li>30 - AC voltage L2 too low</li>
-  <li>31 - AC frequency L2 too low</li>
-  <li>32 - AC current L2 too low</li>
-  <li>33 - AC power L2 too low</li>
-  <li>34 - AC voltage L3 too low</li>
-  <li>35 - AC frequency L3 too low</li>
-  <li>36 - AC current L3 too low</li>
-  <li>37 - AC power L3 too low</li>
-  <li>62 - Fuel temperature too low</li>
-  <li>63 - Fuel level too low</li>
-  <li>65 - AC voltage L1 too high</li>
-  <li>66 - AC frequency too high</li>
-  <li>67 - AC current too high</li>
-  <li>68 - AC power too high</li>
-  <li>70 - Servo current too high</li>
-  <li>71 - Oil pressure too high</li>
-  <li>72 - Engine temperature too high</li>
-  <li>73 - Winding temperature too high</li>
-  <li>74 - Exhaust temperature too low</li>
-  <li>77 - Starter current too low</li>
-  <li>78 - Glow current too high</li>
-  <li>79 - Glow current too high</li>
-  <li>80 - Fuel holding magnet current too high</li>
-  <li>81 - Stop solenoid hold coil current too high</li>
-  <li>82 - Stop solenoid pull coil current too high</li>
-  <li>83 - Optional DC out current too high</li>
-  <li>84 - 5V output voltage too high</li>
-  <li>85 - Boost output current too high</li>
-  <li>89 - Starter battery voltage too high</li>
-  <li>90 - Startup aborted (rotation too high)</li>
-  <li>92 - Rotation too high</li>
-  <li>93 - Power contactor current too high</li>
-  <li>94 - AC voltage L2 too high</li>
-  <li>95 - AC frequency L2 too high</li>
-  <li>96 - AC current L2 too high</li>
-  <li>97 - AC power L2 too high</li>
-  <li>98 - AC voltage L3 too high</li>
-  <li>99 - AC frequency L3 too high</li>
-  <li>100 - AC current L3 too high</li>
-  <li>101 - AC power L3 too high</li>
-  <li>126 - Fuel temperature too high</li>
-  <li>127 - Fuel level too high</li>
-  <li>130 - Lost control unit</li>
-  <li>131 - Lost panel</li>
-  <li>132 - Service needed</li>
-  <li>133 - Lost 3-phase module</li>
-  <li>134 - Lost AGT module</li>
-  <li>135 - Synchronization failure</li>
-  <li>137 - Intake airfilter</li>
-  <li>139 - Lost sync. module</li>
-  <li>140 - Load-balance failed</li>
-  <li>141 - Sync-mode deactivated</li>
-  <li>142 - Engine controller</li>
-  <li>148 - Rotating field wrong</li>
-  <li>149 - Fuel level sensor lost</li>
-  <li>150 - Init failed</li>
-  <li>151 - Watchdog</li>
-  <li>152 - Out: winding</li>
-  <li>153 - Out: exhaust</li>
-  <li>154 - Out: Cyl. head</li>
-  <li>155 - Inverter over temperature</li>
-  <li>156 - Inverter overload</li>
-  <li>157 - Inverter communication lost</li>
-  <li>158 - Inverter sync failed</li>
-  <li>159 - CAN communication lost</li>
-  <li>160 - L1 overload</li>
-  <li>161 - L2 overload</li>
-  <li>162 - L3 overload</li>
-  <li>163 - DC overload</li>
-  <li>164 - DC overvoltage</li>
-  <li>165 - Emergency stop</li>
-  <li>166 - No connection</li>
-</ul></dd>
-  <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-generator">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div> 
-<h3>Generator</h3>
-<dl class="message-properties">
-  <dt class="optional">DC current (DC A)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/0/Current</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">DC voltage (DC V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine coolant temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/CoolantTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine exhaust temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/ExaustTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine load (%)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/Load</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Oil pressure (kPa)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OilPressure</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine oil temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OilTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Engine oil temperature (Seconds)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/OperatingHours</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Heatsink temperature (RPM)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/Speed</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Internal winding temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Engine/WindingTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Generator specific error code <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code><span class="property-type">string</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Error/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/Id</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Heatsink temperature (Degrees celsius)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/HeatsinkTemperature</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Generator model<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/ProductId</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Remote start mode<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/RemoteStartModeEnabled</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Disabled</li>
-  <li>1 - Enabled</li>
-</ul></dd>
-  <dt class="optional">Start generator<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Start</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Stop generator</li>
-  <li>1 - Start generator</li>
-</ul></dd>
-  <dt class="optional">Starter battery voltage (DC V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/StarterVoltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Status<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/StatusCode</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Standby</li>
-  <li>1 - Startup 1</li>
-  <li>2 - Startup 2</li>
-  <li>3 - Startup 3</li>
-  <li>4 - Startup 4</li>
-  <li>5 - Startup 5</li>
-  <li>6 - Startup 6</li>
-  <li>7 - Startup 7</li>
-  <li>8 - Running</li>
-  <li>9 - Stopping</li>
-  <li>10 - Error</li>
-</ul></dd>
-  <dt class="optional">Error<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/ErrorCode</b><span class="property-mode"></span>
-<ul>
-  <li>0 - No error</li>
-  <li>1 - AC voltage L1 too low</li>
-  <li>2 - AC frequency L1 too low</li>
-  <li>3 - AC current too low</li>
-  <li>4 - AC power too low</li>
-  <li>5 - Emergency stop</li>
-  <li>6 - Servo current too low</li>
-  <li>7 - Oil pressure too low</li>
-  <li>8 - Engine temperature too low</li>
-  <li>9 - Winding temperature too low</li>
-  <li>10 - Exhaust temperature too low</li>
-  <li>13 - Starter current too low</li>
-  <li>14 - Glow current too low</li>
-  <li>15 - Glow current too low</li>
-  <li>16 - Fuel holding magnet current too low</li>
-  <li>17 - Stop solenoid hold coil current too low</li>
-  <li>18 - Stop solenoid pull coil current too low</li>
-  <li>19 - Optional DC out current too low</li>
-  <li>20 - 5V output voltage too low</li>
-  <li>21 - Boost output current too low</li>
-  <li>22 - Panel supply current too high</li>
-  <li>25 - Starter battery voltage too low</li>
-  <li>26 - Startup aborted (rotation too low)</li>
-  <li>28 - Rotation too low</li>
-  <li>29 - Power contactor current too low</li>
-  <li>30 - AC voltage L2 too low</li>
-  <li>31 - AC frequency L2 too low</li>
-  <li>32 - AC current L2 too low</li>
-  <li>33 - AC power L2 too low</li>
-  <li>34 - AC voltage L3 too low</li>
-  <li>35 - AC frequency L3 too low</li>
-  <li>36 - AC current L3 too low</li>
-  <li>37 - AC power L3 too low</li>
-  <li>62 - Fuel temperature too low</li>
-  <li>63 - Fuel level too low</li>
-  <li>65 - AC voltage L1 too high</li>
-  <li>66 - AC frequency too high</li>
-  <li>67 - AC current too high</li>
-  <li>68 - AC power too high</li>
-  <li>70 - Servo current too high</li>
-  <li>71 - Oil pressure too high</li>
-  <li>72 - Engine temperature too high</li>
-  <li>73 - Winding temperature too high</li>
-  <li>74 - Exhaust temperature too low</li>
-  <li>77 - Starter current too low</li>
-  <li>78 - Glow current too high</li>
-  <li>79 - Glow current too high</li>
-  <li>80 - Fuel holding magnet current too high</li>
-  <li>81 - Stop solenoid hold coil current too high</li>
-  <li>82 - Stop solenoid pull coil current too high</li>
-  <li>83 - Optional DC out current too high</li>
-  <li>84 - 5V output voltage too high</li>
-  <li>85 - Boost output current too high</li>
-  <li>89 - Starter battery voltage too high</li>
-  <li>90 - Startup aborted (rotation too high)</li>
-  <li>92 - Rotation too high</li>
-  <li>93 - Power contactor current too high</li>
-  <li>94 - AC voltage L2 too high</li>
-  <li>95 - AC frequency L2 too high</li>
-  <li>96 - AC current L2 too high</li>
-  <li>97 - AC power L2 too high</li>
-  <li>98 - AC voltage L3 too high</li>
-  <li>99 - AC frequency L3 too high</li>
-  <li>100 - AC current L3 too high</li>
-  <li>101 - AC power L3 too high</li>
-  <li>126 - Fuel temperature too high</li>
-  <li>127 - Fuel level too high</li>
-  <li>130 - Lost control unit</li>
-  <li>131 - Lost panel</li>
-  <li>132 - Service needed</li>
-  <li>133 - Lost 3-phase module</li>
-  <li>134 - Lost AGT module</li>
-  <li>135 - Synchronization failure</li>
-  <li>137 - Intake airfilter</li>
-  <li>139 - Lost sync. module</li>
-  <li>140 - Load-balance failed</li>
-  <li>141 - Sync-mode deactivated</li>
-  <li>142 - Engine controller</li>
-  <li>148 - Rotating field wrong</li>
-  <li>149 - Fuel level sensor lost</li>
-  <li>150 - Init failed</li>
-  <li>151 - Watchdog</li>
-  <li>152 - Out: winding</li>
-  <li>153 - Out: exhaust</li>
-  <li>154 - Out: Cyl. head</li>
-  <li>155 - Inverter over temperature</li>
-  <li>156 - Inverter overload</li>
-  <li>157 - Inverter communication lost</li>
-  <li>158 - Inverter sync failed</li>
-  <li>159 - CAN communication lost</li>
-  <li>160 - L1 overload</li>
-  <li>161 - L2 overload</li>
-  <li>162 - L3 overload</li>
-  <li>163 - DC overload</li>
-  <li>164 - DC overvoltage</li>
-  <li>165 - Emergency stop</li>
-  <li>166 - No connection</li>
 </ul></dd>
   <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
@@ -4720,12 +4180,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Yield today for today on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (kWh)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/0/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/Yield</b><span class="property-mode"></span>
 </dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Maximum power for yesterday on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (W)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/1/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/MaxPower</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Yield today for yesterday on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (kWh)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/1/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/Yield</b><span class="property-mode"></span>
-</dd>
   <dt class="optional">Mode<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Mode</b><span class="property-mode"> (Mode: both)</span>
 <ul>
@@ -4899,12 +4353,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Yield today for today on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (kWh)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/0/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/Yield</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Maximum power for yesterday on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (W)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/1/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/MaxPower</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Yield today for yesterday on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (kWh)<span class="property-type">float</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/1/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/Yield</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">Mode<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Mode</b><span class="property-mode"> (Mode: both)</span>
@@ -5512,30 +4960,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <li>0 - Stopped</li>
   <li>1 - Running</li>
 </ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-pump">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Pump</h3>
-<dl class="message-properties">
-  <dt class="optional">Pump State<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/State</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Stopped</li>
-  <li>1 - Running</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-pump">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>Node for getting pump information.</p>
-<h3>Pump</h3>
-<dl class="message-properties">
   <dt class="optional">Auto start enabled<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Settings/Pump0/AutoStartEnabled</b><span class="property-mode"> (Mode: both)</span>
 <ul>
@@ -5564,6 +4988,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
  
 <h3>Pump</h3>
 <dl class="message-properties">
+  <dt class="optional">Pump State<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/State</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Stopped</li>
+  <li>1 - Running</li>
+</ul></dd>
   <dt class="optional">Auto start enabled<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Settings/Pump0/AutoStartEnabled</b><span class="property-mode"> (Mode: both)</span>
 <ul>
@@ -5808,186 +5238,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dl>
 </script>
 
-<script type="text/x-red" data-help-name="victron-input-relay">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>The <b>relay</b> node reads the state of the relay(s) of the Venus device.</p>
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay on the charger<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-relay">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay on the charger<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-relay">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>The <b>relay</b> node reads the state of the relay(s) of the Venus device.</p>
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay status<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-relay">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay status<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-relay">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>The <b>relay</b> node reads the state of the relay(s) of the Venus device.</p>
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay on the charger<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-relay">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay on the charger<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-relay">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>The <b>relay</b> node reads the state of the relay(s) of the Venus device.</p>
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay state<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-relay">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay state<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-relay">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>The <b>relay</b> node reads the state of the relay(s) of the Venus device.</p>
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay on the Multi RS<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-relay">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay on the Multi RS<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-relay">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>The <b>relay</b> node reads the state of the relay(s) of the Venus device.</p>
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay on the charger<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-relay">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Relay</h3>
-<dl class="message-properties">
-  <dt class="optional">Relay on the charger<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/Relay/0/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Open</li>
-  <li>1 - Closed</li>
-</ul></dd>
-</dl>
-</script>
-
 <script type="text/x-red" data-help-name="victron-input-settings">
 <h3>Details</h3>
 <p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
@@ -6087,6 +5337,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">System name<span class="property-type">string</span></dt>
   <dd>Dbus path: <b>/Settings/SystemSetup/SystemName</b><span class="property-mode"> (Mode: both)</span>
 </dd>
+  <dt class="optional">Grid limiting status<span class="property-type">enum</span></dt>
+  <dd>Dbus path: <b>/PvPowerLimiterActive</b><span class="property-mode"></span>
+<ul>
+  <li>0 - Feed-in limiting is inactive</li>
+  <li>1 - Feed-in limiting is active</li>
+</ul><p>Applies to both AC-coupled and DC-coupled limiting.</p></dd>
 </dl>
 </script>
 
@@ -6189,30 +5445,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">System name<span class="property-type">string</span></dt>
   <dd>Dbus path: <b>/Settings/SystemSetup/SystemName</b><span class="property-mode"> (Mode: both)</span>
 </dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-settings">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>With this node several settings can be read. Currently the focus is mainly on the Carlo Gavazzi Wired AC Sensors (cgwacs).</p>
-<h3>Settings</h3>
-<dl class="message-properties">
-  <dt class="optional">Grid limiting status<span class="property-type">enum</span></dt>
-  <dd>Dbus path: <b>/PvPowerLimiterActive</b><span class="property-mode"></span>
-<ul>
-  <li>0 - Feed-in limiting is inactive</li>
-  <li>1 - Feed-in limiting is active</li>
-</ul><p>Applies to both AC-coupled and DC-coupled limiting.</p></dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-settings">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
- 
-<h3>Settings</h3>
-<dl class="message-properties">
   <dt class="optional">Grid limiting status<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/PvPowerLimiterActive</b><span class="property-mode"></span>
 <ul>
@@ -6681,6 +5913,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> dimming<span class="property-type">integer</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/Dimming</b><span class="property-mode"> (Mode: both)</span>
 </dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> auto mode<span class="property-type">enum</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/Auto</b><span class="property-mode"> (Mode: both)</span>
+<ul>
+  <li>0 - Manual</li>
+  <li>1 - Auto</li>
+</ul></dd>
 </dl>
 </script>
 
@@ -6713,82 +5951,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> dimming<span class="property-type">integer</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/Dimming</b><span class="property-mode"> (Mode: both)</span>
 </dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-switch">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div><p>The <b>switch</b> node can be used for the usb-connected I/O extender.</p>
-<h3>Switch</h3>
-<dl class="message-properties">
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> auto mode<span class="property-type">enum</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/Auto</b><span class="property-mode"> (Mode: both)</span>
 <ul>
   <li>0 - Manual</li>
   <li>1 - Auto</li>
 </ul></dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> state<span class="property-type">enum</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - On</li>
-</ul></dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> dimming<span class="property-type">integer</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/Dimming</b><span class="property-mode"> (Mode: both)</span>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-output-switch">
-<h3>Details</h3>
-<p>The <strong>output nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-
-<div class="wildcard-info" style="background: #f5f5f5; padding: 10px; margin: 10px 0; border-left: 4px solid #007acc;">
-  <strong>📝 Wildcard Paths:</strong> 
-  Paths containing placeholders like <code>{type}</code>, <code>{tracker}</code>, <code>{phase}</code> 
-  will be automatically expanded to show available options based on your connected devices.
-  <ul style="margin: 5px 0;">
-    <li><code>{type}</code> - Switch types (output_1, output_2, pwm_1, relay_1, etc.)</li>
-    <li><code>{tracker}</code> - PV tracker numbers (0, 1, 2, 3)</li>
-    <li><code>{phase}</code> - AC phases (1, 2, 3 for L1, L2, L3)</li>
-    <li><code>{day}</code> - History days (0=today, 1=yesterday)</li>
-    <li><code>{input}</code> - AC inputs (1, 2)</li>
-    <li><code>{channel}</code> - DC channels (0, 1)</li>
-    <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
-  </ul>
-</div> 
-<h3>Switch</h3>
-<dl class="message-properties">
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> auto mode<span class="property-type">enum</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/Auto</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Manual</li>
-  <li>1 - Auto</li>
-</ul></dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> state<span class="property-type">enum</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/State</b><span class="property-mode"> (Mode: both)</span>
-<ul>
-  <li>0 - Off</li>
-  <li>1 - On</li>
-</ul></dd>
-  <dt class="optional" style="padding-top: 8px; padding-left: 8px;"><code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code> dimming<span class="property-type">integer</span></dt>
-  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/SwitchableOutput/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{type}</code>/Dimming</b><span class="property-mode"> (Mode: both)</span>
-</dd>
 </dl>
 </script>
 
@@ -7132,21 +6300,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </ul></dd>
   <dt class="optional">Volatile Organic Compounds index<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/VOC</b><span class="property-mode"></span>
-</dd>
-</dl>
-</script>
-
-<script type="text/x-red" data-help-name="victron-input-temperature">
-<h3>Details</h3>
-<p>The <strong>input nodes</strong> have two selectable inputs: the devices select and measurement select. The available options are dynamically updated based on the data that is actually available on the Venus device.</p>
-<p>Like the other nodes, the <b>temperature</b> node reads the temperate information from the dbus. This means that source of the temperature sensor can obtain its information from different sources (e.g. directly connected probe or Bluetooth connected Ruuvi tag).</p><p>See the <a href="https://www.victronenergy.com/media/pg/Cerbo_GX/en/installation.html#UUID-4d5df29c-761e-cfcc-9e2c-8230f126e7bb">manual</a> for information on connecting a temperature sensor.</p><p>Tank sensors also expose temperature, so they can appear under the dropdown too.</p>
-<h3>Temperature</h3>
-<dl class="message-properties">
-  <dt class="optional">Sensor battery voltage (V)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/BatteryVoltage</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Temperature (°C)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Temperature</b><span class="property-mode"></span>
 </dd>
 </dl>
 </script>

--- a/src/nodes/config-client.html
+++ b/src/nodes/config-client.html
@@ -473,9 +473,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input voltage <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (V AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/1/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/V</b><span class="property-mode"></span>
 </dd>
-  <dt class="optional">Input voltage phase 3 (V AC)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Ac/In/1/L3/V</b><span class="property-mode"></span>
-</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input current <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> 1 (A AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/1/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/I</b><span class="property-mode"></span>
 </dd>
@@ -585,9 +582,6 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input voltage <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> (V AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/1/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/V</b><span class="property-mode"></span>
-</dd>
-  <dt class="optional">Input voltage phase 3 (V AC)<span class="property-type">float</span></dt>
-  <dd>Dbus path: <b>/Ac/In/1/L3/V</b><span class="property-mode"></span>
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Input current <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code> 1 (A AC)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Ac/In/1/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{phase}</code>/I</b><span class="property-mode"></span>
@@ -1161,6 +1155,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Auxiliary voltage (V)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
+</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Diagnostics; error <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code><span class="property-type">enum</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Diagnostics/LastErrors/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/Error</b><span class="property-mode"></span>
 <ul>
@@ -1671,6 +1668,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Auxiliary voltage (V)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
+</dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Diagnostics; error <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code><span class="property-type">enum</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/Diagnostics/LastErrors/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{index}</code>/Error</b><span class="property-mode"></span>
 <ul>
@@ -2164,6 +2164,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Auxiliary voltage (V)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Total energy consumed (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyIn</b><span class="property-mode"></span>
 </dd>
@@ -2226,6 +2229,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional">Battery voltage (V)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Auxiliary voltage (V)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
@@ -2295,6 +2301,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional">Battery voltage (V DC)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional">Auxiliary voltage (V DC)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">Total energy consumed (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyIn</b><span class="property-mode"></span>
@@ -3366,6 +3375,9 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
   <dt class="optional">Battery voltage (V DC)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/Dc/0/Voltage</b><span class="property-mode"></span>
 </dd>
+  <dt class="optional">Auxiliary voltage (V DC)<span class="property-type">float</span></dt>
+  <dd>Dbus path: <b>/Dc/1/Voltage</b><span class="property-mode"></span>
+</dd>
   <dt class="optional">Total energy produced (kWh)<span class="property-type">float</span></dt>
   <dd>Dbus path: <b>/History/EnergyOut</b><span class="property-mode"></span>
 </dd>
@@ -3389,7 +3401,7 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
     <li><code>{channel}</code> - DC channels (0, 1)</li>
     <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
   </ul>
-</div><p>Generator input node for relay controlled and Fischer Panda generators.<br />In order to use the relay for controlling a generator, make sure to set the relay to <i>Generator</i> via the (remote) console first.<br />The <strong>Generator start/stop<strong> dropdown is for the generic generator. It can activate a relay, but also, in case of Fischer panda, a generator directly via D-Bus.<br />The other option(s) are for generator data like voltages, RPM, oil pressure etcetera.<br />Also see <a href="https://github.com/victronenergy/venus/wiki/dbus#generator-data">here</a> for more information.</p>
+</div><p>Generator input node for relay controlled and Fischer Panda generators.<br />In order to use the relay for controlling a generator, make sure to set the relay to <i>Generator</i> via the (remote) console first.<br />The <strong>Generator start/stop</strong> dropdown is for the generic generator. It can activate a relay, but also, in case of Fischer panda, a generator directly via D-Bus.<br />The other option(s) are for generator data like voltages, RPM, oil pressure etcetera.<br />Also see <a href="https://github.com/victronenergy/venus/wiki/dbus#generator-data">here</a> for more information.</p>
 <h3>Generator</h3>
 <dl class="message-properties">
   <dt class="optional">Generator not detected at AC input alarm<span class="property-type">enum</span></dt>
@@ -4019,7 +4031,7 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
     <li><code>{channel}</code> - DC channels (0, 1)</li>
     <li><code>{index}</code> - Index numbers (0, 1, 2, 3, etc.)</li>
   </ul>
-</div><p>This node gives allows for monitoring the grid. See also <a href="https://www.victronenergy.com/accessories/energy-meter">energy meters</a> accessories.</p>
+</div><p>This node allows for monitoring the grid. See also <a href="https://www.victronenergy.com/accessories/energy-meter">energy meters</a> accessories.</p>
 <h3>Gridmeter</h3>
 <dl class="message-properties">
   <dt class="optional">Frequency (Hz)<span class="property-type">float</span></dt>
@@ -4179,6 +4191,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Yield today for today on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (kWh)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/0/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/Yield</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Maximum power for yesterday on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (W)<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/1/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/MaxPower</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Yield today for yesterday on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (kWh)<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/1/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/Yield</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">Mode<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Mode</b><span class="property-mode"> (Mode: both)</span>
@@ -4353,6 +4371,12 @@ Questions can also be asked within the Node-RED space on the Victron Energy comm
 </dd>
   <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Yield today for today on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (kWh)<span class="property-type">float</span></dt>
   <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/0/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/Yield</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Maximum power for yesterday on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (W)<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/1/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/MaxPower</b><span class="property-mode"></span>
+</dd>
+  <dt class="optional" style="padding-top: 8px; padding-left: 8px;">Yield today for yesterday on tracker <code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code> (kWh)<span class="property-type">float</span></dt>
+  <dd style="padding-top: 8px; padding-left: 8px;">Dbus path: <b>/History/Daily/1/Pv/<code style="background-color: #e1f5fe; color: #01579b; font-weight: bold; padding: 1px 3px; border-radius: 3px;">{tracker}</code>/Yield</b><span class="property-mode"></span>
 </dd>
   <dt class="optional">Mode<span class="property-type">enum</span></dt>
   <dd>Dbus path: <b>/Mode</b><span class="property-mode"> (Mode: both)</span>

--- a/src/services/services.json
+++ b/src/services/services.json
@@ -818,7 +818,7 @@
       {
         "path": "/Dc/1/Voltage",
         "type": "float",
-        "name": "Starter battery voltage (V)"
+        "name": "Auxiliary voltage (V)"
       },
       {
         "path": "/Diagnostics/LastErrors/{index}/Error",
@@ -1432,7 +1432,7 @@
       {
         "path": "/Dc/1/Voltage",
         "type": "float",
-        "name": "Starter battery voltage (V)"
+        "name": "Auxiliary voltage (V)"
       },
       {
         "path": "/History/EnergyIn",
@@ -1530,7 +1530,7 @@
       {
         "path": "/Dc/1/Voltage",
         "type": "float",
-        "name": "Starter battery voltage (V)"
+        "name": "Auxiliary voltage (V)"
       },
       {
         "path": "/History/EnergyOut",
@@ -2559,7 +2559,7 @@
   },
   "generator": {
     "help": {
-      "both": "<p>Generator input node for relay controlled and Fischer Panda generators.<br />In order to use the relay for controlling a generator, make sure to set the relay to <i>Generator</i> via the (remote) console first.<br />The <strong>Generator start/stop<strong> dropdown is for the generic generator. It can activate a relay, but also, in case of Fischer panda, a generator directly via D-Bus.<br />The other option(s) are for generator data like voltages, RPM, oil pressure etcetera.<br />Also see <a href=\"https://github.com/victronenergy/venus/wiki/dbus#generator-data\">here</a> for more information.</p>",
+      "both": "<p>Generator input node for relay controlled and Fischer Panda generators.<br />In order to use the relay for controlling a generator, make sure to set the relay to <i>Generator</i> via the (remote) console first.<br />The <strong>Generator start/stop</strong> dropdown is for the generic generator. It can activate a relay, but also, in case of Fischer panda, a generator directly via D-Bus.<br />The other option(s) are for generator data like voltages, RPM, oil pressure etcetera.<br />Also see <a href=\"https://github.com/victronenergy/venus/wiki/dbus#generator-data\">here</a> for more information.</p>",
       "input": "",
       "output": " "
     },
@@ -3211,7 +3211,7 @@
   },
   "gridmeter": {
     "help": {
-      "both": "<p>This node gives allows for monitoring the grid. See also <a href=\"https://www.victronenergy.com/accessories/energy-meter\">energy meters</a> accessories.</p>",
+      "both": "<p>This node allows for monitoring the grid. See also <a href=\"https://www.victronenergy.com/accessories/energy-meter\">energy meters</a> accessories.</p>",
       "input": "",
       "output": ""
     },

--- a/test/config-client-help-duplicates.test.js
+++ b/test/config-client-help-duplicates.test.js
@@ -1,0 +1,48 @@
+/**
+ * Regression test for duplicate Node-RED help blocks in config-client.html.
+ *
+ * Node-RED's editor looks up help content with:
+ *   $("script[data-help-name='" + type + "']").html()
+ * jQuery's .html() getter only reads the FIRST element in a matched set, so
+ * when the same data-help-name appears more than once in the file, every
+ * block after the first is silently never shown - it's dead documentation
+ * that can still diverge from what's displayed and mislead future editors.
+ *
+ * This has already happened: e.g. victron-input-switch/-output-switch had
+ * an "Auto mode" block added after the original (State + Dimming only)
+ * block, so Auto mode has never actually rendered in the editor.
+ *
+ * See https://github.com/victronenergy/node-red-contrib-victron/issues/563
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const HTML_FILE = path.join(__dirname, '..', 'src', 'nodes', 'config-client.html')
+const content = fs.readFileSync(HTML_FILE, 'utf8')
+
+const HELP_SCRIPT_OPEN_TAG = /<script type="text\/x-red" data-help-name="([^"]+)">/g
+
+function findHelpNameCounts (html) {
+  const counts = {}
+  let match
+  while ((match = HELP_SCRIPT_OPEN_TAG.exec(html)) !== null) {
+    const name = match[1]
+    counts[name] = (counts[name] || 0) + 1
+  }
+  return counts
+}
+
+describe('config-client.html - no duplicate data-help-name blocks', () => {
+  const counts = findHelpNameCounts(content)
+  const helpNames = Object.keys(counts)
+
+  test('at least one victron-input-switch and victron-output-switch block is present', () => {
+    expect(counts['victron-input-switch']).toBeGreaterThan(0)
+    expect(counts['victron-output-switch']).toBeGreaterThan(0)
+  })
+
+  test.each(helpNames)('%s has exactly one help block', (name) => {
+    expect(counts[name]).toBe(1)
+  })
+})

--- a/test/service2doc.test.js
+++ b/test/service2doc.test.js
@@ -1,4 +1,4 @@
-const { generateDocumentation, generateWildcardExplanation, highlightWildcards } = require('../scripts/service2doc.js')
+const { generateDocumentation, generateWildcardExplanation, highlightWildcards, dedupePathDocs } = require('../scripts/service2doc.js')
 
 describe('Service Documentation Generator', () => {
   const testServicesData = {
@@ -13,8 +13,8 @@ describe('Service Documentation Generator', () => {
           path: '/SwitchableOutput/{type}/State',
           type: 'enum',
           enum: {
-            '0': 'Off',
-            '1': 'On'
+            0: 'Off',
+            1: 'On'
           },
           name: '{type} state',
           mode: 'both'
@@ -31,7 +31,7 @@ describe('Service Documentation Generator', () => {
 
   test('generates wildcard explanation for HTML format', () => {
     const explanation = generateWildcardExplanation('nodered')
-    
+
     expect(explanation).toContain('Wildcard Paths')
     expect(explanation).toContain('<code>{type}</code>')
     expect(explanation).toContain('Switch types (output_1, output_2')
@@ -40,7 +40,7 @@ describe('Service Documentation Generator', () => {
 
   test('generates wildcard explanation for markdown format', () => {
     const explanation = generateWildcardExplanation('md')
-    
+
     expect(explanation).toContain('**📝 Wildcard Paths:**')
     expect(explanation).toContain('`{type}`')
     expect(explanation).toContain('Switch types (output_1, output_2')
@@ -49,7 +49,7 @@ describe('Service Documentation Generator', () => {
   test('highlights wildcards in HTML format', () => {
     const text = 'Power for tracker {tracker} on phase {phase}'
     const highlighted = highlightWildcards(text, 'nodered')
-    
+
     expect(highlighted).toContain('<code style="background-color: #e1f5fe')
     expect(highlighted).toContain('{tracker}')
     expect(highlighted).toContain('{phase}')
@@ -58,7 +58,7 @@ describe('Service Documentation Generator', () => {
   test('highlights wildcards in markdown format', () => {
     const text = 'Power for tracker {tracker} on phase {phase}'
     const highlighted = highlightWildcards(text, 'md')
-    
+
     expect(highlighted).toContain('`{tracker}`')
     expect(highlighted).toContain('`{phase}`')
   })
@@ -107,5 +107,62 @@ describe('Service Documentation Generator', () => {
     expect(doc).toContain('Battery voltage (V DC)')
     expect(doc).toContain('/Dc/0/Voltage')
     expect(doc).not.toContain('Wildcard Paths')
+  })
+
+  test('merges multiple sub-categories of one service into a single help block per node type', () => {
+    // Mirrors services.json's switch/acload/heatpump shape: several
+    // sub-categories under one node, each redeclaring /State.
+    const multiCategoryService = {
+      switch: {
+        help: { both: '<p>Switch node.</p>' },
+        switch: [
+          { path: '/SwitchableOutput/{type}/Auto', type: 'enum', name: '{type} auto mode', mode: 'both' },
+          { path: '/SwitchableOutput/{type}/State', type: 'enum', name: '{type} state', mode: 'both' }
+        ],
+        acload: [
+          { path: '/SwitchableOutput/{type}/State', type: 'enum', name: '{type} state', mode: 'both' }
+        ],
+        heatpump: [
+          { path: '/SwitchableOutput/{type}/State', type: 'enum', name: '{type} state', mode: 'both' }
+        ]
+      }
+    }
+    const registeredNodes = { inputNodes: new Set(['switch']), outputNodes: new Set(['switch']) }
+    const doc = generateDocumentation(multiCategoryService, registeredNodes, 'nodered')
+
+    const inputBlockCount = doc.split('data-help-name="victron-input-switch"').length - 1
+    const outputBlockCount = doc.split('data-help-name="victron-output-switch"').length - 1
+    expect(inputBlockCount).toBe(1)
+    expect(outputBlockCount).toBe(1)
+
+    // The property redeclared by switch/acload/heatpump appears once per
+    // node type block (not once per sub-category that declared it).
+    const stateDdCount = doc.split('/State</b>').length - 1
+    expect(stateDdCount).toBe(2) // once in the input block, once in the output block
+    expect(doc).toContain('auto mode')
+  })
+
+  test('dedupePathDocs keeps the first declaration for exact path duplicates', () => {
+    const paths = [
+      { path: '/Relay/0/State', name: 'Relay on the charger' },
+      { path: '/Relay/0/State', name: 'Relay status' }
+    ]
+    expect(dedupePathDocs(paths)).toEqual([{ path: '/Relay/0/State', name: 'Relay on the charger' }])
+  })
+
+  test('dedupePathDocs prefers a wildcard path over a concrete path of the same shape', () => {
+    const paths = [
+      { path: '/Relay/0/State', name: 'Relay on the charger' },
+      { path: '/Relay/{relay}/State', name: 'Venus relay {relay} state' }
+    ]
+    expect(dedupePathDocs(paths)).toEqual([{ path: '/Relay/{relay}/State', name: 'Venus relay {relay} state' }])
+  })
+
+  test('dedupePathDocs keeps unrelated paths untouched', () => {
+    const paths = [
+      { path: '/Dc/0/Voltage', name: 'Battery voltage' },
+      { path: '/Dc/0/Current', name: 'Battery current' }
+    ]
+    expect(dedupePathDocs(paths)).toEqual(paths)
   })
 })

--- a/test/service2doc.test.js
+++ b/test/service2doc.test.js
@@ -165,4 +165,12 @@ describe('Service Documentation Generator', () => {
     ]
     expect(dedupePathDocs(paths)).toEqual(paths)
   })
+
+  test('dedupePathDocs keeps distinct numeric-indexed paths separate when no wildcard covers them', () => {
+    const paths = [
+      { path: '/Dc/0/Voltage', name: 'Battery voltage' },
+      { path: '/Dc/1/Voltage', name: 'Auxiliary voltage' }
+    ]
+    expect(dedupePathDocs(paths)).toEqual(paths)
+  })
 })


### PR DESCRIPTION
`config-client.html`'s `<script data-help-name="...">` help blocks are generated from services.json by `scripts/service2doc.js`. Whenever a node type had more than one sub-category (e.g. switch's switch/acload split, or relay's 7 per-device categories), `generateServiceDoc()` emitted one full block per sub-category, all sharing the same data-help-name. Node-RED's editor looks up help with `$("script[data-help-name='type']").html()`, and jQuery's `.html()` only reads the first matched element, so every block after the first was silently dead - e.g. switch's "Auto mode" property has never actually rendered in the editor.

`generateServiceDoc()` now merges path definitions from all sub-categories into one block per node type via `dedupePathDocs()`: exact-path duplicates keep the first declaration, and a wildcard path (e.g. `/Relay/{relay}/State`) is preferred over a concrete path of the same shape (e.g. /Relay/0/State) so the merged help documents the property generically instead of picking one device's wording arbitrarily.

`config-client.html` is regenerated via `npm run documentation`, which also incidentally deduped a literal copy-paste duplicate entry already present in services.json's acsystem paths.

`test/config-client-help-duplicates.test.js` is a regression test guarding against any data-help-name reappearing more than once.

https://github.com/victronenergy/node-red-contrib-victron/issues/563