### PR TITLE
fix(virtual): make acload/heatpump Position/PhaseSetting configurable without S2

### DIFF
--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1899,9 +1899,8 @@
 	}
 
 	// Keeps Position/Phase and the S2 Measurement dropdown consistent with the device's actual
-	// configuration for acload/heatpump: enabling S2 support is what promotes the device from a
-	// plain generic energy meter to its own full type, adding Position (and, for a 1-phase
-	// config, which phase it's wired to) - see acload.js/heatpump.js isFullDevice(). The S2
+	// configuration for acload/heatpump: Position (and, for a 1-phase config, which phase it's
+	// wired to) is configurable regardless of S2 support - see acload.js/heatpump.js. The S2
 	// Measurement dropdown mirrors Number of phases/Phase so that info doesn't need
 	// re-confirming: a 1-phase config is locked to the single matching phase, a 3-phase config
 	// offers only "3-phase symmetric"/"Per phase" (no single-phase reading applies), split phase
@@ -1933,17 +1932,14 @@
 	  };
 
 	  const update = () => {
-	    const isFull = $('#node-input-enable_s2support').is(':checked');
 	    const nrOfPhases = Number($(`#node-input-${prefix}_nrofphases`).val());
-	    $(`#node-input-${prefix}_position`).closest('.form-row').toggle(isFull);
-	    $(`#${prefix}-phasesetting-row`).toggle(isFull && nrOfPhases === 1);
+	    $(`#${prefix}-phasesetting-row`).toggle(nrOfPhases === 1);
 	    updateS2MeasurementOptions(nrOfPhases);
 	  };
 	  $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', update);
 	  $(`#node-input-${prefix}_phasesetting`).off('change.s2measurement').on('change.s2measurement', () => {
 	    updateS2MeasurementOptions(Number($(`#node-input-${prefix}_nrofphases`).val()));
 	  });
-	  $('#node-input-enable_s2support').off(`change.${prefix}-full`).on(`change.${prefix}-full`, update);
 	  update();
 	}
 

--- a/resources/victron-virtual-functions.js
+++ b/resources/victron-virtual-functions.js
@@ -1933,6 +1933,7 @@
 
 	  const update = () => {
 	    const nrOfPhases = Number($(`#node-input-${prefix}_nrofphases`).val());
+	    $(`#node-input-${prefix}_position`).closest('.form-row').show();
 	    $(`#${prefix}-phasesetting-row`).toggle(nrOfPhases === 1);
 	    updateS2MeasurementOptions(nrOfPhases);
 	  };

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1108,9 +1108,8 @@ export function updateBatteryVoltageVisibility () {
 }
 
 // Keeps Position/Phase and the S2 Measurement dropdown consistent with the device's actual
-// configuration for acload/heatpump: enabling S2 support is what promotes the device from a
-// plain generic energy meter to its own full type, adding Position (and, for a 1-phase
-// config, which phase it's wired to) - see acload.js/heatpump.js isFullDevice(). The S2
+// configuration for acload/heatpump: Position (and, for a 1-phase config, which phase it's
+// wired to) is configurable regardless of S2 support - see acload.js/heatpump.js. The S2
 // Measurement dropdown mirrors Number of phases/Phase so that info doesn't need
 // re-confirming: a 1-phase config is locked to the single matching phase, a 3-phase config
 // offers only "3-phase symmetric"/"Per phase" (no single-phase reading applies), split phase
@@ -1142,17 +1141,14 @@ function updatePhaseSettingVisibility (prefix) {
   }
 
   const update = () => {
-    const isFull = $('#node-input-enable_s2support').is(':checked')
     const nrOfPhases = Number($(`#node-input-${prefix}_nrofphases`).val())
-    $(`#node-input-${prefix}_position`).closest('.form-row').toggle(isFull)
-    $(`#${prefix}-phasesetting-row`).toggle(isFull && nrOfPhases === 1)
+    $(`#${prefix}-phasesetting-row`).toggle(nrOfPhases === 1)
     updateS2MeasurementOptions(nrOfPhases)
   }
   $(`#node-input-${prefix}_nrofphases`).off('change.phasesetting').on('change.phasesetting', update)
   $(`#node-input-${prefix}_phasesetting`).off('change.s2measurement').on('change.s2measurement', () => {
     updateS2MeasurementOptions(Number($(`#node-input-${prefix}_nrofphases`).val()))
   })
-  $('#node-input-enable_s2support').off(`change.${prefix}-full`).on(`change.${prefix}-full`, update)
   update()
 }
 

--- a/src/nodes/victron-virtual-functions.js
+++ b/src/nodes/victron-virtual-functions.js
@@ -1142,6 +1142,7 @@ function updatePhaseSettingVisibility (prefix) {
 
   const update = () => {
     const nrOfPhases = Number($(`#node-input-${prefix}_nrofphases`).val())
+    $(`#node-input-${prefix}_position`).closest('.form-row').show()
     $(`#${prefix}-phasesetting-row`).toggle(nrOfPhases === 1)
     updateS2MeasurementOptions(nrOfPhases)
   }

--- a/src/nodes/victron-virtual/device-type/acload.js
+++ b/src/nodes/victron-virtual/device-type/acload.js
@@ -2,9 +2,9 @@ const { accumulateDelta } = require('../energy-utils')
 const { enableS2Support } = require('../s2-support')
 const { buildMinimalMeterProperties, initializeMinimalMeter } = require('./shared/minimal-meter')
 
-// Presents as a plain generic energy meter by default (see minimal-meter.js). Enabling S2
-// support is the only thing that adds extra paths (Position/PhaseSetting plus the S2 paths
-// themselves), promoting it to its own full AC load device.
+// Presents as a plain generic energy meter by default (see minimal-meter.js). Position/PhaseSetting
+// are configurable regardless of S2 support; enabling S2 support additionally adds the S2 paths
+// themselves, promoting it to its own full AC load device.
 function isFullDevice (config) {
   return !!config.enable_s2support
 }
@@ -12,7 +12,7 @@ function isFullDevice (config) {
 function properties (config) {
   const isFull = isFullDevice(config)
   return buildMinimalMeterProperties({
-    includePosition: isFull,
+    includePosition: true,
     isGenericEnergyMeter: !isFull
   })
 }
@@ -39,7 +39,7 @@ function initialize (config, ifaceDesc, iface, node) {
 
   initializeMinimalMeter(config, ifaceDesc, iface, {
     nrOfPhases: config.acload_nrofphases,
-    includePosition: isFull,
+    includePosition: true,
     position: config.acload_position,
     phaseSetting: config.acload_phasesetting
   })

--- a/src/nodes/victron-virtual/device-type/heatpump.js
+++ b/src/nodes/victron-virtual/device-type/heatpump.js
@@ -2,9 +2,9 @@ const { accumulateDelta } = require('../energy-utils')
 const { enableS2Support } = require('../s2-support')
 const { buildMinimalMeterProperties, initializeMinimalMeter } = require('./shared/minimal-meter')
 
-// Presents as a plain generic energy meter by default (see minimal-meter.js). Enabling S2
-// support is the only thing that adds extra paths (Position/PhaseSetting plus the S2 paths
-// themselves), promoting it to its own full heat pump device.
+// Presents as a plain generic energy meter by default (see minimal-meter.js). Position/PhaseSetting
+// are configurable regardless of S2 support; enabling S2 support additionally adds the S2 paths
+// themselves, promoting it to its own full heat pump device.
 function isFullDevice (config) {
   return !!config.enable_s2support
 }
@@ -12,7 +12,7 @@ function isFullDevice (config) {
 function properties (config) {
   const isFull = isFullDevice(config)
   return buildMinimalMeterProperties({
-    includePosition: isFull,
+    includePosition: true,
     isGenericEnergyMeter: !isFull
   })
 }
@@ -39,7 +39,7 @@ function initialize (config, ifaceDesc, iface, node) {
 
   initializeMinimalMeter(config, ifaceDesc, iface, {
     nrOfPhases: config.heatpump_nrofphases,
-    includePosition: isFull,
+    includePosition: true,
     position: config.heatpump_position,
     phaseSetting: config.heatpump_phasesetting
   })

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -241,7 +241,7 @@ class VictronDbusListener {
           if (res) {
             const deviceInstance = res[1]?.[0]
             if (deviceInstance === undefined) {
-              console.error(`deviceInstance could not be assigned because res[1][0] is undefined owner=${owner} services[owner]=${JSON.stringify(this.services[owner])} (${this.services[owner].name})`)
+              console.error(`deviceInstance could not be assigned because res[1][0] is undefined owner=${owner} services[owner]=${JSON.stringify(this.services[owner])}`)
             }
             return resolve(deviceInstance)
           }
@@ -249,6 +249,12 @@ class VictronDbusListener {
         })
       }
     })
+
+    // the owner may have disconnected (NameOwnerChanged) while GetValue was in flight,
+    // in which case the entry was already removed from this.services
+    if (!this.services[owner]) {
+      return
+    }
 
     this.services[owner].deviceInstance = deviceInstance
 

--- a/src/services/dbus-listener.js
+++ b/src/services/dbus-listener.js
@@ -253,6 +253,7 @@ class VictronDbusListener {
     // the owner may have disconnected (NameOwnerChanged) while GetValue was in flight,
     // in which case the entry was already removed from this.services
     if (!this.services[owner]) {
+      console.warn(`initService ${name}, owner ${owner} was removed from services while GetValue was in flight, skipping`)
       return
     }
 

--- a/test/dbus-listener.test.js
+++ b/test/dbus-listener.test.js
@@ -51,6 +51,25 @@ describe('VictronDbusListener', () => {
       await listener._initService('the-dynamicess-owner', 'com.victronenergy.dynamicess')
       expect(listener.services['the-dynamicess-owner'].deviceInstance).toBe(null)
     })
+
+    test('does not throw when the service disconnects before GetValue resolves (regression)', async () => {
+      let invokeCallback
+      listener.bus = {
+        invoke: jest.fn((_params, callback) => {
+          invokeCallback = callback
+        })
+      }
+
+      const initPromise = listener._initService('the-owner', 'the-name')
+
+      // simulate NameOwnerChanged deleting the service while GetValue is still in flight
+      delete listener.services['the-owner']
+
+      invokeCallback(new Error('NoReply'), null)
+
+      await expect(initPromise).resolves.not.toThrow()
+      expect(listener.services['the-owner']).toBeUndefined()
+    })
   })
 
   describe('_requestRoot singleton service handling', () => {

--- a/test/victron-virtual-acload.test.js
+++ b/test/victron-virtual-acload.test.js
@@ -261,10 +261,10 @@ describe('acload device module', () => {
       expect(acload.productType({})).toBe('grid')
     })
 
-    test('properties include Position when S2 enabled, omit it otherwise', () => {
+    test('properties include Position regardless of S2 support', () => {
       expect(acload.properties({ enable_s2support: true }).Position).toBeDefined()
-      expect(acload.properties({ enable_s2support: false }).Position).toBeUndefined()
-      expect(acload.properties({}).Position).toBeUndefined()
+      expect(acload.properties({ enable_s2support: false }).Position).toBeDefined()
+      expect(acload.properties({}).Position).toBeDefined()
     })
 
     test('properties declare IsGenericEnergyMeter as 0 when S2 enabled, 1 otherwise', () => {
@@ -280,15 +280,15 @@ describe('acload device module', () => {
       expect(Object.keys(full).some(k => k.startsWith('S2/0/RmSettings/'))).toBe(false)
     })
 
-    test('initialize does not add Position/PhaseSetting when S2 is disabled', () => {
+    test('initialize still adds Position/PhaseSetting when S2 is disabled', () => {
       const ifaceDesc = { properties: {} }
       const iface = {}
       const node = { error: jest.fn() }
-      acload.initialize({ acload_nrofphases: 1 }, ifaceDesc, iface, node)
-      expect(iface.Position).toBeUndefined()
-      expect(iface.PhaseSetting).toBeUndefined()
-      expect(ifaceDesc.properties.PhaseSetting).toBeUndefined()
-      expect(ifaceDesc.properties['Ac/L1/Power']).toBeDefined()
+      acload.initialize({ acload_nrofphases: 1, acload_position: 1, acload_phasesetting: 2 }, ifaceDesc, iface, node)
+      expect(iface.Position).toBe(1)
+      expect(iface.PhaseSetting).toBe(2)
+      expect(ifaceDesc.properties.PhaseSetting).toBeDefined()
+      expect(ifaceDesc.properties['Ac/L2/Power']).toBeDefined()
     })
 
     test('initialize returns the generic energy meter label when S2 is disabled', () => {

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -338,6 +338,35 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
     })
 
+    test('shows heatpump Position row, nested under the input-heatpump wrapper without its own input-heatpump class', () => {
+      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
+      const mockPhaseSettingRow = createMockElement()
+      const mockPositionRow = createMockElement()
+
+      global.$.mockImplementation((selector) => {
+        if (selector === 'select#node-input-device') {
+          return createMockElement({ val: 'heatpump' })
+        }
+        if (selector === '#node-input-heatpump_nrofphases') {
+          return mockNrOfPhasesSelect
+        }
+        if (selector === '#heatpump-phasesetting-row') {
+          return mockPhaseSettingRow
+        }
+        if (selector === '#node-input-heatpump_position') {
+          return mockPositionRow
+        }
+        if (selector.startsWith('.input-')) {
+          return createMockElement()
+        }
+        return createMockElement()
+      })
+
+      checkSelectedVirtualDevice()
+
+      expect(mockPositionRow.show).toHaveBeenCalled()
+    })
+
     test('locks S2 Measurement to the matching single phase for a 1-phase config, overriding any prior selection', () => {
       const mockNrOfPhasesSelect = createMockElement({ val: '1' })
       const mockPhaseSettingSelect = createMockElement({ val: '2' })

--- a/test/victron-virtual-functions.test.js
+++ b/test/victron-virtual-functions.test.js
@@ -313,10 +313,9 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
     })
 
-    test('hides acload Position/PhaseSetting row for a 1-phase config when S2 support is disabled', () => {
+    test('shows acload PhaseSetting row for a 1-phase config even when S2 support is disabled', () => {
       const mockNrOfPhasesSelect = createMockElement({ val: '1' })
       const mockPhaseSettingRow = createMockElement()
-      const mockPositionRow = createMockElement()
 
       global.$.mockImplementation((selector) => {
         if (selector === 'select#node-input-device') {
@@ -328,9 +327,6 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
         if (selector === '#acload-phasesetting-row') {
           return mockPhaseSettingRow
         }
-        if (selector === '#node-input-acload_position') {
-          return mockPositionRow
-        }
         if (selector.startsWith('.input-')) {
           return createMockElement()
         }
@@ -339,8 +335,7 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
 
       checkSelectedVirtualDevice()
 
-      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
-      expect(mockPositionRow.toggle).toHaveBeenCalledWith(false)
+      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(true)
     })
 
     test('locks S2 Measurement to the matching single phase for a 1-phase config, overriding any prior selection', () => {
@@ -492,40 +487,6 @@ describe('General victron-virtual-functions coverage (non-switch)', () => {
       checkSelectedVirtualDevice()
 
       expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
-    })
-
-    test('hides Position and PhaseSetting row for acload grid meter only, even for a 1-phase config', () => {
-      const mockNrOfPhasesSelect = createMockElement({ val: '1' })
-      const mockPhaseSettingRow = createMockElement()
-      const mockPositionRow = createMockElement()
-      const mockGridMeterOnlyCheckbox = createMockElement({ is: true })
-
-      global.$.mockImplementation((selector) => {
-        if (selector === 'select#node-input-device') {
-          return createMockElement({ val: 'acload' })
-        }
-        if (selector === '#node-input-acload_nrofphases') {
-          return mockNrOfPhasesSelect
-        }
-        if (selector === '#acload-phasesetting-row') {
-          return mockPhaseSettingRow
-        }
-        if (selector === '#node-input-acload_grid_meter_only') {
-          return mockGridMeterOnlyCheckbox
-        }
-        if (selector === '#node-input-acload_position') {
-          return mockPositionRow
-        }
-        if (selector.startsWith('.input-')) {
-          return createMockElement()
-        }
-        return createMockElement()
-      })
-
-      checkSelectedVirtualDevice()
-
-      expect(mockPhaseSettingRow.toggle).toHaveBeenCalledWith(false)
-      expect(mockPositionRow.toggle).toHaveBeenCalledWith(false)
     })
 
     test('handles generator device selection', () => {

--- a/test/victron-virtual-heatpump.test.js
+++ b/test/victron-virtual-heatpump.test.js
@@ -94,19 +94,19 @@ describe('heatpump device module', () => {
       expect(heatpump.productType({})).toBe('grid')
     })
 
-    test('properties omit Position', () => {
-      expect(heatpump.properties({}).Position).toBeUndefined()
+    test('properties still include Position', () => {
+      expect(heatpump.properties({}).Position).toBeDefined()
     })
 
     test('properties declare IsGenericEnergyMeter as 1', () => {
       expect(heatpump.properties({}).IsGenericEnergyMeter.value).toBe(1)
     })
 
-    test('initialize does not add Position/PhaseSetting or S2 support', () => {
+    test('initialize still adds Position/PhaseSetting, but no S2 support', () => {
       const { ifaceDesc, iface, node } = makeFixtures()
-      const result = heatpump.initialize({ heatpump_nrofphases: 1 }, ifaceDesc, iface, node)
-      expect(iface.Position).toBeUndefined()
-      expect(iface.PhaseSetting).toBeUndefined()
+      const result = heatpump.initialize({ heatpump_nrofphases: 1, heatpump_position: 1, heatpump_phasesetting: 2 }, ifaceDesc, iface, node)
+      expect(iface.Position).toBe(1)
+      expect(iface.PhaseSetting).toBe(2)
       expect(ifaceDesc.__enableS2).toBeUndefined()
       expect(result).toBe('Virtual 1-phase heat pump (generic energy meter)')
     })


### PR DESCRIPTION
Position and PhaseSetting were only added when enable_s2support was true, even though they're meaningful regardless of S2 support (the energy meter device type already treats them independently of any S2 concept). S2 support still separately gates only the S2 transport paths and whether the device reports as a full acload/heatpump vs. a generic energy meter.

Closes #567