### PR TITLE
victron-virtual: declare energymeter_role / energymeter_position in editor defaults (fixes #570)

### DIFF
--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -40,6 +40,8 @@
             // energymeter
             energymeter_role: {value: "", required: false},
             energymeter_position: {value: 0, required: false},
+            energymeter_nrofphases: {value: 1, required: false},
+            energymeter_phasesetting: {value: 1, required: false},
             // motordrive
             include_motor_temp: {value: false},
             include_controller_temp: {value: false},

--- a/src/nodes/victron-virtual.html
+++ b/src/nodes/victron-virtual.html
@@ -37,6 +37,9 @@
             generator_grid_meter_only: {value: false, required: false},
             // grid
             grid_nrofphases: {value: 1, required: false},
+            // energymeter
+            energymeter_role: {value: "", required: false},
+            energymeter_position: {value: 0, required: false},
             // motordrive
             include_motor_temp: {value: false},
             include_controller_temp: {value: false},

--- a/test/victron-virtual-energymeter-defaults.test.js
+++ b/test/victron-virtual-energymeter-defaults.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+/**
+ * Regression test for issue #570.
+ *
+ * The Node-RED editor only retains a node's properties across a deploy if
+ * they are declared in RED.nodes.registerType's `defaults` object (in the
+ * node's .html file). Any config key read by a device-type module at
+ * runtime but missing from `defaults` is silently dropped on the next
+ * editor deploy - even a deploy of an unrelated node.
+ *
+ * This asserts every `config.energymeter_*` key read by
+ * device-type/energymeter.js is declared in victron-virtual.html's
+ * `defaults`, so this class of bug can't silently reappear for this
+ * device type.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const energymeterSource = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'nodes', 'victron-virtual', 'device-type', 'energymeter.js'),
+  'utf8'
+)
+const htmlSource = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'nodes', 'victron-virtual.html'),
+  'utf8'
+)
+
+const configKeys = [...new Set(
+  [...energymeterSource.matchAll(/config\.(energymeter_\w+)/g)].map(m => m[1])
+)]
+
+describe('victron-virtual.html defaults - energymeter', () => {
+  test('device-type/energymeter.js reads at least the known config keys', () => {
+    // guards against the regex above silently matching nothing if the source changes shape
+    expect(configKeys).toEqual(expect.arrayContaining([
+      'energymeter_role',
+      'energymeter_position',
+      'energymeter_nrofphases',
+      'energymeter_phasesetting'
+    ]))
+  })
+
+  test.each(configKeys)('"%s" is declared in the editor defaults', (key) => {
+    const declared = new RegExp(`\\b${key}\\s*:\\s*\\{`).test(htmlSource)
+    expect(declared).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem
`victron-virtual` (device type `energymeter`) reads `config.energymeter_role` and `config.energymeter_position` at runtime (`src/nodes/victron-virtual/device-type/energymeter.js`), but neither is declared in the editor's `defaults` in `src/nodes/victron-virtual.html`. The Node-RED editor only keeps declared properties when it loads a flow, so **any** editor deploy — even of an unrelated node — silently drops both values. The device then falls back to the default `grid` role, re-registers as `com.victronenergy.grid.*`, and for a charger on the inverter output its power is double-counted in dbus-systemcalc's AC Consumption while the EVCS disappears from VRM. Details and reproduction in #570.

## Fix
Declare the two properties in `defaults`, in the same style as the other device-type sections. An empty `energymeter_role` still resolves to `'grid'` at runtime (`ROLE_TO_SERVICE_TYPE[...] || 'grid'`), so existing nodes behave exactly as before.

## Testing
- Simulated the editor's import (core fields + declared `defaults` keys): with the unpatched html the role is stripped (reproducing the field failure); with this change it is retained and the node round-trips byte-identical.
- Applied the change to a live installation (1.7.24), restarted Node-RED (node html is read at startup), and confirmed in the running editor that `RED.nodes.getType('victron-virtual').defaults` contains both keys and the editor's post-import copy of the node keeps `energymeter_role: "evcharger"`.
- Live regression/restore test: stripping the role reproduced the double-count (AC Consumption ≈ inverter output + the charger's 7.4 kW again); restoring it removed it; with this patch in place a real editor-style deploy no longer loses the role.

A follow-up could expose these two fields in the edit dialog for the `energymeter` device type, since the runtime already supports them but there is currently no UI to set them.

Fixes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)
